### PR TITLE
Workaround a race condition in MRM channel model

### DIFF
--- a/apps/mrm/java/org/contikios/mrm/ChannelModel.java
+++ b/apps/mrm/java/org/contikios/mrm/ChannelModel.java
@@ -1009,7 +1009,8 @@ public class ChannelModel {
    * @param lookThrough Line to look through (or null)
    * @return All visible sides
    */
-  private Vector<Line2D> getAllVisibleSides(double sourceX, double sourceY, AngleInterval angleInterval, Line2D lookThrough) {
+  synchronized private Vector<Line2D> getAllVisibleSides(double sourceX, double sourceY, AngleInterval angleInterval, Line2D lookThrough) {
+    // synchronized because a race condition happens in this method when MRMVisualizerSkin accesses this module from another thread
     Point2D source = new Point2D.Double(sourceX, sourceY);
 
     // Check if results were already calculated earlier


### PR DESCRIPTION
This patch works around a race condition caused by simultaneous access to the ChannelModel module from the simulation and GUI threads.

It makes the method where the race condition occurs synchronized. When the MRM link visualizer is enabled in the GUI, the GUI thread calls to mrm.ChannelModel module which alters its state without any synchronization which causes a race condition and an exception that stops the simulation.

I consider it a workaround because, probably the whole module is not thread-safe and a nicer solution would be to refactor it. However, it fixes the issue.

To reproduce, use the attached CSC and binary. Select one of the nodes in the network window to display the link quality information. Start the simulation. An exception should happen in some time (usually within 3 simulated minutes).
[mrm_race.zip](https://github.com/contiki-ng/cooja/files/2966420/mrm_race.zip)

