### PR TITLE
project load tolerant vs uncnown interfaces

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMote.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMote.java
@@ -202,8 +202,11 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
             simulation.getCooja().tryLoadClass(this, MoteInterface.class, intfClass);
 
         if (moteInterfaceClass == null) {
-          logger.fatal("Could not load mote interface class: " + intfClass);
-          return false;
+          logger.fatal("Could not load mote"+ getID() +" interface class: " + intfClass);
+          continue;
+          //TODO new CCOJA revisions may have not investigated interfaces
+          //     ignore this miss, to allow load later projects
+          //return false;
         }
 
         MoteInterface moteInterface = myInterfaceHandler.getInterfaceOfType(moteInterfaceClass);


### PR DESCRIPTION
now cooja continue load project, skiping interfaces that are uncknown.

* former behaviour aborts projects with uncknown interfaces, therefore produced
 by new cooja revisions may not load.