### PR TITLE
Increase the size of a number of buffers

### DIFF
--- a/apps/native_gateway/java/org/contikios/cooja/plugins/NativeIPGateway.java
+++ b/apps/native_gateway/java/org/contikios/cooja/plugins/NativeIPGateway.java
@@ -138,7 +138,7 @@ public class NativeIPGateway extends VisPlugin implements MotePlugin {
 
   private SlipState readSlipState = SlipState.STATE_OK;
   private int readSlipLength = 0;
-  private final int READ_SLIP_BUFFER_SIZE = 2048;
+  private final int READ_SLIP_BUFFER_SIZE = 16 * 1024;
   private byte[] readSlipBuffer = new byte[READ_SLIP_BUFFER_SIZE];
 
   public NativeIPGateway(Mote mote, Simulation simulation, final GUI gui) {

--- a/apps/serial_socket/java/org/contikios/cooja/serialsocket/SerialSocketClient.java
+++ b/apps/serial_socket/java/org/contikios/cooja/serialsocket/SerialSocketClient.java
@@ -401,7 +401,7 @@ public class SerialSocketClient extends VisPlugin implements MotePlugin {
       @Override
       public void run() {
         int numRead = 0;
-        byte[] data = new byte[1024];
+        byte[] data = new byte[16*1024];
         logger.info("Start forwarding: socket -> serial port");
         while (numRead >= 0) {
           try {

--- a/apps/serial_socket/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
+++ b/apps/serial_socket/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
@@ -467,7 +467,7 @@ public class SerialSocketServer extends VisPlugin implements MotePlugin {
     @Override
     public void run() {
       int numRead = 0;
-      byte[] data = new byte[1024];
+      byte[] data = new byte[16*1024];
       try {
         in = new DataInputStream(clientSocket.getInputStream());
       } catch (IOException ex) {

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiRS232.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiRS232.java
@@ -71,8 +71,8 @@ public class ContikiRS232 extends SerialUI implements ContikiMoteInterface, Poll
   private ContikiMote mote = null;
   private VarMemory moteMem = null;
 
-  static final int SERIAL_BUF_SIZE = 2048; /* rs232.c:40 */
-  
+  static final int SERIAL_BUF_SIZE = 16 * 1024; /* rs232.c:40 */
+
   /**
    * Creates an interface to the RS232 at mote.
    *

--- a/java/org/contikios/cooja/dialogs/SerialUI.java
+++ b/java/org/contikios/cooja/dialogs/SerialUI.java
@@ -60,7 +60,7 @@ import org.contikios.cooja.interfaces.SerialPort;
 public abstract class SerialUI extends Log implements SerialPort {
   private static Logger logger = Logger.getLogger(SerialUI.class);
 
-  private final static int MAX_LENGTH = 1024;
+  private final static int MAX_LENGTH = 16*1024;
 
   private byte lastSerialData = 0; /* SerialPort */
   private String lastLogMessage = ""; /* Log */

--- a/java/org/contikios/cooja/plugins/BufferListener.java
+++ b/java/org/contikios/cooja/plugins/BufferListener.java
@@ -133,7 +133,7 @@ public class BufferListener extends VisPlugin {
   private static final long TIME_MINUTE = 60*TIME_SECOND;
   private static final long TIME_HOUR = 60*TIME_MINUTE;
 
-  final static int MAX_BUFFER_SIZE = 2048;
+  final static int MAX_BUFFER_SIZE = 16 * 1024;
 
   private static ArrayList<Class<? extends Parser>> bufferParsers =
     new ArrayList<Class<? extends Parser>>();

--- a/java/org/contikios/cooja/util/MoteSerialSocketConnection.java
+++ b/java/org/contikios/cooja/util/MoteSerialSocketConnection.java
@@ -100,7 +100,7 @@ public class MoteSerialSocketConnection {
     Thread socketThread = new Thread(new Runnable() {
       public void run() {
         int numRead = 0;
-        byte[] data = new byte[1024];
+        byte[] data = new byte[16*1024];
         while (true) {
           numRead = -1;
           try {


### PR DESCRIPTION
No point restricting ourselves with 1kB. For instance, the buffer in `SerialSocketServer` was actually limiting the IP datagram length to 1024.