### PR TITLE
add visual edit  for bitrate on Radio interface

### DIFF
--- a/java/org/contikios/cooja/MoteInterface.java
+++ b/java/org/contikios/cooja/MoteInterface.java
@@ -35,6 +35,7 @@ import java.util.Observable;
 import javax.swing.JPanel;
 import org.apache.log4j.Logger;
 import org.jdom.Element;
+import java.lang.Double;
 
 import org.contikios.cooja.interfaces.PolledAfterActiveTicks;
 import org.contikios.cooja.interfaces.PolledAfterAllTicks;
@@ -139,7 +140,67 @@ public abstract class MoteInterface extends Observable {
    */
   public abstract void setConfigXML(Collection<Element> configXML,
       boolean visAvailable);
-  
+
+  public static
+  String getXMLText(final Collection<Element> configXML, final String name) {
+	    for (Element element : configXML) {
+            if (element.getName().equals(name)) {
+                return element.getText();
+            }
+	    }
+        return null;
+  }
+
+  public static
+  boolean assignXMLValue(Collection<Element> configXML
+		  			, final String name, final String value) 
+  {
+	    for (Element element : configXML) {
+            if (element.getName().equals(name)) {
+                element.setText(value);
+                return true;
+            }
+	    }
+        return false;
+  }
+
+  public static
+  double getXMLDouble(final Collection<Element> configXML, final String name) {
+	    for (Element element : configXML) {
+            if (element.getName().equals(name)) {
+                return Double.parseDouble(element.getText());
+            }
+	    }
+        return Double.NaN;
+  }
+
+  public static
+  boolean assignXMLValue(Collection<Element> configXML
+		  			, final String name, final double value) 
+  {
+	    for (Element element : configXML) {
+            if (element.getName().equals(name)) {
+                element.setText("" + value);
+                return true;
+            }
+	    }
+        return false;
+  }
+
+
+  public static
+  void setXMLValue(Collection<Element> configXML
+		  			, final String name, final double value) 
+  {
+	    if ( assignXMLValue(configXML, name, value) )
+	    	return;
+
+	    Element element;
+        element = new Element(name);
+        element.setText("" + value);
+        configXML.add(element);
+  }
+
   /**
    * Called to free resources used by the mote interface.
    * This method is called when the mote is removed from the simulation.

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiRadio.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiRadio.java
@@ -355,8 +355,12 @@ public class ContikiRadio extends Radio implements ContikiMoteInterface, PolledA
 
       /* Calculate transmission duration (us) */
       /* XXX Currently floored due to millisecond scheduling! */
+      if (RADIO_TRANSMISSION_RATE_kbps > 0.0) {
       long duration = (int) (Simulation.MILLISECOND*((8 * size /*bits*/) / RADIO_TRANSMISSION_RATE_kbps));
       transmissionEndTime = now + Math.max(1, duration);
+      }
+      else
+    	  transmissionEndTime = now+1;
 
       lastEventTime = now;
       lastEvent = RadioEvent.TRANSMISSION_STARTED;
@@ -386,17 +390,21 @@ public class ContikiRadio extends Radio implements ContikiMoteInterface, PolledA
            element.setText("" + RADIO_TRANSMISSION_RATE_kbps);
            config.add(element);
 
+   		   //logger.info("contikiRadio: take XML:"+getMote().getID());
            return config;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML,
-                 boolean visAvailable) {
+                 boolean visAvailable) 
+  {
          for (Element element : configXML) {
                  if (element.getName().equals("bitrate")) {
                          RADIO_TRANSMISSION_RATE_kbps = Double.parseDouble(element.getText());
                          logger.info("Radio bitrate reconfigured to (kbps): " + RADIO_TRANSMISSION_RATE_kbps);
                  }
          }
+         super.setConfigXML(configXML, visAvailable);
   }
 
   public Mote getMote() {
@@ -406,4 +414,5 @@ public class ContikiRadio extends Radio implements ContikiMoteInterface, PolledA
   public String toString() {
     return "Radio at " + mote;
   }
+
 }


### PR DESCRIPTION
Radio interface now provide visual edit of global configuration for bitrate, powerup/dn_time

* new visual elements are depends on configXML elements - if config of Radio interface
  provides elements with name : "bitrate", "powerup_time", "powerdn_time",
  editor for double value this settings are provided.

* assignment for that configXML elements is global - updates all motes interfaces Radio.