### PR TITLE
Remove javax.xml.bind dependency 

### DIFF
--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiEEPROM.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiEEPROM.java
@@ -38,7 +38,6 @@ import java.awt.event.ActionListener;
 import java.io.*;
 import java.util.*;
 import javax.swing.*;
-import javax.xml.bind.DatatypeConverter;
 import org.apache.log4j.Logger;
 import org.jdom.Element;
 
@@ -278,7 +277,7 @@ public class ContikiEEPROM extends MoteInterface implements ContikiMoteInterface
 
       // Infinite boolean
       element = new Element("eeprom");
-      element.setText(DatatypeConverter.printBase64Binary(getEEPROMData()));
+      element.setText(Base64.getEncoder().encodeToString(getEEPROMData()));
       config.add(element);
 
       return config;
@@ -287,7 +286,7 @@ public class ContikiEEPROM extends MoteInterface implements ContikiMoteInterface
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
       for (Element element : configXML) {
         if (element.getName().equals("eeprom")) {
-          setEEPROMData(DatatypeConverter.parseBase64Binary(element.getText()));
+          setEEPROMData(Base64.getDecoder().decode(element.getText()));
         }
       }
   }


### PR DESCRIPTION
The deprecated javax.xml.bind package was used for Base64 conversions in COOJA, but this functionality is existent in java.util.Base64. By changing this, we can now compile COOJA using newer Java versions.