### PR TITLE
Direct Core access memory type provided, for speedup singe mote execution

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -927,6 +927,16 @@ public class Simulation extends Observable implements Runnable {
     return motes.size();
   }
 
+  public int getMotesCount(MoteType x) {
+    int cnt = 0;
+    for (Mote m: getMotes()) {
+        if (m.getType() == x) {
+          ++cnt;
+        }
+      }
+    return cnt;
+  }
+
   /**
    * Returns all motes in this simulation.
    *

--- a/java/org/contikios/cooja/contikimote/ContikiMote.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMote.java
@@ -75,11 +75,8 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
    * @param sim Mote's simulation
    */
   public ContikiMote(ContikiMoteType moteType, Simulation sim) {
-    setSimulation(sim);
     this.myType = moteType;
-    this.myMemory = moteType.createInitialMemory();
-    this.myInterfaceHandler = new MoteInterfaceHandler(this, moteType.getMoteInterfaceClasses());
-
+    initSimulation(sim);
     requestImmediateWakeup();
   }
 
@@ -178,12 +175,21 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
 
     return config;
   }
+  
+  protected final 
+  void initSimulation(Simulation sim) {
+      setSimulation(sim);
+      if ( sim.getMotesCount(myType) > 1 )
+          this.myMemory = myType.createInitialMemory();
+      else
+          this.myMemory = myType.createSingleMemory();
+          //this.myMemory = moteType.createInitialMemory();
+      this.myInterfaceHandler = new MoteInterfaceHandler(this, myType.getMoteInterfaceClasses());
+  }
 
   @Override
   public boolean setConfigXML(Simulation simulation, Collection<Element> configXML, boolean visAvailable) {
-    setSimulation(simulation);
-    myMemory = myType.createInitialMemory();
-    myInterfaceHandler = new MoteInterfaceHandler(this, myType.getMoteInterfaceClasses());
+    initSimulation(simulation);
 
     for (Element element: configXML) {
       String name = element.getName();

--- a/java/org/contikios/cooja/mote/memory/DirectCoreMemory.java
+++ b/java/org/contikios/cooja/mote/memory/DirectCoreMemory.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2021, alexrayne
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+package org.contikios.cooja.mote.memory;
+
+import java.util.Arrays;
+import java.util.Map;
+import org.contikios.cooja.CoreComm;
+
+/**
+ * A memory that is backed by an array.
+ *
+ * @author Enrico Joerns
+ */
+public class DirectCoreMemory implements MemoryInterface {
+
+  private final long startAddress;
+  private final long offset;
+  private final int  memory_size;
+  //private final byte wrthrogh[];
+  private final MemoryLayout layout;
+  private final boolean readonly;
+  private final Map<String, Symbol> symbols;// XXX Allow to set symbols
+  private final CoreComm myCore;
+  
+  public static final boolean READONLY = true;
+  public static final boolean WRITABLE = false;
+  
+  public DirectCoreMemory(CoreComm comm, long offset, long address, int size, MemoryLayout layout, Map<String, Symbol> symbols) {
+    this(comm, offset, address, size, layout, WRITABLE, symbols);
+  }
+
+  public DirectCoreMemory(CoreComm comm, long offset, long address, int size, MemoryLayout layout, boolean readonly, Map<String, Symbol> symbols) {
+    this.myCore	= comm;
+    this.startAddress = address;
+    this.offset = offset;
+    this.layout = layout;
+    this.memory_size = size;
+    this.readonly = readonly;
+    this.symbols = symbols;
+  }
+
+  @Override
+  public byte[] getMemory() {
+    throw new UnsupportedOperationException("Not supported yet.");
+  }
+
+  final public 
+  boolean in_mem(long adr, long len) {
+     return (adr >= startAddress) && ((adr + len ) <= (startAddress + memory_size) );
+  }
+
+  /**
+   * XXX Should addr be the relative or the absolute address of this section?
+   * @param addr
+   * @param size
+   * @return
+   * @throws org.contikios.cooja.mote.memory.MemoryInterface.MoteMemoryException 
+   */
+  @Override
+  public byte[] getMemorySegment(long addr, int size) throws MoteMemoryException {
+    if(!in_mem(addr, size)) {
+        throw new MoteMemoryException("get out of memory");
+    }
+    
+    byte[] ret = new byte[size];
+    myCore.getMemory( (int)(addr-offset), size, ret);
+    return ret;
+  }
+
+  @Override
+  public void setMemorySegment(long addr, byte[] data) throws MoteMemoryException {
+    if (readonly) {
+      throw new MoteMemoryException("Invalid write access for readonly memory");
+    }
+    
+    if(!in_mem(addr, data.length)) {
+        throw new MoteMemoryException("set out of memory");
+    }
+    
+    myCore.setMemory((int)(addr-offset), data.length, data);
+  }
+
+  @Override
+  public void clearMemory() {
+    byte[] zero = new byte[memory_size];
+    Arrays.fill(zero, (byte)0);
+    myCore.setMemory((int)(startAddress), memory_size, zero);
+  }
+
+  @Override
+  public long getStartAddr() {
+    return startAddress;
+  }
+
+  @Override
+  public int getTotalSize() {
+    return memory_size;
+  }
+
+  @Override
+  public Map<String, Symbol> getSymbolMap() {
+    return symbols;
+  }
+
+  @Override
+  public MemoryLayout getLayout() {
+    return layout;
+  }
+
+  @Override
+  public boolean addSegmentMonitor(SegmentMonitor.EventType flag, long address, int size, SegmentMonitor monitor) {
+    throw new UnsupportedOperationException("Not supported yet.");
+  }
+
+  @Override
+  public boolean removeSegmentMonitor(long address, int size, SegmentMonitor monitor) {
+    throw new UnsupportedOperationException("Not supported yet.");
+  }
+  
+}

--- a/java/org/contikios/cooja/mote/memory/SectionMoteMemory.java
+++ b/java/org/contikios/cooja/mote/memory/SectionMoteMemory.java
@@ -68,7 +68,7 @@ public class SectionMoteMemory implements MemoryInterface {
    * Adds a section to this memory.
    * 
    * A new section will be checked for address overlap with existing sections.
-   *
+   * 
    * @param name
    * @param section
    * @return true if adding succeeded, false otherwise
@@ -288,11 +288,38 @@ public class SectionMoteMemory implements MemoryInterface {
     for (String secname : sections.keySet()) {
       // Copy section memory to new ArrayMemory
       MemoryInterface section = sections.get(secname);
-      MemoryInterface cpmem = new ArrayMemory(section.getStartAddr(), section.getLayout(), section.getMemory().clone(), section.getSymbolMap());
+      MemoryInterface cpmem = cloneSection(section);
       clone.addMemorySection(secname, cpmem);
     }
 
     return clone;
+  }
+  
+  protected MemoryInterface cloneSection( MemoryInterface section ) {
+    byte[] mem = null;
+    
+    try {
+      mem = section.getMemory().clone();
+    }
+    catch (Exception e) {
+        mem = null;
+    }
+    
+    if (mem != null) {
+        return new ArrayMemory(section.getStartAddr(), section.getLayout()
+                              , mem, section.getSymbolMap()
+                              );
+    }
+    else {
+          long start = section.getStartAddr();
+          int  size  = section.getTotalSize();
+          MemoryInterface y = new ArrayMemory(start, size
+                                             , section.getLayout(), section.getSymbolMap()
+                                             );
+          if (section.getTotalSize() > 0) 
+              y.setMemorySegment(start, section.getMemorySegment(start, size) );
+          return y;
+    }
   }
 
   private ArrayList<PolledMemorySegments> polledMemories = new ArrayList<PolledMemorySegments>();


### PR DESCRIPTION
There provided mote execution speedup via using direct mote's corelib-memory access.

* For ordinary corelib memory access done via clone-per-mote instances of original coer-lib. Before tick mote, whole memory of clone copyes into corelib-memory, and after tick it copies back. All operations with memory contents goes with that cloned memory per each mote.
* If simulation have only single mote instance for moteType, no need save contents of corelib memory, we can use it directly.
* Here provided DirecCoreMemory interface that pass this direc-access.  This interface used by mote, when it is single in simulation.

* Results of profling in simulation of 2 different motes:
   - ordinar mote memory interface - saving copy, most time of simulation ( > 60%) spent on save/restore corelib contents. Tick execution time is negligible, even 4log spends far less time then this copy. save to coerlib - most expensive operation, and can take about 25-35% CPU. 
   - direct interface spent less (<20%) time on memory access. And it still can be optimised. save to corelib takes less 9%. Most time of simulation takes 4log (> 35-40% ). time of execution now can be seen on it's new scale - it takes about few 1-2%

* TODO: now need to look for ways to scale this techniks on multiple mote instances. Simplest aproach i see - just make individual corelib for each mote.

*  there no need further DirectAccess optimisations, until 4log cpu wastes are solved. 
 