### PR TITLE
Make the output directory and library location configurable

### DIFF
--- a/config/external_tools.config
+++ b/config/external_tools.config
@@ -1,5 +1,6 @@
 PATH_CONTIKI = ../../..
 PATH_COOJA_CORE_RELATIVE = /platform/cooja
+PATH_CONTIKI_NG_BUILD_DIR = build/cooja
 PATH_MAKE = make
 PATH_LINKER = ld
 PATH_AR = ar

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -247,6 +247,7 @@ public class Cooja extends Observable {
   private static final String externalToolsSettingNames[] = new String[] {
     "PATH_CONTIKI", "PATH_COOJA_CORE_RELATIVE","PATH_COOJA","PATH_APPS",
     "PATH_APPSEARCH",
+    "PATH_CONTIKI_NG_BUILD_DIR",
 
     "PATH_MAKE",
     "PATH_SHELL",

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -121,7 +121,8 @@ public class ContikiMoteType implements MoteType {
   /**
    * Temporary output directory
    */
-  final static public File tempOutputDirectory = new File("obj_cooja");
+  final static public File tempOutputDirectory = new File(
+      Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "build/cooja"));
 
   /**
    * Communication stacks in Contiki.
@@ -185,13 +186,13 @@ public class ContikiMoteType implements MoteType {
   /* For internal use only: using during Contiki compilation. */
   private File contikiApp = null; /* Contiki application: hello-world.c */
 
-  public File libSource = null; /* JNI library: obj_cooja/mtype1.c */
+  public File libSource = null; /* JNI library: build/cooja/mtype1.c */
 
-  public File libFile = null; /* JNI library: obj_cooja/mtype1.lib */
+  public File libFile = null; /* JNI library: build/cooja/mtype1.lib */
 
-  public File archiveFile = null; /* Contiki archive: obj_cooja/mtype1.a */
+  public File archiveFile = null; /* Contiki archive: build/cooja/mtype1.a */
 
-  public File mapFile = null; /* Contiki map: obj_cooja/mtype1.map */
+  public File mapFile = null; /* Contiki map: build/cooja/mtype1.map */
 
   public String javaClassName = null; /* Loading Java class name: Lib1 */
 
@@ -230,7 +231,8 @@ public class ContikiMoteType implements MoteType {
   public boolean configureAndInit(Container parentContainer, Simulation simulation,
                                   boolean visAvailable) throws MoteTypeCreationException {
     myConfig = simulation.getCooja().getProjectConfig().clone();
-
+    String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "");
+    
     if (visAvailable) {
 
       if (getDescription() == null) {
@@ -256,16 +258,16 @@ public class ContikiMoteType implements MoteType {
       contikiApp = getContikiSourceFile();
       libSource = new File(
               contikiApp.getParentFile(),
-              "obj_cooja/" + getIdentifier() + ".c");
+              output_dir + "/" + getIdentifier() + ".c");
       libFile = new File(
               contikiApp.getParentFile(),
-              "obj_cooja/" + getIdentifier() + librarySuffix);
+              output_dir + "/" + getIdentifier() + librarySuffix);
       archiveFile = new File(
               contikiApp.getParentFile(),
-              "obj_cooja/" + getIdentifier() + dependSuffix);
+              output_dir + "/" + getIdentifier() + dependSuffix);
       mapFile = new File(
               contikiApp.getParentFile(),
-              "obj_cooja/" + getIdentifier() + mapSuffix);
+              output_dir + "/" + getIdentifier() + mapSuffix);
       javaClassName = CoreComm.getAvailableClassName();
 
       if (javaClassName == null) {
@@ -1235,6 +1237,7 @@ public class ContikiMoteType implements MoteType {
           throws MoteTypeCreationException {
     boolean warnedOldVersion = false;
     File oldVersionSource = null;
+    String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "");
 
     moteInterfacesClasses = new ArrayList<Class<? extends MoteInterface>>();
 
@@ -1256,7 +1259,7 @@ public class ContikiMoteType implements MoteType {
           /* XXX Do not load the generated firmware. Instead, load the unique library file directly */
         File contikiFirmware = new File(
                 getContikiSourceFile().getParentFile(),
-                "obj_cooja/" + getIdentifier() + librarySuffix);
+                output_dir + "/" + getIdentifier() + librarySuffix);
           setContikiFirmwareFile(contikiFirmware);
           break;
         case "commands":

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -231,7 +231,7 @@ public class ContikiMoteType implements MoteType {
   public boolean configureAndInit(Container parentContainer, Simulation simulation,
                                   boolean visAvailable) throws MoteTypeCreationException {
     myConfig = simulation.getCooja().getProjectConfig().clone();
-    String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "");
+    String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "build/cooja");
     
     if (visAvailable) {
 
@@ -1237,7 +1237,7 @@ public class ContikiMoteType implements MoteType {
           throws MoteTypeCreationException {
     boolean warnedOldVersion = false;
     File oldVersionSource = null;
-    String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "");
+    String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "build/cooja");
 
     moteInterfacesClasses = new ArrayList<Class<? extends MoteInterface>>();
 

--- a/java/org/contikios/cooja/dialogs/CompileContiki.java
+++ b/java/org/contikios/cooja/dialogs/CompileContiki.java
@@ -455,7 +455,7 @@ public class CompileContiki {
     boolean includeSymbols = false; /* TODO */
 
     /* Fetch configuration from external tools */
-    String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "");
+    String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "build/cooja");
     String link1 = Cooja.getExternalToolsSetting("LINK_COMMAND_1", "");
     String link2 = Cooja.getExternalToolsSetting("LINK_COMMAND_2", "");
     String ar1 = Cooja.getExternalToolsSetting("AR_COMMAND_1", "");

--- a/java/org/contikios/cooja/dialogs/CompileContiki.java
+++ b/java/org/contikios/cooja/dialogs/CompileContiki.java
@@ -455,6 +455,7 @@ public class CompileContiki {
     boolean includeSymbols = false; /* TODO */
 
     /* Fetch configuration from external tools */
+    String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "");
     String link1 = Cooja.getExternalToolsSetting("LINK_COMMAND_1", "");
     String link2 = Cooja.getExternalToolsSetting("LINK_COMMAND_2", "");
     String ar1 = Cooja.getExternalToolsSetting("AR_COMMAND_1", "");
@@ -462,25 +463,25 @@ public class CompileContiki {
     String ccFlags = Cooja.getExternalToolsSetting("COMPILER_ARGS", "");
 
     /* Replace MAPFILE variable */
-    link1 = link1.replace("$(MAPFILE)", "obj_cooja/" + mapFile.getName());
-    link2 = link2.replace("$(MAPFILE)", "obj_cooja/" + mapFile.getName());
-    ar1 = ar1.replace("$(MAPFILE)", "obj_cooja/" + mapFile.getName());
-    ar2 = ar2.replace("$(MAPFILE)", "obj_cooja/" + mapFile.getName());
-    ccFlags = ccFlags.replace("$(MAPFILE)", "obj_cooja/" + mapFile.getName());
+    link1 = link1.replace("$(MAPFILE)", output_dir + "/" + mapFile.getName());
+    link2 = link2.replace("$(MAPFILE)", output_dir + "/" + mapFile.getName());
+    ar1 = ar1.replace("$(MAPFILE)", output_dir + "/" + mapFile.getName());
+    ar2 = ar2.replace("$(MAPFILE)", output_dir + "/" + mapFile.getName());
+    ccFlags = ccFlags.replace("$(MAPFILE)", output_dir + "/" + mapFile.getName());
 
     /* Replace LIBFILE variable */
-    link1 = link1.replace("$(LIBFILE)", "obj_cooja/" + libFile.getName());
-    link2 = link2.replace("$(LIBFILE)", "obj_cooja/" + libFile.getName());
-    ar1 = ar1.replace("$(LIBFILE)", "obj_cooja/" + libFile.getName());
-    ar2 = ar2.replace("$(LIBFILE)", "obj_cooja/" + libFile.getName());
-    ccFlags = ccFlags.replace("$(LIBFILE)", "obj_cooja/" + libFile.getName());
+    link1 = link1.replace("$(LIBFILE)", output_dir + "/" + libFile.getName());
+    link2 = link2.replace("$(LIBFILE)", output_dir + "/" + libFile.getName());
+    ar1 = ar1.replace("$(LIBFILE)", output_dir + "/" + libFile.getName());
+    ar2 = ar2.replace("$(LIBFILE)", output_dir + "/" + libFile.getName());
+    ccFlags = ccFlags.replace("$(LIBFILE)", output_dir + "/" + libFile.getName());
 
     /* Replace ARFILE variable */
-    link1 = link1.replace("$(ARFILE)", "obj_cooja/" + archiveFile.getName());
-    link2 = link2.replace("$(ARFILE)", "obj_cooja/" + archiveFile.getName());
-    ar1 = ar1.replace("$(ARFILE)", "obj_cooja/" + archiveFile.getName());
-    ar2 = ar2.replace("$(ARFILE)", "obj_cooja/" + archiveFile.getName());
-    ccFlags = ccFlags.replace("$(ARFILE)", "obj_cooja/" + archiveFile.getName());
+    link1 = link1.replace("$(ARFILE)", output_dir + "/" + archiveFile.getName());
+    link2 = link2.replace("$(ARFILE)", output_dir + "/" + archiveFile.getName());
+    ar1 = ar1.replace("$(ARFILE)", output_dir + "/" + archiveFile.getName());
+    ar2 = ar2.replace("$(ARFILE)", output_dir + "/" + archiveFile.getName());
+    ccFlags = ccFlags.replace("$(ARFILE)", output_dir + "/" + archiveFile.getName());
 
     /* Replace JAVA_HOME variable */
     String javaHome = System.getenv().get("JAVA_HOME");

--- a/java/org/contikios/cooja/dialogs/ConfigurationWizard.java
+++ b/java/org/contikios/cooja/dialogs/ConfigurationWizard.java
@@ -621,7 +621,7 @@ public class ConfigurationWizard extends JDialog {
     testOutput.addMessage("### Compiling C library source: " + cLibrarySourceFile.getName());
     try {
       String contikiPath = Cooja.getExternalToolsSetting("PATH_CONTIKI").replaceAll("\\\\", "/");
-      String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "");
+      String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "build/cooja");
 
       CompileContiki.compile(
           "make " +

--- a/java/org/contikios/cooja/dialogs/ConfigurationWizard.java
+++ b/java/org/contikios/cooja/dialogs/ConfigurationWizard.java
@@ -621,11 +621,13 @@ public class ConfigurationWizard extends JDialog {
     testOutput.addMessage("### Compiling C library source: " + cLibrarySourceFile.getName());
     try {
       String contikiPath = Cooja.getExternalToolsSetting("PATH_CONTIKI").replaceAll("\\\\", "/");
+      String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "");
+
       CompileContiki.compile(
           "make " +
           "-f " + contikiPath + "/Makefile.include " +
           "CONTIKI=" + contikiPath + " " +
-          "obj_cooja/" + cLibraryName + ".cooja " +
+          output_dir + "/" + cLibraryName + ".cooja " +
           "TARGET=cooja CONTIKI_APP_OBJ=",
           envOneDimension,
           null,

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -110,24 +110,26 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
       moteType.setIdentifier(
           ContikiMoteType.generateUniqueMoteTypeID(simulation.getMoteTypes(), null));
     }
-
+    
+    String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "");
+    
     /* Create variables used for compiling Contiki */
     ((ContikiMoteType)moteType).setContikiSourceFile(source);
     ((ContikiMoteType)moteType).libSource = new File(
         source.getParentFile(),
-        "obj_cooja/" + moteType.getIdentifier() + ".c"
+        output_dir + "/" + moteType.getIdentifier() + ".c"
     );
     ((ContikiMoteType)moteType).libFile = new File(
         source.getParentFile(),
-        "obj_cooja/" + moteType.getIdentifier() + ContikiMoteType.librarySuffix
+        output_dir + "/" + moteType.getIdentifier() + ContikiMoteType.librarySuffix
     );
     ((ContikiMoteType)moteType).archiveFile = new File(
         source.getParentFile(),
-        "obj_cooja/" + moteType.getIdentifier() + ContikiMoteType.dependSuffix
+        output_dir + "/" + moteType.getIdentifier() + ContikiMoteType.dependSuffix
     );
     ((ContikiMoteType)moteType).mapFile = new File(
         source.getParentFile(),
-        "obj_cooja/" + moteType.getIdentifier() + ContikiMoteType.mapSuffix);
+        output_dir + "/" + moteType.getIdentifier() + ContikiMoteType.mapSuffix);
     ((ContikiMoteType)moteType).javaClassName = CoreComm.getAvailableClassName();
 
     if (((ContikiMoteType)moteType).javaClassName == null) {
@@ -352,10 +354,11 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
 
   public void writeSettingsToMoteType() {
     /* XXX Do not load the generated firmware.
-     * Instead, load the copy in obj_cooja/ */
+     * Instead, load the copy in output_dir */
+    String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", ""); 
     File contikiFirmware = new File(
         moteType.getContikiSourceFile().getParentFile(),
-        "obj_cooja/" + moteType.getIdentifier() + ContikiMoteType.librarySuffix
+        output_dir + "/" + moteType.getIdentifier() + ContikiMoteType.librarySuffix
     );
     moteType.setContikiFirmwareFile(contikiFirmware);
 

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -111,7 +111,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
           ContikiMoteType.generateUniqueMoteTypeID(simulation.getMoteTypes(), null));
     }
     
-    String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "");
+    String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "build/cooja");
     
     /* Create variables used for compiling Contiki */
     ((ContikiMoteType)moteType).setContikiSourceFile(source);
@@ -355,7 +355,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
   public void writeSettingsToMoteType() {
     /* XXX Do not load the generated firmware.
      * Instead, load the copy in output_dir */
-    String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", ""); 
+    String output_dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "build/cooja"); 
     File contikiFirmware = new File(
         moteType.getContikiSourceFile().getParentFile(),
         output_dir + "/" + moteType.getIdentifier() + ContikiMoteType.librarySuffix


### PR DESCRIPTION
At the moment `obj_cooja` is hard-coded in multiple places.

This commit adds a configuration token called `PATH_CONTIKI_NG_BUILD_DIR` that can be set from the external dialog window. The configured value replaces all hard-coded instances of "obj_cooja".

We default to `build/cooja` if unconfigured. This pull is basically aimed at playing nicely alongside contiki-ng/contiki-ng#698