### PR TITLE
Fix NullPointerException in Notes using default Look and Feel

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1248,7 +1248,7 @@ public class Cooja extends Observable {
           UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
         }
       } else {
-        UIManager.setLookAndFeel("com.sun.java.swing.plaf.nimbus.NimbusLookAndFeel");
+        UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
       }
       return;
     } catch (Exception e) {

--- a/java/org/contikios/cooja/plugins/Notes.java
+++ b/java/org/contikios/cooja/plugins/Notes.java
@@ -119,10 +119,14 @@ public class Notes extends VisPlugin {
     }
     BasicInternalFrameUI ui = (BasicInternalFrameUI) Notes.this.getUI();
 
+    try {
     if (visible) {
       ui.getNorthPane().setPreferredSize(null);
     } else {
       ui.getNorthPane().setPreferredSize(new Dimension(0,0));
+    }
+    } catch (NullPointerException e) {
+      // This catches an error where the defined look and feel makes north pane null.
     }
 
     Notes.this.revalidate();


### PR DESCRIPTION
When running on current Java versions, a null pointer exception occurs when opening a project because the default theme does not define the north pane, which is used in the Notes plugin.

This pull request addresses this issue in two ways: 
1) Add a try catch block in the Notes plugin to catch this exception.
2) Use `javax` nimbus look and feel instead of `com.sun.java`, which more JVMs should be able to locate.