### PR TITLE
double-click at MoteOutput and RadioLogger - now selects time 

### DIFF
--- a/java/org/contikios/cooja/interfaces/TimeSelect.java
+++ b/java/org/contikios/cooja/interfaces/TimeSelect.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2008, Swedish Institute of Computer Science.
+ * Copyright (c) 2020,  alexrayne <alexraynepe196@gmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+/**
+ * @author alexrayne <alexraynepe196@gmail.com>
+ */
+
+package org.contikios.cooja.interfaces;
+
+import org.contikios.cooja.*;
+
+@ClassDescription("Timeline selectable plugin")
+public interface TimeSelect {
+
+    // action on select time request
+    public void trySelectTime(final long toTime);
+
+    default
+    public void performTimePlugins( Simulation sim, Long time ) {
+        performTimePluginsExcept(sim, time, this);
+    }
+
+    default
+    public <N extends Plugin & TimeSelect> 
+    void performTimePlugins( Simulation sim, Long time, Class<N> pluginClass) 
+    {
+        performTimePluginsExcept(sim, time, this, pluginClass);
+    }
+
+    static
+    public void performTimePluginsExcept( Simulation sim, Long time, TimeSelect exception ) 
+    {
+        Plugin[] plugins = sim.getCooja().getStartedPlugins();
+        for (Plugin p: plugins) {
+          if (p == exception)
+              continue;
+          if (!(p instanceof TimeSelect)) {
+            continue;
+          }
+
+          /* Select simulation time */
+          TimeSelect plugin = (TimeSelect) p;
+          plugin.trySelectTime(time);
+        }
+    }
+
+    static
+    public <N extends Plugin & TimeSelect> 
+    void performTimePluginsExcept( Simulation sim, Long time, TimeSelect exception
+              , Class<N> pluginClass
+              ) 
+    {
+        Plugin[] plugins = sim.getCooja().getStartedPlugins();
+        for (Plugin p: plugins) {
+          if (p == exception)
+              continue;
+          if (!(pluginClass.isInstance(p))) {
+            continue;
+          }
+
+          /* Select simulation time */
+          TimeSelect plugin = (TimeSelect) p;
+          plugin.trySelectTime(time);
+        }
+    }
+}

--- a/java/org/contikios/cooja/plugins/BufferListener.java
+++ b/java/org/contikios/cooja/plugins/BufferListener.java
@@ -98,6 +98,7 @@ import org.contikios.cooja.VisPlugin;
 import org.contikios.cooja.dialogs.TableColumnAdjuster;
 import org.contikios.cooja.dialogs.UpdateAggregator;
 import org.contikios.cooja.interfaces.IPAddress;
+import org.contikios.cooja.interfaces.TimeSelect;
 import org.contikios.cooja.mote.memory.MemoryBuffer;
 import org.contikios.cooja.mote.memory.MemoryInterface;
 import org.contikios.cooja.mote.memory.MemoryInterface.SegmentMonitor;
@@ -112,7 +113,9 @@ import org.contikios.cooja.util.StringUtils;
  */
 @ClassDescription("Buffer view")
 @PluginType(PluginType.SIM_PLUGIN)
-public class BufferListener extends VisPlugin {
+public class BufferListener extends VisPlugin
+    implements TimeSelect
+{
   private static final long serialVersionUID = 1L;
   private static Logger logger = Logger.getLogger(BufferListener.class);
 
@@ -1163,23 +1166,7 @@ public class BufferListener extends VisPlugin {
     private static final long serialVersionUID = -6358463434933029699L;
     @Override
     public void actionPerformed(ActionEvent e) {
-      int view = logTable.getSelectedRow();
-      if (view < 0) {
-        return;
-      }
-      int model = logTable.convertRowIndexToModel(view);
-      long time = logs.get(model).time;
-
-      Plugin[] plugins = simulation.getCooja().getStartedPlugins();
-      for (Plugin p: plugins) {
-        if (!(p instanceof BufferListener)) {
-          continue;
-        }
-
-        /* Select simulation time */
-        BufferListener plugin = (BufferListener) p;
-        plugin.trySelectTime(time);
-      }
+      focusTimePlugins(BufferListener.class);
     }
   };
 
@@ -1187,23 +1174,7 @@ public class BufferListener extends VisPlugin {
     private static final long serialVersionUID = -6358463434933029699L;
     @Override
     public void actionPerformed(ActionEvent e) {
-      int view = logTable.getSelectedRow();
-      if (view < 0) {
-        return;
-      }
-      int model = logTable.convertRowIndexToModel(view);
-      long time = logs.get(model).time;
-
-      Plugin[] plugins = simulation.getCooja().getStartedPlugins();
-      for (Plugin p: plugins) {
-        if (!(p instanceof TimeLine)) {
-          continue;
-        }
-
-        /* Select simulation time */
-        TimeLine plugin = (TimeLine) p;
-        plugin.trySelectTime(time);
-      }
+      focusTimePlugins(TimeLine.class);
     }
   };
 
@@ -1211,25 +1182,20 @@ public class BufferListener extends VisPlugin {
     private static final long serialVersionUID = -3041714249257346688L;
     @Override
     public void actionPerformed(ActionEvent e) {
+        focusTimePlugins(RadioLogger.class);
+    }
+  };
+
+  private <N extends Plugin & TimeSelect>
+  void focusTimePlugins(Class<N> pluginClass) {
       int view = logTable.getSelectedRow();
       if (view < 0) {
         return;
       }
       int model = logTable.convertRowIndexToModel(view);
       long time = logs.get(model).time;
-
-      Plugin[] plugins = simulation.getCooja().getStartedPlugins();
-      for (Plugin p: plugins) {
-        if (!(p instanceof RadioLogger)) {
-          continue;
-        }
-
-        /* Select simulation time */
-        RadioLogger plugin = (RadioLogger) p;
-        plugin.trySelectTime(time);
-      }
-    }
-  };
+      performTimePlugins(simulation, time, pluginClass);
+  }
 
   private Action showInAllAction = new AbstractAction("All") {
     private static final long serialVersionUID = -8433490108577001803L;
@@ -1239,8 +1205,13 @@ public class BufferListener extends VisPlugin {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-      timeLineAction.actionPerformed(null);
-      radioLoggerAction.actionPerformed(null);
+        int view = logTable.getSelectedRow();
+        if (view < 0) {
+          return;
+        }
+        int model = logTable.convertRowIndexToModel(view);
+        long time = logs.get(model).time;
+        performTimePlugins(simulation, time);
     }
   };
 

--- a/java/org/contikios/cooja/plugins/TimeLine.java
+++ b/java/org/contikios/cooja/plugins/TimeLine.java
@@ -96,6 +96,7 @@ import org.contikios.cooja.WatchpointMote.WatchpointListener;
 import org.contikios.cooja.interfaces.LED;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.interfaces.Radio.RadioEvent;
+import org.contikios.cooja.interfaces.TimeSelect;
 import org.contikios.cooja.motes.AbstractEmulatedMote;
 
 /**
@@ -105,7 +106,8 @@ import org.contikios.cooja.motes.AbstractEmulatedMote;
  */
 @ClassDescription("Timeline")
 @PluginType(PluginType.SIM_STANDARD_PLUGIN)
-public class TimeLine extends VisPlugin implements HasQuickHelp {
+public class TimeLine extends VisPlugin implements HasQuickHelp, TimeSelect 
+{
   private static final long serialVersionUID = -883154261246961973L;
   public static final int LED_PIXEL_HEIGHT = 2;
   public static final int EVENT_PIXEL_HEIGHT = 4;
@@ -913,6 +915,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     return output.toString();
   }
 
+  // TimeSelect
   public void trySelectTime(final long toTime) {
     java.awt.EventQueue.invokeLater(new Runnable() {
       public void run() {
@@ -934,52 +937,11 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     });
   }
 
-  private Action radioLoggerAction = new AbstractAction("Show in " + Cooja.getDescriptionOf(RadioLogger.class)) {
-    private static final long serialVersionUID = 7690116136861949864L;
-    public void actionPerformed(ActionEvent e) {
-      if (popupLocation == null) {
-        return;
-      }
-      long time = (long) (popupLocation.x*currentPixelDivisor);
-
-      Plugin[] plugins = simulation.getCooja().getStartedPlugins();
-      for (Plugin p: plugins) {
-      	if (!(p instanceof RadioLogger)) {
-      		continue;
-      	}
-
-        /* Select simulation time */
-      	RadioLogger plugin = (RadioLogger) p;
-        plugin.trySelectTime(time);
-      }
-    }
-  };
-  private Action logListenerAction = new AbstractAction("Show in " + Cooja.getDescriptionOf(LogListener.class)) {
-    private static final long serialVersionUID = -8626118368774023257L;
-    public void actionPerformed(ActionEvent e) {
-      if (popupLocation == null) {
-        return;
-      }
-      long time = (long) (popupLocation.x*currentPixelDivisor);
-
-      Plugin[] plugins = simulation.getCooja().getStartedPlugins();
-      for (Plugin p: plugins) {
-      	if (!(p instanceof LogListener)) {
-      		continue;
-      	}
-
-        /* Select simulation time */
-        LogListener plugin = (LogListener) p;
-        plugin.trySelectTime(time);
-      }
-    }
-  };
-
-  private Action showInAllAction = new AbstractAction("Show in " + Cooja.getDescriptionOf(LogListener.class) + " and " + Cooja.getDescriptionOf(RadioLogger.class)) {
+  private Action showInAllAction = new AbstractAction("Show in TimeSelect-ables ") {
     private static final long serialVersionUID = -2458733078524773995L;
     public void actionPerformed(ActionEvent e) {
-      logListenerAction.actionPerformed(null);
-      radioLoggerAction.actionPerformed(null);
+      long time = (long) (popupLocation.x*currentPixelDivisor);
+      performTimePlugins(simulation, time);
     }
   };
 
@@ -1407,8 +1369,6 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       final JPopupMenu popupMenu = new JPopupMenu();
 
       popupMenu.add(new JMenuItem(showInAllAction));
-      popupMenu.add(new JMenuItem(logListenerAction));
-      popupMenu.add(new JMenuItem(radioLoggerAction));
 
       JMenu advancedMenu = new JMenu("Advanced");
       advancedMenu.add(new JCheckBoxMenuItem(executionDetailsAction) {
@@ -1430,21 +1390,6 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
           if (System.currentTimeMillis() - lastClick < 250) {
             popupLocation = e.getPoint();
             showInAllAction.actionPerformed(null);
-
-            long time = (long) (popupLocation.x*currentPixelDivisor);
-            Plugin[] plugins = simulation.getCooja().getStartedPlugins();
-            for (Plugin p: plugins) {
-            	if (!(p instanceof TimeLine)) {
-            		continue;
-            	}
-            	if (p == TimeLine.this) {
-            		continue;
-            	}
-              /* Select simulation time */
-            	TimeLine plugin = (TimeLine) p;
-              plugin.trySelectTime(time);
-            }
-
           }
           lastClick = System.currentTimeMillis();
         }


### PR DESCRIPTION
on double-click at MoteOutput, and RadioLogger implements syncronise focus over all timed plugins 

deployed TimeSelect interface for plugins. And plugins are refactored on this interface.

* TimeSelect interface provide common ability to focus at time for plugins.
+ Also it provide performTimePlugins(sim, time ...) action, to focus plugins in simulation at desired time.