### PR TITLE
Make Cooja output less verbose

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1321,7 +1321,6 @@ public class Cooja extends Observable {
   }
 
   public static Simulation quickStartSimulationConfig(File config, boolean vis, Long manualRandomSeed) {
-    logger.info("> Starting Cooja");
     JDesktopPane desktop = createDesktopPane();
     if (vis) {
       frame = new JFrame(WINDOW_TITLE);
@@ -1356,7 +1355,6 @@ public class Cooja extends Observable {
    * @return True if simulation was created
    */
   private static Simulation quickStartSimulation(String source) {
-    logger.info("> Starting Cooja");
     JDesktopPane desktop = createDesktopPane();
     frame = new JFrame(WINDOW_TITLE);
     Cooja gui = new Cooja(desktop);

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -259,7 +259,7 @@ public class Simulation extends Observable implements Runnable {
 
   public void run() {
     lastStartTime = System.currentTimeMillis();
-    logger.info("Simulation main loop started, system time: " + lastStartTime);
+    logger.info("Simulation started, system time: " + lastStartTime);
     isRunning = true;
     speedLimitLastRealtime = System.currentTimeMillis();
     speedLimitLastSimtime = getSimulationTime();
@@ -318,7 +318,7 @@ public class Simulation extends Observable implements Runnable {
 
     this.setChanged();
     this.notifyObservers(this);
-    logger.info("Simulation main loop stopped, system time: " + System.currentTimeMillis() +
+    logger.info("Simulation completed, system time: " + System.currentTimeMillis() +
         "\tDuration: " + (System.currentTimeMillis() - lastStartTime) +
                 " ms" +
                 "\tSimulated time " + getSimulationTimeMillis() +

--- a/java/org/contikios/cooja/dialogs/MessageListText.java
+++ b/java/org/contikios/cooja/dialogs/MessageListText.java
@@ -9,7 +9,7 @@ public class MessageListText implements MessageList {
     
     @Override
     public void addMessage(String string, int type) {
-        System.out.println("Message:" + string);
+        System.out.println(string);
     }
 
     @Override

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -296,7 +296,6 @@ public class LogScriptEngine {
     };
     scriptThread = new Thread(group, new Runnable() {
       public void run() {
-        /*logger.info("test script thread starts");*/
         try {
           ((Invocable)engine).getInterface(Runnable.class).run();
         } catch (RuntimeException e) {
@@ -307,7 +306,7 @@ public class LogScriptEngine {
 
           if (throwable.getMessage() != null &&
               throwable.getMessage().contains("test script killed") ) {
-            logger.info("Test script finished");
+            logger.debug("Test script finished");
           } else {
             if (!Cooja.isVisualized()) {
               logger.fatal("Test script error, terminating Cooja.");
@@ -324,7 +323,6 @@ public class LogScriptEngine {
             }
           }
         }
-        /*logger.info("test script thread exits");*/
       }
     });
     scriptThread.start(); /* Starts by acquiring semaphore (blocks) */

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -385,7 +385,7 @@ public class ScriptRunner extends VisPlugin {
           updateTitle();
         }
 
-        logger.info("Test script activated");
+        logger.debug("Test script activated");
 
       } catch (ScriptException e) {
         logger.fatal("Test script error: ", e);
@@ -428,7 +428,7 @@ public class ScriptRunner extends VisPlugin {
         codeEditor.setEnabled(true);
         updateTitle();
       }
-      logger.info("Test script deactivated");
+      logger.debug("Test script deactivated");
     }
   }
 


### PR DESCRIPTION
Remove the "Starting Cooja" message and
the "Message:" prefix on compilation output.
Put script status updates at debug level
since they are mainly for debugging Cooja
itself, the start/stop simulation messages
that immediately follow are typically more
interesting for the end user.