### PR TITLE
Do not crash on compilation failure

### DIFF
--- a/apps/mspsim/src/org/contikios/cooja/mspmote/AbstractMspMoteType.java
+++ b/apps/mspsim/src/org/contikios/cooja/mspmote/AbstractMspMoteType.java
@@ -141,18 +141,14 @@ public abstract class AbstractMspMoteType extends MspMoteType {
                             true
                             );
                 } catch (Exception e) {
-                    MoteTypeCreationException newException =
-                            new MoteTypeCreationException("Mote type creation failed: " + e.getMessage(), e);
-                    newException.setCompilationOutput(compilationOutput);
-
                     /* Print last 10 compilation errors to console */
                     MessageContainer[] messages = compilationOutput.getMessages();
                     for (int i = Math.max(messages.length - 10, 0); i < messages.length; i++) {
                         logger.fatal(">> " + messages[i]);
                     }
 
-                    logger.fatal("Compilation error: " + e.getMessage());
-                    throw newException;
+                    logger.fatal("Compilation error: " + compilationOutput);
+                    return false;
                 }
             }
         }

--- a/apps/mspsim/src/org/contikios/cooja/mspmote/SkyMoteType.java
+++ b/apps/mspsim/src/org/contikios/cooja/mspmote/SkyMoteType.java
@@ -157,11 +157,6 @@ public class SkyMoteType extends MspMoteType {
               true
           );
         } catch (Exception e) {
-          MoteTypeCreationException newException =
-            new MoteTypeCreationException("Mote type creation failed: " + e.getMessage());
-          newException = (MoteTypeCreationException) newException.initCause(e);
-          newException.setCompilationOutput(compilationOutput);
-
           /* Print last 10 compilation errors to console */
           MessageContainer[] messages = compilationOutput.getMessages();
           for (int i=messages.length-10; i < messages.length; i++) {
@@ -171,8 +166,8 @@ public class SkyMoteType extends MspMoteType {
             logger.fatal(">> " + messages[i]);
           }
 
-          logger.fatal("Compilation error: " + e.getMessage());
-          throw newException;
+          logger.fatal("Compilation error: " + compilationOutput);
+          return false;
         }
       }
     }

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -703,7 +703,7 @@ public class Simulation extends Observable implements Runnable {
         } else {
           logger
               .fatal("Mote type was not created: " + element.getText().trim());
-          throw new Exception("All mote types were not recreated");
+          return false;
         }
       }
 


### PR DESCRIPTION
The Contiki-NG regression tests makes Cooja
crash with a backtrace when Contiki-NG cannot
be compiled.

The user does not benefit from a stack trace of
Cooja in those scenarios so return an error instead
of crashing. The Contiki-NG regression tests still
fail, but with a reasonable error message.