### PR TITLE
Only try to build ContikiMote Java library once.

### DIFF
--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -218,7 +218,6 @@ public abstract class CoreComm {
       int b;
       String[] cmd = new String[] {
           Cooja.getExternalToolsSetting("PATH_JAVAC"),
-          "-version",
           "-cp",
           "." + File.pathSeparator +
           Cooja.getExternalToolsSetting("PATH_CONTIKI")

--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -216,37 +216,18 @@ public abstract class CoreComm {
 
     try {
       int b;
-      String[] cmd = new String[] { Cooja.getExternalToolsSetting("PATH_JAVAC"),
-          "-version", "org/contikios/cooja/corecomm/" + className + ".java" };
+      String[] cmd = new String[] {
+          Cooja.getExternalToolsSetting("PATH_JAVAC"),
+          "-version",
+          "-cp",
+          "." + File.pathSeparator +
+          Cooja.getExternalToolsSetting("PATH_CONTIKI")
+          + "/tools/cooja/dist/cooja.jar",
+          "org/contikios/cooja/corecomm/" + className + ".java" };
 
       Process p = Runtime.getRuntime().exec(cmd, null, null);
       InputStream outputStream = p.getInputStream();
       InputStream errorStream = p.getErrorStream();
-      while ((b = outputStream.read()) >= 0) {
-        compilationStandardStream.write(b);
-      }
-      while ((b = errorStream.read()) >= 0) {
-        compilationErrorStream.write(b);
-      }
-      p.waitFor();
-
-      if (classFile.exists()) {
-        return;
-      }
-
-      // Try including cooja.jar
-      cmd = new String[] {
-          Cooja.getExternalToolsSetting("PATH_JAVAC"),
-          "-version",
-          "org/contikios/cooja/corecomm/" + className + ".java",
-          "-cp",
-          Cooja.getExternalToolsSetting("PATH_CONTIKI")
-              + "/tools/cooja/dist/cooja.jar" };
-
-      p = Runtime.getRuntime().exec(cmd, null, null);
-
-      outputStream = p.getInputStream();
-      errorStream = p.getErrorStream();
       while ((b = outputStream.read()) >= 0) {
         compilationStandardStream.write(b);
       }


### PR DESCRIPTION
Cooja tries to build the ContikiMote Java library first without and then with the Cooja JAR included in the class path. This results in a warning if it fails in the first try. This changes Cooja to try to compile the library both with current path and the Cooja JAR in the class path in a single step to avoid the compile warning. This should solve the issue reported in #3.