### PR TITLE
Fix coojas path configuration when used without contiki

### DIFF
--- a/config/external_tools.config
+++ b/config/external_tools.config
@@ -1,4 +1,5 @@
-PATH_CONTIKI = ../../..
+PATH_COOJA = ../
+PATH_CONTIKI = ../../
 PATH_COOJA_CORE_RELATIVE = /platform/cooja
 PATH_MAKE = make
 PATH_LINKER = ld
@@ -22,7 +23,7 @@ AR_COMMAND_2 =
 CONTIKI_STANDARD_PROCESSES = sensors_process;etimer_process
 CORECOMM_TEMPLATE_FILENAME = corecomm_template.java
 PATH_JAVAC = javac
-DEFAULT_PROJECTDIRS = [CONTIKI_DIR]/tools/cooja/apps/mrm;[CONTIKI_DIR]/tools/cooja/apps/mspsim;[CONTIKI_DIR]/tools/cooja/apps/avrora;[CONTIKI_DIR]/tools/cooja/apps/serial_socket;[CONTIKI_DIR]/tools/cooja/apps/powertracker
+DEFAULT_PROJECTDIRS = [APPS_DIR]/mrm;[APPS_DIR]/mspsim;[APPS_DIR]/avrora;[APPS_DIR]/serial_socket;[APPS_DIR]/powertracker
 
 PARSE_WITH_COMMAND=false
 MAPFILE_DATA_START = ^.data[ \t]*0x([0-9A-Fa-f]*)[ \t]*0x[0-9A-Fa-f]*[ \t]*$

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -245,7 +245,8 @@ public class Cooja extends Observable {
   public static Properties currentExternalToolsSettings;
 
   private static final String externalToolsSettingNames[] = new String[] {
-    "PATH_CONTIKI", "PATH_COOJA_CORE_RELATIVE","PATH_COOJA","PATH_APPS",
+    "PATH_COOJA",
+    "PATH_CONTIKI", "PATH_COOJA_CORE_RELATIVE","PATH_APPS",
     "PATH_APPSEARCH",
 
     "PATH_MAKE",
@@ -4174,8 +4175,8 @@ public class Cooja extends Observable {
 
   private final static String[][] PATH_IDENTIFIER = {
 	  {"[CONTIKI_DIR]","PATH_CONTIKI",""},
-	  {"[COOJA_DIR]","PATH_COOJA","/tools/cooja"},
-	  {"[APPS_DIR]","PATH_APPS","/tools/cooja/apps"}
+	  {"[COOJA_DIR]","PATH_COOJA",""},
+	  {"[APPS_DIR]","PATH_APPS","apps"}
   };
   
   private File createContikiRelativePath(File file) {
@@ -4188,7 +4189,7 @@ public class Cooja extends Observable {
     	String fileCanonical = file.getCanonicalPath();
       
     	//No so nice, but goes along with GUI.getExternalToolsSetting
-    	String defp = Cooja.getExternalToolsSetting("PATH_CONTIKI", null);
+			String defp = Cooja.getExternalToolsSetting("PATH_COOJA", null);
     	
     	
 		for(int i = 0; i < elem; i++){
@@ -4246,16 +4247,16 @@ public class Cooja extends Observable {
     	
     	
     	if(i == elem) return null;
-    	//logger.info("Found: " + PATH_IDENTIFIER[i][0]);
+       //logger.info("Found: " + PATH_IDENTIFIER[i][0]);
     	
     	//No so nice, but goes along with GUI.getExternalToolsSetting
-    	String defp = Cooja.getExternalToolsSetting("PATH_CONTIKI", null);
+			String defp = Cooja.getExternalToolsSetting("PATH_COOJA", null);
     	path = new File(Cooja.getExternalToolsSetting(PATH_IDENTIFIER[i][1], defp + PATH_IDENTIFIER[i][2]));
     	
     	//logger.info("Config: " + PATH_IDENTIFIER[i][1] + ", " + defp + PATH_IDENTIFIER[i][2] + " = " + path.toString());
 		canonical = path.getCanonicalPath();
     	
-		
+    
     	File absolute = new File(portablePath.replace(PATH_IDENTIFIER[i][0], canonical));
 		if(!absolute.exists()){
 			logger.warn("Replaced " + portable  + " with " + absolute.toString() + " (default: "+ defp + PATH_IDENTIFIER[i][2] +"), but could not find it. This does not have to be an error, as the file might be created later.");


### PR DESCRIPTION
This PR removes the dependency of cooja to be in contiki's directory structure. This way cooja can be used standalone.

As it is right now without this patch, if one only downloads cooja and tries to start it, cooja does not find the default apps:
+ `PATH_CONTIKI` is configured as `../../..` in Cooja; `cooja.jar` lies in `contiki-ng/tools/cooja/build`, so `PATH_CONTIKI` will be `contiki-ng`
+ `PATH_CONTIKI/tools/cooja` is then used as root for cooja and everything else (extensions)

This patch uses coojas path instead. `PATH_CONTIKI` and `PATH_COOJA` are both still configurable stuff like `[APPS_DIR]` is now in `PATH_COOJA/apps` instead of `PATH_CONTIKI/tools/cooja/apps`

