### PR TITLE
Use java.util.PriorityQueue to implement the EventQueue

### DIFF
--- a/apps/avrora/src/org/contikios/cooja/avrmote/interfaces/MicaZID.java
+++ b/apps/avrora/src/org/contikios/cooja/avrmote/interfaces/MicaZID.java
@@ -59,27 +59,29 @@ public class MicaZID extends MoteID {
     private VarMemory moteMem;
     boolean tosID = false;
     boolean contikiID = false;
-    private MicaZMote mote;
+    private final MicaZMote mote;
     private int persistentSetIDCounter = 1000;
 
-    TimeEvent persistentSetIDEvent = new MoteTimeEvent(mote, 0) {
-        public void execute(long t) {
-            if (persistentSetIDCounter-- > 0) {
-                setMoteID(moteID);
-                if (t + mote.getInterfaces().getClock().getDrift() < 0) {
-                    /* Wait until node is booting */
-                    mote.getSimulation().scheduleEvent(this, -mote.getInterfaces().getClock().getDrift());
-                } else {
-                    mote.getSimulation().scheduleEvent(this, t + Simulation.MILLISECOND / 16);
-                }
-            }
-        }
-    };
+    private final TimeEvent persistentSetIDEvent;
 
 
     public MicaZID(Mote mote) {
         this.mote = (MicaZMote) mote;
         this.moteMem = new VarMemory(mote.getMemory());
+
+        persistentSetIDEvent = new MoteTimeEvent(mote) {
+            public void execute(long t) {
+                if (persistentSetIDCounter-- > 0) {
+                    setMoteID(moteID);
+                    if (t + mote.getInterfaces().getClock().getDrift() < 0) {
+                        /* Wait until node is booting */
+                        mote.getSimulation().scheduleEvent(this, -mote.getInterfaces().getClock().getDrift());
+                    } else {
+                        mote.getSimulation().scheduleEvent(this, t + Simulation.MILLISECOND / 16);
+                    }
+                }
+            }
+        };
 
         if (moteMem.variableExists("node_id")) {
             contikiID = true;

--- a/apps/mspsim/src/org/contikios/cooja/mspmote/MspMoteTimeEvent.java
+++ b/apps/mspsim/src/org/contikios/cooja/mspmote/MspMoteTimeEvent.java
@@ -40,12 +40,12 @@ import org.contikios.cooja.MoteTimeEvent;
  * @author Fredrik Osterlind
  */
 public abstract class MspMoteTimeEvent extends MoteTimeEvent {
-  private static Logger logger = Logger.getLogger(MspMoteTimeEvent.class);
+  private static final Logger logger = Logger.getLogger(MspMoteTimeEvent.class);
 
-  private MspMote mote;
+  private final MspMote mote;
 
-  public MspMoteTimeEvent(MspMote mote, long time) {
-    super(mote, time);
+  public MspMoteTimeEvent(MspMote mote) {
+    super(mote);
     this.mote = mote;
   }
 

--- a/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/CC1101Radio.java
+++ b/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/CC1101Radio.java
@@ -236,7 +236,7 @@ public class CC1101Radio extends Radio implements CustomDataRadio {
 			}
 
 			final byte byteToDeliver = b;
-			getMote().getSimulation().scheduleEvent(new MspMoteTimeEvent(mote, 0) {
+			getMote().getSimulation().scheduleEvent(new MspMoteTimeEvent(mote) {
 				public void execute(long t) {
 					super.execute(t);
 					cc1101.receivedByte(byteToDeliver);
@@ -269,7 +269,7 @@ public class CC1101Radio extends Radio implements CustomDataRadio {
 		} else {
 			inputByte = lastIncomingByte;
 		}
-		mote.getSimulation().scheduleEvent(new MspMoteTimeEvent(mote, 0) {
+		mote.getSimulation().scheduleEvent(new MspMoteTimeEvent(mote) {
 			public void execute(long t) {
 				super.execute(t);
 				cc1101.receivedByte(inputByte);
@@ -366,7 +366,7 @@ public class CC1101Radio extends Radio implements CustomDataRadio {
 		}
 		currentSignalStrength = signalStrength;
 		if (rssiLastCounter == 0) {
-			getMote().getSimulation().scheduleEvent(new MspMoteTimeEvent(mote, 0) {
+			getMote().getSimulation().scheduleEvent(new MspMoteTimeEvent(mote) {
 				public void execute(long t) {
 					super.execute(t);
 

--- a/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/CC1120Radio.java
+++ b/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/CC1120Radio.java
@@ -237,7 +237,7 @@ public class CC1120Radio extends Radio implements CustomDataRadio {
 			}
 
 			final byte byteToDeliver = b;
-			getMote().getSimulation().scheduleEvent(new MspMoteTimeEvent(mote, 0) {
+			getMote().getSimulation().scheduleEvent(new MspMoteTimeEvent(mote) {
 				public void execute(long t) {
 					super.execute(t);
 					cc1120.receivedByte(byteToDeliver);
@@ -270,7 +270,7 @@ public class CC1120Radio extends Radio implements CustomDataRadio {
 		} else {
 			inputByte = lastIncomingByte;
 		}
-		mote.getSimulation().scheduleEvent(new MspMoteTimeEvent(mote, 0) {
+		mote.getSimulation().scheduleEvent(new MspMoteTimeEvent(mote) {
 			public void execute(long t) {
 				super.execute(t);
 				cc1120.receivedByte(inputByte);
@@ -367,7 +367,7 @@ public class CC1120Radio extends Radio implements CustomDataRadio {
 		}
 		currentSignalStrength = signalStrength;
 		if (rssiLastCounter == 0) {
-			getMote().getSimulation().scheduleEvent(new MspMoteTimeEvent(mote, 0) {
+			getMote().getSimulation().scheduleEvent(new MspMoteTimeEvent(mote) {
 				public void execute(long t) {
 					super.execute(t);
 

--- a/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/CC2520Radio.java
+++ b/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/CC2520Radio.java
@@ -208,7 +208,7 @@ public class CC2520Radio extends Radio implements CustomDataRadio {
     } else {
       inputByte = lastIncomingByte;
     }
-    mote.getSimulation().scheduleEvent(new MspMoteTimeEvent(mote, 0) {
+    mote.getSimulation().scheduleEvent(new MspMoteTimeEvent(mote) {
       public void execute(long t) {
         super.execute(t);
         radio.receivedByte(inputByte);
@@ -306,7 +306,7 @@ public class CC2520Radio extends Radio implements CustomDataRadio {
     }
     currentSignalStrength = signalStrength;
     if (rssiLastCounter == 0) {
-      getMote().getSimulation().scheduleEvent(new MspMoteTimeEvent(mote, 0) {
+      getMote().getSimulation().scheduleEvent(new MspMoteTimeEvent(mote) {
         public void execute(long t) {
           super.execute(t);
 

--- a/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/Msp802154BitErrorRadio.java
+++ b/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/Msp802154BitErrorRadio.java
@@ -358,7 +358,7 @@ public class Msp802154BitErrorRadio extends Msp802154Radio {
       }
     }
 
-    mote.getSimulation().scheduleEvent(new MspMoteTimeEvent(mote, 0) {
+    mote.getSimulation().scheduleEvent(new MspMoteTimeEvent(mote) {
       public void execute(long t) {
         super.execute(t);
         radio.receivedByte(inputByte);

--- a/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/Msp802154Radio.java
+++ b/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/Msp802154Radio.java
@@ -225,7 +225,7 @@ public class Msp802154Radio extends Radio implements CustomDataRadio {
       }
 
       final byte byteToDeliver = b;
-      getMote().getSimulation().scheduleEvent(new MspMoteTimeEvent(mote, 0) {
+      getMote().getSimulation().scheduleEvent(new MspMoteTimeEvent(mote) {
         public void execute(long t) {
           super.execute(t);
           radio.receivedByte(byteToDeliver);
@@ -258,7 +258,7 @@ public class Msp802154Radio extends Radio implements CustomDataRadio {
     } else {
       inputByte = lastIncomingByte;
     }
-    mote.getSimulation().scheduleEvent(new MspMoteTimeEvent(mote, 0) {
+    mote.getSimulation().scheduleEvent(new MspMoteTimeEvent(mote) {
       public void execute(long t) {
         super.execute(t);
         radio.receivedByte(inputByte);
@@ -358,7 +358,7 @@ public class Msp802154Radio extends Radio implements CustomDataRadio {
     }
     currentSignalStrength = signalStrength;
     if (rssiLastCounter == 0) {
-      getMote().getSimulation().scheduleEvent(new MspMoteTimeEvent(mote, 0) {
+      getMote().getSimulation().scheduleEvent(new MspMoteTimeEvent(mote) {
         public void execute(long t) {
           super.execute(t);
 

--- a/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/MspSerial.java
+++ b/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/MspSerial.java
@@ -51,10 +51,10 @@ import se.sics.mspsim.core.USARTSource;
 public class MspSerial extends SerialUI implements SerialPort {
   private static final long DELAY_INCOMING_DATA = 69; /* 115200 bit/s */
   
-  private static Logger logger = Logger.getLogger(MspSerial.class);
+  private static final Logger logger = Logger.getLogger(MspSerial.class);
 
   private Simulation simulation;
-  private MspMote mote;
+  private final MspMote mote;
   private USARTSource usart;
   
   private Vector<Byte> incomingData = new Vector<Byte>();
@@ -77,7 +77,7 @@ public class MspSerial extends SerialUI implements SerialPort {
       });
     }
 
-    writeDataEvent = new MspMoteTimeEvent((MspMote) mote, 0) {
+    writeDataEvent = new MspMoteTimeEvent(this.mote) {
       public void execute(long t) {
         super.execute(t);
         

--- a/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/TR1001Radio.java
+++ b/apps/mspsim/src/org/contikios/cooja/mspmote/interfaces/TR1001Radio.java
@@ -133,7 +133,7 @@ public class TR1001Radio extends Radio implements USARTListener, CustomDataRadio
     }
 
     /* Feed incoming bytes to radio "slowly" via time events */
-    TimeEvent receiveCrosslevelDataEvent = new MspMoteTimeEvent(mote, 0) {
+    TimeEvent receiveCrosslevelDataEvent = new MspMoteTimeEvent(mote) {
       public void execute(long t) {
         super.execute(t);
         
@@ -174,7 +174,7 @@ public class TR1001Radio extends Radio implements USARTListener, CustomDataRadio
     receivedByte = isInterfered ? CORRUPTED_DATA : (Byte) data;
 
     final byte finalByte = receivedByte;
-    mote.getSimulation().scheduleEvent(new MspMoteTimeEvent(mote, 0) {
+    mote.getSimulation().scheduleEvent(new MspMoteTimeEvent(mote) {
       public void execute(long t) {
         super.execute(t);
 
@@ -320,7 +320,7 @@ public class TR1001Radio extends Radio implements USARTListener, CustomDataRadio
     return mote.getInterfaces().getPosition();
   }
 
-  private TimeEvent timeoutTransmission = new MoteTimeEvent(mote, 0) {
+  private final TimeEvent timeoutTransmission = new MoteTimeEvent(mote) {
     public void execute(long t) {
       if (!isTransmitting()) {
         /* Nothing to do */

--- a/apps/mspsim/src/org/contikios/cooja/mspmote/plugins/MspStackWatcher.java
+++ b/apps/mspsim/src/org/contikios/cooja/mspmote/plugins/MspStackWatcher.java
@@ -114,7 +114,7 @@ public class MspStackWatcher extends VisPlugin implements MotePlugin {
     stackUI = new StackUI(cpu, -1); /* Needs manual updates */
     stackUI.init("Stack usage", mspMote.registry);
     stackUI.start();
-    increasePosTimeEvent = new MoteTimeEvent(mspMote, 0) {
+    increasePosTimeEvent = new MoteTimeEvent(mspMote) {
       public void execute(long t) {
         stackUI.requestIncreasePos();
         simulation.scheduleEvent(this, t + Simulation.MILLISECOND);

--- a/java/org/contikios/cooja/MoteTimeEvent.java
+++ b/java/org/contikios/cooja/MoteTimeEvent.java
@@ -40,15 +40,10 @@ package org.contikios.cooja;
  * @author Fredrik Osterlind
  */
 public abstract class MoteTimeEvent extends TimeEvent {
-  private Mote mote;
+  private final Mote mote;
 
-  public MoteTimeEvent(Mote mote, long time) {
-    super(time);
-    this.mote = mote;
-  }
-  
-  public MoteTimeEvent(Mote mote, long time, String name) {
-    super(time, name);
+  public MoteTimeEvent(Mote mote) {
+    super();
     this.mote = mote;
   }
 

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -177,6 +177,14 @@ public class Simulation extends Observable implements Runnable {
   }
 
   /**
+   * @return True iff current thread is the simulation thread,
+   * or the simulation threat has not yet been created.
+   */
+  public boolean isSimulationThreadOrNull() {
+    return simulationThread == Thread.currentThread() || simulationThread == null;
+  }
+
+  /**
    * Schedule simulation event for given time.
    * Already scheduled events must be removed before they are rescheduled.
    *
@@ -195,7 +203,7 @@ public class Simulation extends Observable implements Runnable {
     eventQueue.addEvent(e, time);
   }
 
-  private TimeEvent delayEvent = new TimeEvent(0) {
+  private final TimeEvent delayEvent = new TimeEvent() {
     public void execute(long t) {
       if (speedLimitNone) {
         /* As fast as possible: no need to reschedule delay event */
@@ -229,7 +237,7 @@ public class Simulation extends Observable implements Runnable {
     }
   };
 
-  private TimeEvent millisecondEvent = new TimeEvent(0) {
+  private final TimeEvent millisecondEvent = new TimeEvent() {
     public void execute(long t) {
       if (!hasMillisecondObservers) {
         return;
@@ -244,7 +252,7 @@ public class Simulation extends Observable implements Runnable {
   };
 
   public void clearEvents() {
-    eventQueue.removeAll();
+    eventQueue.clear();
     pollRequests.clear();
   }
 
@@ -259,7 +267,7 @@ public class Simulation extends Observable implements Runnable {
     this.setChanged();
     this.notifyObservers(this);
 
-    TimeEvent nextEvent = null;
+    EventQueue.Pair nextEvent = null;
     try {
       while (isRunning) {
 
@@ -278,7 +286,7 @@ public class Simulation extends Observable implements Runnable {
         }
         currentSimulationTime = nextEvent.time;
         /*logger.info("Executing event #" + EVENT_COUNTER++ + " @ " + currentSimulationTime + ": " + nextEvent);*/
-        nextEvent.execute(currentSimulationTime);
+        nextEvent.event.execute(currentSimulationTime);
 
         if (stopSimulation) {
           isRunning = false;
@@ -296,8 +304,8 @@ public class Simulation extends Observable implements Runnable {
     			System.exit(1);
     		} else {
     		  String title = "Simulation error";
-    		  if (nextEvent instanceof MoteTimeEvent) {
-    		    title += ": " + ((MoteTimeEvent)nextEvent).getMote();
+    		  if (nextEvent.event instanceof MoteTimeEvent) {
+    		    title += ": " + ((MoteTimeEvent)nextEvent.event).getMote();
     		  }
     		  Cooja.showErrorDialog(Cooja.getTopParentContainer(), title, e, false);
     		}
@@ -385,7 +393,7 @@ public class Simulation extends Observable implements Runnable {
     if (isRunning()) {
       return;
     }
-    TimeEvent stopEvent = new TimeEvent(0) {
+    TimeEvent stopEvent = new TimeEvent() {
       public void execute(long t) {
         /* Stop simulation */
         stopSimulation();
@@ -783,17 +791,10 @@ public class Simulation extends Observable implements Runnable {
         setChanged();
         notifyObservers(mote);
 
-        /* Loop through all scheduled events.
-         * Delete all events associated with deleted mote. */
-        TimeEvent ev = eventQueue.peekFirst();
-        while (ev != null) {
-          if (ev instanceof MoteTimeEvent) {
-            if (((MoteTimeEvent)ev).getMote() == mote) {
-              ev.remove();
-            }
-          }
-          ev = ev.nextEvent;
-        }
+        // Delete all events associated with deleted mote.
+        eventQueue.removeIf(
+          (TimeEvent ev) ->
+            ev instanceof MoteTimeEvent && ((MoteTimeEvent)ev).getMote() == mote);
       }
     };
 
@@ -1149,7 +1150,7 @@ public class Simulation extends Observable implements Runnable {
    * @return True if simulation is runnable
    */
   public boolean isRunnable() {
-    return isRunning || hasPollRequests || eventQueue.peekFirst() != null;
+    return isRunning || hasPollRequests || !eventQueue.isEmpty();
   }
 
   /**

--- a/java/org/contikios/cooja/TimeEvent.java
+++ b/java/org/contikios/cooja/TimeEvent.java
@@ -34,42 +34,29 @@ package org.contikios.cooja;
  * @author Joakim Eriksson (ported to COOJA by Fredrik Osterlind)
  */
 public abstract class TimeEvent {
-  TimeEvent nextEvent;
-  TimeEvent prevEvent;
 
-  EventQueue queue = null;
-  String name;
+  private boolean isQueued = false;
+  private boolean isScheduled = false;
 
-  protected long time;
-
-  boolean isScheduled = false;
-
-  public TimeEvent(long time) {
-    this(time, null);
-  }
-
-  public TimeEvent(long time, String name) {
-    this.time = time;
-    this.name = name;
-  }
-
-  public final long getTime() {
-    return time;
+  public TimeEvent() {
   }
 
   public boolean isScheduled() {
     return isScheduled;
   }
 
-  public boolean remove() {
+  public boolean isQueued() {
+    return isQueued;
+  }
+
+  public void setScheduled(boolean queued) {
+    isScheduled = queued;
+    isQueued = queued;
+  }
+
+  public void remove() {
     isScheduled = false;
-    return false;
   }
 
   public abstract void execute(long t);
-
-  public String getShort() {
-    return "" + time + (name != null ? ": " + name : "");
-  }
-
 }

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiRS232.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiRS232.java
@@ -149,7 +149,7 @@ public class ContikiRS232 extends SerialUI implements ContikiMoteInterface, Poll
       return;
     }
 
-    pendingBytesEvent = new MoteTimeEvent(mote, 0) {
+    pendingBytesEvent = new MoteTimeEvent(mote) {
       public void execute(long t) {
         ContikiRS232.this.pendingBytesEvent = null;
         if (pendingBytes.isEmpty()) {
@@ -207,7 +207,7 @@ public class ContikiRS232 extends SerialUI implements ContikiMoteInterface, Poll
       return;
     }
 
-    pendingBytesEvent = new MoteTimeEvent(mote, 0) {
+    pendingBytesEvent = new MoteTimeEvent(mote) {
       public void execute(long t) {
         ContikiRS232.this.pendingBytesEvent = null;
         if (pendingBytes.isEmpty()) {

--- a/java/org/contikios/cooja/interfaces/ApplicationRadio.java
+++ b/java/org/contikios/cooja/interfaces/ApplicationRadio.java
@@ -236,7 +236,7 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
         /*logger.info("Transmission started");*/
 
         /* Finish transmission */
-        simulation.scheduleEvent(new MoteTimeEvent(mote, 0) {
+        simulation.scheduleEvent(new MoteTimeEvent(mote) {
           public void execute(long t) {
             isTransmitting = false;
             lastEvent = RadioEvent.TRANSMISSION_FINISHED;

--- a/java/org/contikios/cooja/interfaces/Button.java
+++ b/java/org/contikios/cooja/interfaces/Button.java
@@ -59,13 +59,13 @@ public abstract class Button extends MoteInterface {
   public Button(Mote mote) {
     sim = mote.getSimulation();
 
-    pressButtonEvent = new MoteTimeEvent(mote, 0) {
+    pressButtonEvent = new MoteTimeEvent(mote) {
       @Override
       public void execute(long t) {
         doPressButton();
       }
     };
-    releaseButtonEvent = new MoteTimeEvent(mote, 0) {
+    releaseButtonEvent = new MoteTimeEvent(mote) {
       @Override
       public void execute(long t) {
         doReleaseButton();

--- a/java/org/contikios/cooja/motes/DisturberMoteType.java
+++ b/java/org/contikios/cooja/motes/DisturberMoteType.java
@@ -116,7 +116,7 @@ public class DisturberMoteType extends AbstractApplicationMoteType {
     }
     public void sentPacket(RadioPacket p) {
       /* Send another packet after a small pause */
-      getSimulation().scheduleEvent(new MoteTimeEvent(this, 0) {
+      getSimulation().scheduleEvent(new MoteTimeEvent(this) {
         public void execute(long t) {
           /*logger.info("Sending another radio packet on channel: " + radio.getChannel());*/
           radio.startTransmittingPacket(radioPacket, DURATION);

--- a/java/org/contikios/cooja/plugins/BufferListener.java
+++ b/java/org/contikios/cooja/plugins/BufferListener.java
@@ -217,7 +217,7 @@ public class BufferListener extends VisPlugin {
   private ArrayList<Mote> motes = new ArrayList<Mote>();
   private ArrayList<SegmentMemoryMonitor> memoryMonitors = new ArrayList<SegmentMemoryMonitor>();
 
-  private TimeEvent hourTimeEvent = new TimeEvent(0) {
+  private TimeEvent hourTimeEvent = new TimeEvent() {
     @Override
     public void execute(long t) {
       hasHours = true;

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -366,7 +366,7 @@ public class LogScriptEngine {
     }
   }
 
-  private TimeEvent timeoutEvent = new TimeEvent(0) {
+  private final TimeEvent timeoutEvent = new TimeEvent() {
     public void execute(long t) {
       if (!scriptActive) {
         return;
@@ -377,7 +377,7 @@ public class LogScriptEngine {
       stepScript();
     }
   };
-  private TimeEvent timeoutProgressEvent = new TimeEvent(0) {
+  private final TimeEvent timeoutProgressEvent = new TimeEvent() {
     public void execute(long t) {
       nextProgress = t + timeout/20;
       simulation.scheduleEvent(this, nextProgress);
@@ -468,7 +468,7 @@ public class LogScriptEngine {
 
     public void generateMessage(final long delay, final String msg) {
       final Mote currentMote = (Mote) engine.get("mote");
-      final TimeEvent generateEvent = new TimeEvent(0) {
+      final TimeEvent generateEvent = new TimeEvent() {
         public void execute(long t) {
           if (scriptThread == null ||
               !scriptThread.isAlive()) {

--- a/java/org/contikios/cooja/plugins/skins/TrafficVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/TrafficVisualizerSkin.java
@@ -88,7 +88,7 @@ public class TrafficVisualizerSkin implements VisualizerSkin {
     }
   };
 
-  private final TimeEvent ageArrowsTimeEvent = new TimeEvent(0) {
+  private final TimeEvent ageArrowsTimeEvent = new TimeEvent() {
     @Override
     public void execute(long t) {
       if (!active) {

--- a/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
+++ b/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
@@ -273,7 +273,7 @@ public abstract class AbstractRadioMedium extends RadioMedium {
 						} else {
 							/* EXPERIMENTAL: Simulating propagation delay */
 							final Radio delayedRadio = r;
-							TimeEvent delayedEvent = new TimeEvent(0) {
+							TimeEvent delayedEvent = new TimeEvent() {
 								public void execute(long t) {
 									delayedRadio.signalReceptionStart();
 								}
@@ -309,7 +309,7 @@ public abstract class AbstractRadioMedium extends RadioMedium {
 							
 							/* EXPERIMENTAL: Simulating propagation delay */
 							final Radio delayedRadio = dstRadio;
-							TimeEvent delayedEvent = new TimeEvent(0) {
+							TimeEvent delayedEvent = new TimeEvent() {
 								public void execute(long t) {
 									delayedRadio.signalReceptionEnd();
 								}
@@ -364,7 +364,7 @@ public abstract class AbstractRadioMedium extends RadioMedium {
 							/* EXPERIMENTAL: Simulating propagation delay */
 							final CustomDataRadio delayedRadio = (CustomDataRadio) dstRadio;
 							final Object delayedData = data;
-							TimeEvent delayedEvent = new TimeEvent(0) {
+							TimeEvent delayedEvent = new TimeEvent() {
 								public void execute(long t) {
 									delayedRadio.receiveCustomData(delayedData);
 								}
@@ -410,7 +410,7 @@ public abstract class AbstractRadioMedium extends RadioMedium {
 							/* EXPERIMENTAL: Simulating propagation delay */
 							final Radio delayedRadio = dstRadio;
 							final RadioPacket delayedPacket = packet;
-							TimeEvent delayedEvent = new TimeEvent(0) {
+							TimeEvent delayedEvent = new TimeEvent() {
 								public void execute(long t) {
 									delayedRadio.setReceivedPacket(delayedPacket);
 								}


### PR DESCRIPTION
Implement EventQueue using java.util.PriorityQueue. There are three main benefits to this:
1. Improved performance for large networks (4x to 5x speed ups observed on large networks with 225 nodes). Performance for networks with a smaller number of nodes (49) remains similar to previous implementation.
2. Simulations run with the same seed will have the same output as the previous implementation.
3. TimeEvent no longer manages when it is next scheduled, preventing that time from being changed without it being updated in the EventQueue.