### PR TITLE
TimeLine zoomSlider fix

### DIFF
--- a/java/org/contikios/cooja/plugins/TimeLine.java
+++ b/java/org/contikios/cooja/plugins/TimeLine.java
@@ -589,16 +589,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
   private Action zoomInAction = new AbstractAction("Zoom in (Ctrl+)") {
     private static final long serialVersionUID = -2592452356547803615L;
     public void actionPerformed(ActionEvent e) {
-      Rectangle r = timeline.getVisibleRect();
-      int pixelX = r.x + r.width/2;
-      if (popupLocation != null) {
-        pixelX = popupLocation.x;
-        popupLocation = null;
-      }
-      if (mousePixelPositionX > 0) {
-        pixelX = mousePixelPositionX;
-      }
-      final long centerTime = (long) (pixelX*currentPixelDivisor);
+      final long centerTime = getCenterPointTime(); 
       zoomIn(centerTime, 0.5);
     }
   };
@@ -606,16 +597,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
   private Action zoomOutAction = new AbstractAction("Zoom out (Ctrl-)") {
     private static final long serialVersionUID = 6837091379835151725L;
     public void actionPerformed(ActionEvent e) {
-      Rectangle r = timeline.getVisibleRect();
-      int pixelX = r.x + r.width/2;
-      if (popupLocation != null) {
-        pixelX = popupLocation.x;
-        popupLocation = null;
-      }
-      if (mousePixelPositionX > 0) {
-        pixelX = mousePixelPositionX;
-      }
-      final long centerTime = (long) (pixelX*currentPixelDivisor);
+      final long centerTime = getCenterPointTime(); 
       zoomOut(centerTime, 0.5);
     }
   };
@@ -623,13 +605,14 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
   private Action zoomSliderAction = new AbstractAction("Zoom slider (Ctrl+Mouse)") {
     private static final long serialVersionUID = -4288046377707363837L;
     public void actionPerformed(ActionEvent e) {
+
       final int zoomLevel = zoomGetLevel();
       final JSlider zoomSlider = new JSlider(JSlider.VERTICAL, 0, ZOOM_LEVELS.length-1, zoomLevel);
       zoomSlider.setInverted(true);
       zoomSlider.setPaintTicks(true);
       zoomSlider.setPaintLabels(false);
 
-      final long centerTime = (long) (popupLocation.x*currentPixelDivisor);
+      final long centerTime = getCenterPointTime(); 
 
       zoomSlider.addChangeListener(new ChangeListener() {
         public void stateChanged(ChangeEvent e) {
@@ -644,6 +627,20 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       zoomSlider.requestFocus();
     }
   };
+
+  private
+  long getCenterPointTime() {
+      Rectangle r = timeline.getVisibleRect();
+      int pixelX = r.x + r.width/2;
+      if (popupLocation != null) {
+        pixelX = popupLocation.x;
+        popupLocation = null;
+      }
+      if (mousePixelPositionX > 0) {
+        pixelX = mousePixelPositionX;
+      }
+      return (long) (pixelX*currentPixelDivisor);
+  }
 
   /**
    * Save logged raw data to file for post-processing.


### PR DESCRIPTION
TimeLine zoomSlider was missed in patch vs popupLocation=null, therefore it was break with exception, with looong list in console log.