### PR TITLE
build.xml: remove unused java_version target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -223,12 +223,6 @@ The COOJA Simulator
     </exec>
   </target>
 
-  <target name="java_version" depends="init">
-    <exec executable="javac" dir="${build}" includeantruntime="false">
-      <arg value="-version"/>
-    </exec>
-  </target>
-
   <target name="jar_cooja" depends="init, compile, copy configs">
     <mkdir dir="${dist}"/>
     <jar destfile="${dist}/cooja.jar" basedir="${build}">


### PR DESCRIPTION
This target is not used anywhere in Contiki-NG
or Cooja so remove it. If the target should
exist, it should echo ${ant.java.version}
instead of starting the compiler.