### PR TITLE
Suggest a resursive submodule update when MSPSim is not found

### DIFF
--- a/apps/mspsim/README.md
+++ b/apps/mspsim/README.md
@@ -1,7 +1,13 @@
 MSPSim support for the COOJA Simulator
 --------------------------------------
 
-MSPSim source code access: Standalone MSPSim is available from
-[http://sourceforge.net/projects/mspsim](http://sourceforge.net/projects/mspsim).
+MSPSim is a Java-based instruction level emulator of the MSP430 series
+microprocessor and emulation of some sensor networking platforms. It is used
+by Cooja to emulate MSP430 based platforms and is included as a git sumbodule.
 
--- Fredrik Österlind, 18/3 2008
+To initiate and update the MSPSim submodule:
+
+$ git submodule update --init --recursive
+
+The MSPSim source code is available at Github:
+https://github.com/contiki-ng/mspsim

--- a/apps/mspsim/build.xml
+++ b/apps/mspsim/build.xml
@@ -28,7 +28,7 @@
   <target name="mspsim" depends="init">
   	<fail>-
 ----------------
-Could not find the MSPSim build file. Did you run &quot;git submodule update --init&quot;?
+Could not find the MSPSim build file. Did you run &quot;git submodule update --init --recursive&quot;?
 ----------------
   		<condition><not>
   	      <available file="${mspsim}/build.xml" />


### PR DESCRIPTION
Updates the warning when MSPSim is not found to suggest a recursive submodule update. A non-resursive submodule update does not solve the issue when Cooja is used as a submodule itself.