### PR TITLE
Use jlong for addresses

### DIFF
--- a/config/corecomm_template.java
+++ b/config/corecomm_template.java
@@ -52,7 +52,7 @@ public class [CLASSNAME] extends CoreComm {
 
   public native void tick();
   public native void init();
-  public native void setReferenceAddress(int addr);
-  public native void getMemory(int rel_addr, int length, byte[] mem);
-  public native void setMemory(int rel_addr, int length, byte[] mem);
+  public native void setReferenceAddress(long addr);
+  public native void getMemory(long rel_addr, int length, byte[] mem);
+  public native void setMemory(long rel_addr, int length, byte[] mem);
 }

--- a/config/test_template.c
+++ b/config/test_template.c
@@ -38,7 +38,7 @@
 
 const struct simInterface *simInterfaces[] = {NULL};
 
-long referenceVar; /* Placed somewhere in the BSS section */
+intptr_t referenceVar; /* Placed somewhere in the BSS section */
 
 /* Variables with known memory addresses */
 int var1=1;
@@ -55,24 +55,24 @@ Java_org_contikios_cooja_corecomm_[CLASS_NAME]_init(JNIEnv *env, jobject obj)
  }
 /*---------------------------------------------------------------------------*/
 JNIEXPORT void JNICALL
-Java_org_contikios_cooja_corecomm_[CLASS_NAME]_getMemory(JNIEnv *env, jobject obj, jint rel_addr, jint length, jbyteArray mem_arr)
+Java_org_contikios_cooja_corecomm_[CLASS_NAME]_getMemory(JNIEnv *env, jobject obj, jlong rel_addr, jint length, jbyteArray mem_arr)
 {
   (*env)->SetByteArrayRegion(
       env,
       mem_arr,
       0,
       (size_t) length,
-      (jbyte *) (((long)rel_addr) + referenceVar)
+      (jbyte *) (((intptr_t)rel_addr) + referenceVar)
   );
 
 }
 /*---------------------------------------------------------------------------*/
 JNIEXPORT void JNICALL
-Java_org_contikios_cooja_corecomm_[CLASS_NAME]_setMemory(JNIEnv *env, jobject obj, jint rel_addr, jint length, jbyteArray mem_arr)
+Java_org_contikios_cooja_corecomm_[CLASS_NAME]_setMemory(JNIEnv *env, jobject obj, jlong rel_addr, jint length, jbyteArray mem_arr)
 {
   jbyte *mem = (*env)->GetByteArrayElements(env, mem_arr, 0);
   memcpy(
-      (char*) (((long)rel_addr) + referenceVar),
+      (char*) (((intptr_t)rel_addr) + referenceVar),
       mem,
       length);
   (*env)->ReleaseByteArrayElements(env, mem_arr, mem, 0);
@@ -86,7 +86,7 @@ Java_org_contikios_cooja_corecomm_[CLASS_NAME]_tick(JNIEnv *env, jobject obj)
 }
 /*---------------------------------------------------------------------------*/
 JNIEXPORT void JNICALL
-Java_org_contikios_cooja_corecomm_[CLASS_NAME]_setReferenceAddress(JNIEnv *env, jobject obj, jint addr)
+Java_org_contikios_cooja_corecomm_[CLASS_NAME]_setReferenceAddress(JNIEnv *env, jobject obj, jlong addr)
 {
-  referenceVar = (((long)&referenceVar) - ((long)addr));
+  referenceVar = (((intptr_t)&referenceVar) - ((intptr_t)addr));
 }

--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -346,7 +346,7 @@ public abstract class CoreComm {
    *
    * @param addr Relative address
    */
-  public abstract void setReferenceAddress(int addr);
+  public abstract void setReferenceAddress(long addr);
 
   /**
    * Fills an byte array with memory segment identified by start and length.
@@ -355,7 +355,7 @@ public abstract class CoreComm {
    * @param length Length of segment
    * @param mem Array to fill with memory segment
    */
-  public abstract void getMemory(int relAddr, int length, byte[] mem);
+  public abstract void getMemory(long relAddr, int length, byte[] mem);
 
   /**
    * Overwrites a memory segment identified by start and length.
@@ -364,6 +364,6 @@ public abstract class CoreComm {
    * @param length Length of segment
    * @param mem New memory segment data
    */
-  public abstract void setMemory(int relAddr, int length, byte[] mem);
+  public abstract void setMemory(long relAddr, int length, byte[] mem);
 
 }

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -488,7 +488,7 @@ public class ContikiMoteType implements MoteType {
       tmp.addMemorySection("tmp.common", commonSecParser.parse(0));
 
       try {
-        int referenceVar = (int) varMem.getVariable("referenceVar").addr;
+        long referenceVar = varMem.getVariable("referenceVar").addr;
         myCoreComm.setReferenceAddress(referenceVar);
       } catch (UnknownVariableException e) {
         throw new MoteTypeCreationException("Error setting reference variable: " + e.getMessage(), e);
@@ -525,7 +525,7 @@ public class ContikiMoteType implements MoteType {
   public static abstract class SectionParser {
 
     private final String[] mapFileData;
-    protected int startAddr;
+    protected long startAddr;
     protected int size;
     protected Map<String, Symbol> variables;
 
@@ -537,7 +537,7 @@ public class ContikiMoteType implements MoteType {
       return mapFileData;
     }
 
-    public int getStartAddr() {
+    public long getStartAddr() {
       return startAddr;
     }
 
@@ -555,14 +555,14 @@ public class ContikiMoteType implements MoteType {
 
     abstract Map<String, Symbol> parseSymbols(long offset);
 
-    protected int parseFirstHexInt(String regexp, String[] data) {
+    protected long parseFirstHexLong(String regexp, String[] data) {
       String retString = getFirstMatchGroup(data, regexp, 1);
 
       if (retString == null || retString.equals("")) {
         return -1;
       }
 
-      return Integer.parseInt(retString.trim(), 16);
+      return Long.parseLong(retString.trim(), 16);
     }
 
     public MemoryInterface parse(long offset) {
@@ -620,7 +620,7 @@ public class ContikiMoteType implements MoteType {
         startAddr = -1;
         return;
       }
-      startAddr = parseFirstHexInt(startRegExp, getData());
+      startAddr = parseFirstHexLong(startRegExp, getData());
     }
 
     @Override
@@ -629,7 +629,7 @@ public class ContikiMoteType implements MoteType {
         size = -1;
         return;
       }
-      size = parseFirstHexInt(sizeRegExp, getData());
+      size = (int) parseFirstHexLong(sizeRegExp, getData());
     }
 
     @Override
@@ -641,8 +641,8 @@ public class ContikiMoteType implements MoteType {
       for (String line : getData()) {
         Matcher matcher = pattern.matcher(line);
         if (matcher.find()) {
-          if (Integer.decode(matcher.group(1)).intValue() >= getStartAddr()
-                  && Integer.decode(matcher.group(1)).intValue() <= getStartAddr() + getSize()) {
+          if (Long.decode(matcher.group(1)).longValue() >= getStartAddr() &&
+              Long.decode(matcher.group(1)).longValue() <= getStartAddr() + getSize()) {
             String varName = matcher.group(2);
             varNames.put(varName, new Symbol(
                     Symbol.Type.VARIABLE,
@@ -661,7 +661,7 @@ public class ContikiMoteType implements MoteType {
      * @param varName Name of variable
      * @return Relative memory address of variable or -1 if not found
      */
-    private int getMapFileVarAddress(String[] mapFileData, String varName) {
+    private long getMapFileVarAddress(String[] mapFileData, String varName) {
 
       String regExp = Cooja.getExternalToolsSetting("MAPFILE_VAR_ADDRESS_1")
               + varName
@@ -669,7 +669,7 @@ public class ContikiMoteType implements MoteType {
       String retString = getFirstMatchGroup(mapFileData, regExp, 1);
 
       if (retString != null) {
-        return Integer.parseInt(retString.trim(), 16);
+        return Long.parseLong(retString.trim(), 16);
       } else {
         return -1;
       }
@@ -730,7 +730,7 @@ public class ContikiMoteType implements MoteType {
         startAddr = -1;
         return;
       }
-      startAddr = parseFirstHexInt(startRegExp, getData());
+      startAddr = parseFirstHexLong(startRegExp, getData());
     }
 
     @Override
@@ -745,12 +745,12 @@ public class ContikiMoteType implements MoteType {
         return;
       }
 
-      int end = parseFirstHexInt(endRegExp, getData());
+      long end = parseFirstHexLong(endRegExp, getData());
       if (end < 0) {
         size = -1;
         return;
       }
-      size = end - getStartAddr();
+      size = (int) (end - getStartAddr());
     }
 
     @Override
@@ -780,7 +780,7 @@ public class ContikiMoteType implements MoteType {
 	    logger.debug("Put symbol " + symbol + " with address " + varAddr + " and size " + varSize);
             addresses.put(symbol, new Symbol(Symbol.Type.VARIABLE, symbol, varAddr, varSize));
           } else {
-            int oldAddress = (int) addresses.get(symbol).addr;
+            long oldAddress = addresses.get(symbol).addr;
             if (oldAddress != varAddr) {
               /*logger.warn("Warning, command response not matching previous entry of: "
                + varName);*/
@@ -822,13 +822,13 @@ public class ContikiMoteType implements MoteType {
   public void getCoreMemory(SectionMoteMemory mem) {
     for (MemoryInterface section : mem.getSections().values()) {
       getCoreMemory(
-              (int) (section.getStartAddr() - offset),
+              section.getStartAddr() - offset,
               section.getTotalSize(),
               section.getMemory());
     }
   }
 
-  private void getCoreMemory(int relAddr, int length, byte[] data) {
+  private void getCoreMemory(long relAddr, int length, byte[] data) {
     myCoreComm.getMemory(relAddr, length, data);
   }
 
@@ -842,13 +842,13 @@ public class ContikiMoteType implements MoteType {
   public void setCoreMemory(SectionMoteMemory mem) {
     for (MemoryInterface section : mem.getSections().values()) {
       setCoreMemory(
-              (int) (section.getStartAddr() - offset),
+              section.getStartAddr() - offset,
               section.getTotalSize(),
               section.getMemory());
     }
   }
 
-  private void setCoreMemory(int relAddr, int length, byte[] mem) {
+  private void setCoreMemory(long relAddr, int length, byte[] mem) {
     myCoreComm.setMemory(relAddr, length, mem);
   }
 

--- a/java/org/contikios/cooja/dialogs/ConfigurationWizard.java
+++ b/java/org/contikios/cooja/dialogs/ConfigurationWizard.java
@@ -146,9 +146,9 @@ public class ConfigurationWizard extends JDialog {
   private static String javaLibraryName;
   private static CoreComm javaLibrary;
   private static Map<String, Symbol> addresses;
-  private static int relDataSectionAddr;
+  private static long relDataSectionAddr;
   private static int dataSectionSize;
-  private static int relBssSectionAddr;
+  private static long relBssSectionAddr;
   private static int bssSectionSize;
 
   private static MessageListUI output;
@@ -785,16 +785,16 @@ public class ConfigurationWizard extends JDialog {
     dataSectionSize = dataSecParser.getSize();
     relBssSectionAddr = bssSecParser.getStartAddr();
     bssSectionSize = bssSecParser.getSize();
-    testOutput.addMessage("Data section address: 0x" + Integer.toHexString(relDataSectionAddr));
+    testOutput.addMessage("Data section address: 0x" + Long.toHexString(relDataSectionAddr));
     testOutput.addMessage("Data section size: 0x" + Integer.toHexString(dataSectionSize));
-    testOutput.addMessage("BSS section address: 0x" + Integer.toHexString(relBssSectionAddr));
+    testOutput.addMessage("BSS section address: 0x" + Long.toHexString(relBssSectionAddr));
     testOutput.addMessage("BSS section size: 0x" + Integer.toHexString(bssSectionSize));
     if (relDataSectionAddr < 0) {
-      testOutput.addMessage("Data section address < 0: 0x" + Integer.toHexString(relDataSectionAddr), MessageList.ERROR);
+      testOutput.addMessage("Data section address < 0: 0x" + Long.toHexString(relDataSectionAddr), MessageList.ERROR);
       return false;
     }
     if (relBssSectionAddr < 0) {
-      testOutput.addMessage("BSS section address < 0: 0x" + Integer.toHexString(relBssSectionAddr), MessageList.ERROR);
+      testOutput.addMessage("BSS section address < 0: 0x" + Long.toHexString(relBssSectionAddr), MessageList.ERROR);
       return false;
     }
     if (dataSectionSize <= 0) {
@@ -886,16 +886,16 @@ public class ConfigurationWizard extends JDialog {
     if (parserAddresses != null) {
         addresses.putAll(parserAddresses);
     }
-    testOutput.addMessage("Data section address: 0x" + Integer.toHexString(relDataSectionAddr));
+    testOutput.addMessage("Data section address: 0x" + Long.toHexString(relDataSectionAddr));
     testOutput.addMessage("Data section size: 0x" + Integer.toHexString(dataSectionSize));
-    testOutput.addMessage("BSS section address: 0x" + Integer.toHexString(relBssSectionAddr));
+    testOutput.addMessage("BSS section address: 0x" + Long.toHexString(relBssSectionAddr));
     testOutput.addMessage("BSS section size: 0x" + Integer.toHexString(bssSectionSize));
     if (relDataSectionAddr < 0) {
-      testOutput.addMessage("Data section address < 0: 0x" + Integer.toHexString(relDataSectionAddr), MessageList.ERROR);
+      testOutput.addMessage("Data section address < 0: 0x" + Long.toHexString(relDataSectionAddr), MessageList.ERROR);
       return false;
     }
     if (relBssSectionAddr < 0) {
-      testOutput.addMessage("BSS section address < 0: 0x" + Integer.toHexString(relBssSectionAddr), MessageList.ERROR);
+      testOutput.addMessage("BSS section address < 0: 0x" + Long.toHexString(relBssSectionAddr), MessageList.ERROR);
       return false;
     }
     if (dataSectionSize <= 0) {


### PR DESCRIPTION
A Java long is 64 bits so use that
instead of Java int for addresses.

This patch requires an update of
the address parameters in the Cooja platform.c
in Contiki-NG.