### PR TITLE
Read offset as address variable

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -498,7 +498,7 @@ public class ContikiMoteType implements MoteType {
 
       getCoreMemory(tmp);
 
-      offset = varMem.getIntValueOf("referenceVar") & 0xFFFFFFFFL;
+      offset = varMem.getAddrValueOf("referenceVar");
       logger.debug(getContikiFirmwareFile().getName()
               + ": offsetting Cooja mote address space: 0x" + Long.toHexString(offset));
     }


### PR DESCRIPTION
The offset variable looks like it corresponds to a ptrdiff_t in C, so read it as an address instead of an int. The commit message that introduced the masking doesn't explain why, but I don't think that will improve the situation.