### PR TITLE
provide simControl break mote thread action

### DIFF
--- a/config/corecomm_template.java
+++ b/config/corecomm_template.java
@@ -52,6 +52,7 @@ public class [CLASSNAME] extends CoreComm {
 
   public native void tick();
   public native void init();
+  public native void kill();
   public native void setReferenceAddress(int addr);
   public native void getMemory(int rel_addr, int length, byte[] mem);
   public native void setMemory(int rel_addr, int length, byte[] mem);

--- a/config/test_template.c
+++ b/config/test_template.c
@@ -48,6 +48,7 @@ int arr1[10];
 int arr2[10];
 int uvar1;
 int uvar2;
+int uvar3;
 
 JNIEXPORT void JNICALL
 Java_org_contikios_cooja_corecomm_[CLASS_NAME]_init(JNIEnv *env, jobject obj)
@@ -83,6 +84,11 @@ Java_org_contikios_cooja_corecomm_[CLASS_NAME]_tick(JNIEnv *env, jobject obj)
 {
   ++var1;
   ++uvar1;
+}
+JNIEXPORT void JNICALL
+Java_org_contikios_cooja_corecomm_[CLASS_NAME]_kill(JNIEnv *env, jobject obj)
+{
+  ++uvar3;
 }
 /*---------------------------------------------------------------------------*/
 JNIEXPORT void JNICALL

--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -334,6 +334,8 @@ public abstract class CoreComm {
    */
   public abstract void tick();
 
+  public abstract void kill();
+
   /**
    * Initializes a mote by running a startup script in the core. (Should only be
    * run once, at the same time as the library is loaded)

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -70,9 +70,10 @@ public class Simulation extends Observable implements Runnable {
   /* Used to restrict simulation speed */
   private long speedLimitLastSimtime;
   private long speedLimitLastRealtime;
-
+  
   private long lastStartTime;
   private long currentSimulationTime = 0;
+  private TimeEvent currentSimulationEvent = null;
 
   private String title = null;
 
@@ -276,9 +277,11 @@ public class Simulation extends Observable implements Runnable {
         if (nextEvent.time < currentSimulationTime) {
           throw new RuntimeException("Next event is in the past: " + nextEvent.time + " < " + currentSimulationTime + ": " + nextEvent);
         }
+        currentSimulationEvent= nextEvent;
         currentSimulationTime = nextEvent.time;
         /*logger.info("Executing event #" + EVENT_COUNTER++ + " @ " + currentSimulationTime + ": " + nextEvent);*/
         nextEvent.execute(currentSimulationTime);
+        currentSimulationEvent       = null;
 
         if (stopSimulation) {
           isRunning = false;
@@ -375,6 +378,12 @@ public class Simulation extends Observable implements Runnable {
    */
   public void stopSimulation() {
     stopSimulation(true);
+  }
+
+  public void breakSimulation() {
+      stopSimulation(true);
+      if (currentSimulationEvent != null)
+          currentSimulationEvent.kill();
   }
 
   /**

--- a/java/org/contikios/cooja/TimeEvent.java
+++ b/java/org/contikios/cooja/TimeEvent.java
@@ -68,6 +68,9 @@ public abstract class TimeEvent {
 
   public abstract void execute(long t);
 
+  //kills event execution - signal to execution thread  
+  public void kill() {};
+
   public String getShort() {
     return "" + time + (name != null ? ": " + name : "");
   }

--- a/java/org/contikios/cooja/contikimote/ContikiMote.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMote.java
@@ -43,6 +43,12 @@ import org.contikios.cooja.mote.memory.SectionMoteMemory;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.mote.memory.MemoryInterface;
 import org.contikios.cooja.motes.AbstractWakeupMote;
+import org.contikios.cooja.util.StringUtils;
+import java.lang.Throwable;
+import java.lang.Exception;
+import java.lang.Error;
+import java.lang.RuntimeException;
+
 
 /**
  * A Contiki mote executes an actual Contiki system via
@@ -65,6 +71,8 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
   private ContikiMoteType myType = null;
   private SectionMoteMemory myMemory = null;
   private MoteInterfaceHandler myInterfaceHandler = null;
+  public enum MoteState{ STATE_OK, STATE_HANG};
+  public MoteState execute_state = MoteState.STATE_OK;
 
   /**
    * Creates a new mote of given type.
@@ -113,6 +121,7 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
 
   public void setType(MoteType type) {
     myType = (ContikiMoteType) type;
+    execute_state = MoteState.STATE_OK;
   }
 
   /**
@@ -127,6 +136,8 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
    */
   @Override
   public void execute(long simTime) {
+    if (execute_state != MoteState.STATE_OK)
+        return;
 
     /* Poll mote interfaces */
     myInterfaceHandler.doActiveActionsBeforeTick();
@@ -142,7 +153,36 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
     myType.setCoreMemory(myMemory);
 
     /* Handle a single Contiki events */
+    try {
     myType.tick();
+    } 
+    catch (RuntimeException e) {
+        execute_state = MoteState.STATE_HANG;
+        //coffeecatch_throw_exception rises Error
+        String dump = StringUtils.dumpStackTrace(e);
+        logger.fatal( "mote" + getID() 
+                      + "crashed with:" + e.toString()
+                      + dump 
+                    );
+    }
+    catch (Exception e) {
+        execute_state = MoteState.STATE_HANG;
+        //coffeecatch_throw_exception rises Error
+        String dump = StringUtils.dumpStackTrace(e);
+        logger.fatal( "mote" + getID() 
+                      + "crashed with:" + e.toString()
+                      + dump 
+                    );
+    }
+    catch (Error e) {
+        execute_state = MoteState.STATE_HANG;
+        //coffeecatch_throw_exception rises Error
+        String dump = StringUtils.dumpStackTrace(e);
+        logger.fatal( "mote" + getID() 
+                      + "crashed with:" + e.toString()
+                      + dump 
+                    );
+    }
 
     /* Copy mote memory from Contiki */
     myType.getCoreMemory(myMemory);
@@ -151,6 +191,13 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
     myMemory.pollForMemoryChanges();
     myInterfaceHandler.doActiveActionsAfterTick();
     myInterfaceHandler.doPassiveActionsAfterTick();
+
+    if (execute_state != MoteState.STATE_OK) {
+        simulation.stopSimulation();
+        logger.warn( "stop simulation by hang of mote"+getID() );
+        // do not remove mote, just make it hung 
+        //simulation.removeMote(this);
+    }
   }
 
   /**
@@ -202,8 +249,11 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
             simulation.getCooja().tryLoadClass(this, MoteInterface.class, intfClass);
 
         if (moteInterfaceClass == null) {
-          logger.fatal("Could not load mote interface class: " + intfClass);
-          return false;
+          logger.fatal("Could not load mote"+ getID() +" interface class: " + intfClass);
+          continue;
+          //TODO new CCOJA revisions may have not investigated interfaces
+          //     ignore this miss, to allow load later projects
+          //return false;
         }
 
         MoteInterface moteInterface = myInterfaceHandler.getInterfaceOfType(moteInterfaceClass);

--- a/java/org/contikios/cooja/contikimote/ContikiMote.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMote.java
@@ -71,7 +71,7 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
   private ContikiMoteType myType = null;
   private SectionMoteMemory myMemory = null;
   private MoteInterfaceHandler myInterfaceHandler = null;
-  public enum MoteState{ STATE_OK, STATE_HANG};
+  public enum MoteState{ STATE_OK, STATE_EXEC, STATE_HANG};
   public MoteState execute_state = MoteState.STATE_OK;
 
   /**
@@ -154,7 +154,9 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
 
     /* Handle a single Contiki events */
     try {
-    myType.tick();
+        execute_state = MoteState.STATE_EXEC;
+        myType.tick();
+        execute_state = MoteState.STATE_OK;
     } 
     catch (RuntimeException e) {
         execute_state = MoteState.STATE_HANG;
@@ -198,6 +200,17 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
         // do not remove mote, just make it hung 
         //simulation.removeMote(this);
     }
+  }
+
+  /**
+   * try abort mote executing thread
+   * */
+  @Override
+  public void kill() {
+      if (execute_state == MoteState.STATE_EXEC) {
+          logger.warn( "killing mote"+getID() );
+          myType.kill();
+      }
   }
 
   /**

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -800,6 +800,13 @@ public class ContikiMoteType implements MoteType {
   }
 
   /**
+   * try abort mote executing thread
+   * */
+  public void kill() {
+      myCoreComm.kill();
+  }
+
+  /**
    * Creates and returns a copy of this mote type's initial memory (just after
    * the init function has been run). When a new mote is created it should get
    * it's memory from here.

--- a/java/org/contikios/cooja/motes/AbstractWakeupMote.java
+++ b/java/org/contikios/cooja/motes/AbstractWakeupMote.java
@@ -46,6 +46,10 @@ public abstract class AbstractWakeupMote implements Mote {
     public void execute(long t) {
       AbstractWakeupMote.this.execute(t);
     }
+    @Override
+    public void kill() {
+        AbstractWakeupMote.this.kill();
+    }
     public String toString() {
       return "EXECUTE " + this.getClass().getName();
     }
@@ -67,6 +71,11 @@ public abstract class AbstractWakeupMote implements Mote {
    * @param time Simulation time.
    */
   public abstract void execute(long time);
+
+  /**
+   * try abort mote executing thread
+   * */
+  public void kill() {}
 
   /**
    * Execute mote software as soon as possible.

--- a/java/org/contikios/cooja/plugins/SimControl.java
+++ b/java/org/contikios/cooja/plugins/SimControl.java
@@ -161,6 +161,7 @@ public class SimControl extends VisPlugin implements HasQuickHelp {
     smallPanel.add(startButton = new JButton(startAction));
     smallPanel.add(stopButton = new JButton(stopAction));
     smallPanel.add(new JButton(stepAction));
+    smallPanel.add(new JButton(breakAction));
     smallPanel.add(new JButton(reloadAction));
 
     smallPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -321,6 +322,12 @@ public class SimControl extends VisPlugin implements HasQuickHelp {
       simulation.stepMillisecondSimulation();
     }
   };
+  private Action breakAction = new AbstractAction("Break") {
+      public void actionPerformed(ActionEvent e) {
+        simulation.breakSimulation();
+        stopButton.requestFocus();
+      }
+    };
   private Action reloadAction = new AbstractAction("Reload") {
     public void actionPerformed(ActionEvent e) {
       simulation.getCooja().reloadCurrentSimulation(simulation.isRunning());
@@ -334,6 +341,7 @@ public class SimControl extends VisPlugin implements HasQuickHelp {
         "<p><i>Pause</i> stops the simulation. " +
         "<p>The keyboard shortcut for starting and pausing the simulation is <i>Ctrl+S</i>. " +
         "<p><i>Step</i> runs the simulation for one millisecond. " +
+        "<p><i>Break</i> signal kill to simulaton thread of current mote. " +
         "<p><i>Reload</i> reloads and restarts the simulation. " +
         "<p>Simulation speed is controlled via the Speed limit menu.";
   }

--- a/java/org/contikios/cooja/util/StringUtils.java
+++ b/java/org/contikios/cooja/util/StringUtils.java
@@ -32,8 +32,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.lang.Throwable;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.URL;
 import java.util.zip.GZIPInputStream;
 
@@ -214,5 +216,14 @@ public class StringUtils {
     } catch (Exception ex) {
       return false;
     }
+  }
+
+  public static
+  String dumpStackTrace(Throwable ex) {
+      StringWriter writer = new StringWriter();
+      PrintWriter printWriter = new PrintWriter( writer );
+      ex.printStackTrace( printWriter );
+      printWriter.flush();
+      return writer.toString();
   }
 }


### PR DESCRIPTION
SimControl break button - perform breakSimulation. It is can be invoked if mote hungs, and not return control to sim.

this patch rely on  [contink-ng PR#1225](https://github.com/contiki-ng/contiki-ng/pull/1225) coffeecatch exception hooks. With coffee pressing Break button breaks hunged mote, and reports callstack where mote is.
