### PR TITLE
Add @Override annotation

### DIFF
--- a/java/org/contikios/cooja/COOJAProject.java
+++ b/java/org/contikios/cooja/COOJAProject.java
@@ -160,6 +160,7 @@ public class COOJAProject {
 		return getStringArray("org.contikios.cooja.contikimote.ContikiMoteType.C_SOURCES");
 	}
 
+	@Override
 	public String toString() {
 		if (getDescription() != null) {
 			return getDescription();

--- a/java/org/contikios/cooja/COOJARadioPacket.java
+++ b/java/org/contikios/cooja/COOJARadioPacket.java
@@ -37,6 +37,7 @@ public class COOJARadioPacket implements RadioPacket {
     this.data = data;
   }
 
+  @Override
   public byte[] getPacketData() {
     return data;
   }

--- a/java/org/contikios/cooja/ConvertedRadioPacket.java
+++ b/java/org/contikios/cooja/ConvertedRadioPacket.java
@@ -38,6 +38,7 @@ public class ConvertedRadioPacket implements RadioPacket {
     this.originalData = originalData;
   }
 
+  @Override
   public byte[] getPacketData() {
     return convertedData;
   }

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -223,6 +223,7 @@ public class Cooja extends Observable {
    * File filter only showing saved simulations files (*.csc).
    */
   public static final FileFilter SAVED_SIMULATIONS_FILES = new FileFilter() {
+    @Override
     public boolean accept(File file) {
       if (file.isDirectory()) {
         return true;
@@ -237,9 +238,11 @@ public class Cooja extends Observable {
 
       return false;
     }
+    @Override
     public String getDescription() {
       return "Cooja simulation (.csc, .csc.gz)";
     }
+    @Override
     public String toString() {
       return ".csc";
     }
@@ -389,6 +392,7 @@ public class Cooja extends Observable {
     final boolean showQuickhelp = getExternalToolsSetting("SHOW_QUICKHELP", "true").equalsIgnoreCase("true");
     if (showQuickhelp) {
       SwingUtilities.invokeLater(new Runnable() {
+        @Override
         public void run() {
           JCheckBoxMenuItem checkBox = ((JCheckBoxMenuItem)showQuickHelpAction.getValue("checkbox"));
           if (checkBox == null) {
@@ -616,7 +620,8 @@ public class Cooja extends Observable {
       }
       final File f = file;
       lastItem.addActionListener(new ActionListener() {
-  			public void actionPerformed(ActionEvent e) {
+        @Override
+        public void actionPerformed(ActionEvent e) {
   				doLoadConfigAsync(true, quick, f);
   			}
       });
@@ -628,6 +633,7 @@ public class Cooja extends Observable {
 
   private void doLoadConfigAsync(final boolean ask, final boolean quick, final File file) {
     new Thread(new Runnable() {
+      @Override
       public void run() {
         cooja.doLoadConfig(ask, quick, file, null);
       }
@@ -640,7 +646,8 @@ public class Cooja extends Observable {
     JMenu reconfigureMenu = new JMenu("Open and Reconfigure");
     JMenuItem browseItem2 = new JMenuItem("Browse...");
     browseItem2.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
+      @Override
+      public void actionPerformed(ActionEvent e) {
 				doLoadConfigAsync(true, false, null);
 			}
     });
@@ -651,7 +658,8 @@ public class Cooja extends Observable {
     /* Open menu */
     JMenuItem browseItem = new JMenuItem("Browse...");
     browseItem.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
+      @Override
+      public void actionPerformed(ActionEvent e) {
 				doLoadConfigAsync(true, true, null);
 			}
     });
@@ -725,13 +733,16 @@ public class Cooja extends Observable {
 
     /* File menu */
     fileMenu.addMenuListener(new MenuListener() {
+      @Override
       public void menuSelected(MenuEvent e) {
         updateGUIComponentState();
         updateOpenHistoryMenuItems();
       }
+      @Override
       public void menuDeselected(MenuEvent e) {
       }
 
+      @Override
       public void menuCanceled(MenuEvent e) {
       }
     });
@@ -764,11 +775,14 @@ public class Cooja extends Observable {
 
     /* Simulation menu */
     simulationMenu.addMenuListener(new MenuListener() {
+      @Override
       public void menuSelected(MenuEvent e) {
         updateGUIComponentState();
       }
+      @Override
       public void menuDeselected(MenuEvent e) {
       }
+      @Override
       public void menuCanceled(MenuEvent e) {
       }
     });
@@ -796,11 +810,14 @@ public class Cooja extends Observable {
 
     // Mote type menu
     motesMenu.addMenuListener(new MenuListener() {
+      @Override
       public void menuSelected(MenuEvent e) {
         updateGUIComponentState();
       }
+      @Override
       public void menuDeselected(MenuEvent e) {
       }
+      @Override
       public void menuCanceled(MenuEvent e) {
       }
     });
@@ -809,6 +826,7 @@ public class Cooja extends Observable {
     menuMoteTypeClasses = new JMenu("Create new mote type");
     menuMoteTypeClasses.setMnemonic(KeyEvent.VK_C);
     menuMoteTypeClasses.addMenuListener(new MenuListener() {
+      @Override
       public void menuSelected(MenuEvent e) {
         // Clear menu
         menuMoteTypeClasses.removeAll();
@@ -862,9 +880,11 @@ public class Cooja extends Observable {
         }
       }
 
+      @Override
       public void menuDeselected(MenuEvent e) {
       }
 
+      @Override
       public void menuCanceled(MenuEvent e) {
       }
     });
@@ -874,11 +894,14 @@ public class Cooja extends Observable {
 
     // Mote menu
     motesMenu.addMenuListener(new MenuListener() {
+      @Override
       public void menuSelected(MenuEvent e) {
         updateGUIComponentState();
       }
+      @Override
       public void menuDeselected(MenuEvent e) {
       }
+      @Override
       public void menuCanceled(MenuEvent e) {
       }
     });
@@ -888,6 +911,7 @@ public class Cooja extends Observable {
     menuMoteTypes = new JMenu("Add motes");
     menuMoteTypes.setMnemonic(KeyEvent.VK_A);
     menuMoteTypes.addMenuListener(new MenuListener() {
+      @Override
       public void menuSelected(MenuEvent e) {
         // Clear menu
         menuMoteTypes.removeAll();
@@ -917,9 +941,11 @@ public class Cooja extends Observable {
         menuMoteTypes.add(menuMoteTypeClasses);
       }
 
+      @Override
       public void menuDeselected(MenuEvent e) {
       }
 
+      @Override
       public void menuCanceled(MenuEvent e) {
       }
     });
@@ -937,6 +963,7 @@ public class Cooja extends Observable {
     /* Tools menu */
     toolsMenu.addMenuListener(new MenuListener() {
       private ActionListener menuItemListener = new ActionListener() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           Object pluginClass = ((JMenuItem)e.getSource()).getClientProperty("class");
           Object mote = ((JMenuItem)e.getSource()).getClientProperty("mote");
@@ -993,6 +1020,7 @@ public class Cooja extends Observable {
         return menuItem;
       }
 
+      @Override
       public void menuSelected(MenuEvent e) {
         /* Populate tools menu */
         toolsMenu.removeAll();
@@ -1050,19 +1078,24 @@ public class Cooja extends Observable {
           toolsMenu.add(createMotePluginsSubmenu(pluginClass));
         }
       }
+      @Override
       public void menuDeselected(MenuEvent e) {
       }
+      @Override
       public void menuCanceled(MenuEvent e) {
       }
     });
 
     // Settings menu
     settingsMenu.addMenuListener(new MenuListener() {
+      @Override
       public void menuSelected(MenuEvent e) {
         updateGUIComponentState();
       }
+      @Override
       public void menuDeselected(MenuEvent e) {
       }
+      @Override
       public void menuCanceled(MenuEvent e) {
       }
     });
@@ -1147,11 +1180,13 @@ public class Cooja extends Observable {
     frame.setSize(700, 700);
     frame.setLocationRelativeTo(null);
     frame.addWindowListener(new WindowAdapter() {
+      @Override
       public void windowClosing(WindowEvent e) {
         gui.doQuit(true);
       }
     });
     frame.addComponentListener(new ComponentAdapter() {
+      @Override
       public void componentResized(ComponentEvent e) {
         updateDesktopSize(gui.getDesktopPane());
       }
@@ -1197,6 +1232,7 @@ public class Cooja extends Observable {
 
     if (createSimDialog) {
       SwingUtilities.invokeLater(new Runnable() {
+        @Override
         public void run() {
           gui.doCreateSimulation(true);
         }
@@ -1218,6 +1254,7 @@ public class Cooja extends Observable {
 
     if (createSimDialog) {
       SwingUtilities.invokeLater(new Runnable() {
+        @Override
         public void run() {
           gui.doCreateSimulation(true);
         }
@@ -1291,14 +1328,17 @@ public class Cooja extends Observable {
   private static JDesktopPane createDesktopPane() {
     final JDesktopPane desktop = new JDesktopPane() {
 			private static final long serialVersionUID = -8272040875621119329L;
-			public void setBounds(int x, int y, int w, int h) {
+      @Override
+      public void setBounds(int x, int y, int w, int h) {
         super.setBounds(x, y, w, h);
         updateDesktopSize(this);
       }
+      @Override
       public void remove(Component c) {
         super.remove(c);
         updateDesktopSize(this);
       }
+      @Override
       public Component add(Component comp) {
         Component c = super.add(comp);
         updateDesktopSize(this);
@@ -1307,10 +1347,12 @@ public class Cooja extends Observable {
     };
     desktop.setDesktopManager(new DefaultDesktopManager() {
 			private static final long serialVersionUID = -5987404936292377152L;
-			public void endResizingFrame(JComponent f) {
+      @Override
+      public void endResizingFrame(JComponent f) {
         super.endResizingFrame(f);
         updateDesktopSize(desktop);
       }
+      @Override
       public void endDraggingFrame(JComponent f) {
         super.endDraggingFrame(f);
         updateDesktopSize(desktop);
@@ -1653,6 +1695,7 @@ public class Cooja extends Observable {
    */
   public void showPlugin(final Plugin plugin) {
     new RunnableInEDT<Boolean>() {
+      @Override
       public Boolean work() {
         JInternalFrame pluginFrame = plugin.getCooja();
         if (pluginFrame == null) {
@@ -1740,6 +1783,7 @@ public class Cooja extends Observable {
    */
   public void removePlugin(final Plugin plugin, final boolean askUser) {
     new RunnableInEDT<Boolean>() {
+      @Override
       public Boolean work() {
         /* Free resources */
         plugin.closePlugin();
@@ -2055,6 +2099,7 @@ public class Cooja extends Observable {
     }
 
     ActionListener menuItemListener = new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         Object pluginClass = ((JMenuItem)e.getSource()).getClientProperty("class");
         Object mote = ((JMenuItem)e.getSource()).getClientProperty("mote");
@@ -2215,6 +2260,7 @@ public class Cooja extends Observable {
 
     if (askForConfirmation) {
       boolean ok = new RunnableInEDT<Boolean>() {
+        @Override
         public Boolean work() {
           String s1 = "Remove";
           String s2 = "Cancel";
@@ -2302,6 +2348,7 @@ public class Cooja extends Observable {
     } else {
       final File suggestedFile = configFile;
       configFile = new RunnableInEDT<File>() {
+        @Override
         public File work() {
           JFileChooser fc = new JFileChooser();
 
@@ -2354,6 +2401,7 @@ public class Cooja extends Observable {
       final Thread loadThread = Thread.currentThread();
 
       progressDialog = new RunnableInEDT<JDialog>() {
+        @Override
         public JDialog work() {
           final JDialog progressDialog = new JDialog((Window) Cooja.getTopParentContainer(), progressTitle, ModalityType.APPLICATION_MODAL);
 
@@ -2369,6 +2417,7 @@ public class Cooja extends Observable {
 
           button = new JButton("Abort");
           button.addActionListener(new ActionListener() {
+            @Override
             public void actionPerformed(ActionEvent e) {
               if (loadThread.isAlive()) {
                 loadThread.interrupt();
@@ -2391,6 +2440,7 @@ public class Cooja extends Observable {
           progressDialog.setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
 
           java.awt.EventQueue.invokeLater(new Runnable() {
+            @Override
             public void run() {
               progressDialog.setVisible(true);
             }
@@ -2457,6 +2507,7 @@ public class Cooja extends Observable {
 
     final JDialog progressDialog = new JDialog(frame, "Reloading", true);
     final Thread loadThread = new Thread(new Runnable() {
+      @Override
       public void run() {
 
         /* Get current simulation configuration */
@@ -2519,6 +2570,7 @@ public class Cooja extends Observable {
 
     JButton button = new JButton("Abort");
     button.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         if (loadThread.isAlive()) {
           loadThread.interrupt();
@@ -2958,6 +3010,7 @@ public class Cooja extends Observable {
   // // GUI EVENT HANDLER ////
 
   private class GUIEventHandler implements ActionListener {
+    @Override
     public void actionPerformed(ActionEvent e) {
       if (e.getActionCommand().equals("create mote type")) {
         cooja.doCreateMoteType((Class<? extends MoteType>) ((JMenuItem) e
@@ -3349,6 +3402,7 @@ public class Cooja extends Observable {
       final String webPath = tmpWebPath, buildPath = tmpBuildPath;
       final String skyFirmware = tmpSkyFirmware, esbFirmware = tmpEsbFirmware;
       javax.swing.SwingUtilities.invokeLater(new Runnable() {
+        @Override
         public void run() {
           JDesktopPane desktop = createDesktopPane();
 
@@ -3369,6 +3423,7 @@ public class Cooja extends Observable {
 
       // Frame start-up
       javax.swing.SwingUtilities.invokeLater(new Runnable() {
+        @Override
         public void run() {
           JDesktopPane desktop = createDesktopPane();
           frame = new JFrame(WINDOW_TITLE);
@@ -3759,6 +3814,7 @@ public class Cooja extends Observable {
 
         // If plugin is visualizer plugin, parse visualization arguments
         new RunnableInEDT<Boolean>() {
+          @Override
           public Boolean work() {
             Dimension size = new Dimension(100, 100);
             Point location = new Point(100, 100);
@@ -3784,6 +3840,7 @@ public class Cooja extends Observable {
                 final JInternalFrame pluginGUI = startedPlugin.getCooja();
                 if (minimized && pluginGUI != null) {
                   SwingUtilities.invokeLater(new Runnable() {
+                    @Override
                     public void run() {
                       try {
                         pluginGUI.setIcon(true);
@@ -3873,6 +3930,7 @@ public class Cooja extends Observable {
       final String title, final Throwable exception, final boolean retryAvailable) {
 
     return new RunnableInEDT<Boolean>() {
+      @Override
       public Boolean work() {
         JTabbedPane tabbedPane = new JTabbedPane();
         final JDialog errorDialog;
@@ -3930,7 +3988,8 @@ public class Cooja extends Observable {
         if (retryAvailable) {
           Action retryAction = new AbstractAction() {
 						private static final long serialVersionUID = 2370456199250998435L;
-						public void actionPerformed(ActionEvent e) {
+            @Override
+            public void actionPerformed(ActionEvent e) {
               errorDialog.setTitle("-RETRY-");
               errorDialog.dispose();
             }
@@ -3947,7 +4006,8 @@ public class Cooja extends Observable {
 
         AbstractAction closeAction = new AbstractAction(){
 					private static final long serialVersionUID = 6225539435993362733L;
-					public void actionPerformed(ActionEvent e) {
+          @Override
+          public void actionPerformed(ActionEvent e) {
             errorDialog.dispose();
           }
         };
@@ -3981,6 +4041,7 @@ public class Cooja extends Observable {
 
   private static void showWarningsDialog(final Frame parent, final String[] warnings) {
     new RunnableInEDT<Boolean>() {
+      @Override
       public Boolean work() {
         final JDialog dialog = new JDialog(parent, "Compilation warnings", false);
         Box buttonBox = Box.createHorizontalBox();
@@ -3996,6 +4057,7 @@ public class Cooja extends Observable {
         buttonBox.add(Box.createHorizontalGlue());
         JCheckBox hideButton = new JCheckBox("Hide compilation warnings", false);
         hideButton.addActionListener(new ActionListener() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             Cooja.setExternalToolsSetting("HIDE_WARNINGS",
                 "" + ((JCheckBox)e.getSource()).isSelected());
@@ -4007,7 +4069,8 @@ public class Cooja extends Observable {
         /* Close on escape */
         AbstractAction closeAction = new AbstractAction(){
 					private static final long serialVersionUID = 2646163984382201634L;
-					public void actionPerformed(ActionEvent e) {
+          @Override
+          public void actionPerformed(ActionEvent e) {
             dialog.dispose();
           }
         };
@@ -4056,6 +4119,7 @@ public class Cooja extends Observable {
 
       try {
         java.awt.EventQueue.invokeAndWait(new Runnable() {
+          @Override
           public void run() {
             val = RunnableInEDT.this.work();
           }
@@ -4492,29 +4556,35 @@ public class Cooja extends Observable {
   }
   GUIAction newSimulationAction = new GUIAction("New simulation...", KeyEvent.VK_N, KeyStroke.getKeyStroke(KeyEvent.VK_N, ActionEvent.CTRL_MASK)) {
 		private static final long serialVersionUID = 5053703908505299911L;
-		public void actionPerformed(ActionEvent e) {
+    @Override
+    public void actionPerformed(ActionEvent e) {
       cooja.doCreateSimulation(true);
     }
+    @Override
     public boolean shouldBeEnabled() {
       return true;
     }
   };
   GUIAction closeSimulationAction = new GUIAction("Close simulation", KeyEvent.VK_C) {
 		private static final long serialVersionUID = -4783032948880161189L;
-		public void actionPerformed(ActionEvent e) {
+    @Override
+    public void actionPerformed(ActionEvent e) {
       cooja.doRemoveSimulation(true);
     }
+    @Override
     public boolean shouldBeEnabled() {
       return getSimulation() != null;
     }
   };
   GUIAction reloadSimulationAction = new GUIAction("Reload with same random seed", KeyEvent.VK_K, KeyStroke.getKeyStroke(KeyEvent.VK_R, ActionEvent.CTRL_MASK)) {
 		private static final long serialVersionUID = 66579555555421977L;
-		public void actionPerformed(ActionEvent e) {
+    @Override
+    public void actionPerformed(ActionEvent e) {
       if (getSimulation() == null) {
         /* Reload last opened simulation */
         final File file = getLastOpenedFile();
         new Thread(new Runnable() {
+          @Override
           public void run() {
             cooja.doLoadConfig(true, true, file, null);
           }
@@ -4526,28 +4596,33 @@ public class Cooja extends Observable {
       long seed = getSimulation().getRandomSeed();
       reloadCurrentSimulation(getSimulation().isRunning(), seed);
     }
+    @Override
     public boolean shouldBeEnabled() {
       return true;
     }
   };
   GUIAction reloadRandomSimulationAction = new GUIAction("Reload with new random seed", KeyEvent.VK_N, KeyStroke.getKeyStroke(KeyEvent.VK_R, ActionEvent.CTRL_MASK | ActionEvent.SHIFT_MASK)) {
 		private static final long serialVersionUID = -4494402222740250203L;
-		public void actionPerformed(ActionEvent e) {
+    @Override
+    public void actionPerformed(ActionEvent e) {
       /* Replace seed before reloading */
       if (getSimulation() != null) {
         getSimulation().setRandomSeed(getSimulation().getRandomSeed()+1);
         reloadSimulationAction.actionPerformed(null);
       }
     }
+    @Override
     public boolean shouldBeEnabled() {
       return getSimulation() != null;
     }
   };
   GUIAction saveSimulationAction = new GUIAction("Save simulation as...", KeyEvent.VK_S) {
 		private static final long serialVersionUID = 1132582220401954286L;
-		public void actionPerformed(ActionEvent e) {
+    @Override
+    public void actionPerformed(ActionEvent e) {
       cooja.doSaveConfig(true);
     }
+    @Override
     public boolean shouldBeEnabled() {
       if (isVisualizedInApplet()) {
         return false;
@@ -4569,7 +4644,8 @@ public class Cooja extends Observable {
     };*/
   GUIAction exportExecutableJARAction = new GUIAction("Export simulation...") {
 		private static final long serialVersionUID = -203601967460630049L;
-		public void actionPerformed(ActionEvent e) {
+    @Override
+    public void actionPerformed(ActionEvent e) {
       getSimulation().stopSimulation();
 
       /* Info message */
@@ -4589,6 +4665,7 @@ public class Cooja extends Observable {
       /* Select output file */
       JFileChooser fc = new JFileChooser();
       FileFilter jarFilter = new FileFilter() {
+        @Override
         public boolean accept(File file) {
           if (file.isDirectory()) {
             return true;
@@ -4598,9 +4675,11 @@ public class Cooja extends Observable {
           }
           return false;
         }
+        @Override
         public String getDescription() {
           return "Java archive";
         }
+        @Override
         public String toString() {
           return ".jar";
         }
@@ -4629,6 +4708,7 @@ public class Cooja extends Observable {
       final File finalOutputFile = outputFile;
       setExternalToolsSetting("EXECUTE_JAR_LAST", outputFile.getPath());
       new Thread() {
+        @Override
         public void run() {
           try {
             ExecuteJAR.buildExecutableJAR(Cooja.this, finalOutputFile);
@@ -4640,15 +4720,18 @@ public class Cooja extends Observable {
         }
       }.start();
     }
+    @Override
     public boolean shouldBeEnabled() {
       return getSimulation() != null;
     }
   };
   GUIAction exitCoojaAction = new GUIAction("Exit", 'x') {
 		private static final long serialVersionUID = 7523822251658687665L;
-		public void actionPerformed(ActionEvent e) {
+    @Override
+    public void actionPerformed(ActionEvent e) {
       cooja.doQuit(true);
     }
+    @Override
     public boolean shouldBeEnabled() {
       if (isVisualizedInApplet()) {
         return false;
@@ -4658,7 +4741,8 @@ public class Cooja extends Observable {
   };
   GUIAction startStopSimulationAction = new GUIAction("Start simulation", KeyStroke.getKeyStroke(KeyEvent.VK_S, ActionEvent.CTRL_MASK)) {
 		private static final long serialVersionUID = 6750107157493939710L;
-		public void actionPerformed(ActionEvent e) {
+    @Override
+    public void actionPerformed(ActionEvent e) {
       /* Start/Stop current simulation */
       Simulation s = getSimulation();
       if (s == null) {
@@ -4670,6 +4754,7 @@ public class Cooja extends Observable {
         s.startSimulation();
       }
     }
+    @Override
     public void setEnabled(boolean newValue) {
       if (getSimulation() == null) {
         putValue(NAME, "Start simulation");
@@ -4680,6 +4765,7 @@ public class Cooja extends Observable {
       }
       super.setEnabled(newValue);
     }
+    @Override
     public boolean shouldBeEnabled() {
       return getSimulation() != null && getSimulation().isRunnable();
     }
@@ -4689,8 +4775,10 @@ public class Cooja extends Observable {
                public StartPluginGUIAction(String name) {
       super(name);
     }
+    @Override
     public void actionPerformed(final ActionEvent e) {
       new Thread(new Runnable() {
+        @Override
         public void run() {
           Class<Plugin> pluginClass =
             (Class<Plugin>) ((JMenuItem) e.getSource()).getClientProperty("class");
@@ -4699,6 +4787,7 @@ public class Cooja extends Observable {
         }
       }).start();
     }
+    @Override
     public boolean shouldBeEnabled() {
       return getSimulation() != null;
     }
@@ -4706,7 +4795,8 @@ public class Cooja extends Observable {
 
   GUIAction removeAllMotesAction = new GUIAction("Remove all motes") {
 		private static final long serialVersionUID = 4709776747913364419L;
-		public void actionPerformed(ActionEvent e) {
+    @Override
+    public void actionPerformed(ActionEvent e) {
       Simulation s = getSimulation();
       if (s.isRunning()) {
         s.stopSimulation();
@@ -4716,6 +4806,7 @@ public class Cooja extends Observable {
         s.removeMote(getSimulation().getMote(0));
       }
     }
+    @Override
     public boolean shouldBeEnabled() {
       Simulation s = getSimulation();
       return s != null && s.getMotesCount() > 0;
@@ -4723,7 +4814,8 @@ public class Cooja extends Observable {
   };
   GUIAction showQuickHelpAction = new GUIAction("Quick help", KeyStroke.getKeyStroke(KeyEvent.VK_F1, 0)) {
 		private static final long serialVersionUID = 3151729036597971681L;
-		public void actionPerformed(ActionEvent e) {
+    @Override
+    public void actionPerformed(ActionEvent e) {
       if (!(e.getSource() instanceof JCheckBoxMenuItem)) {
         return;
       }
@@ -4735,12 +4827,14 @@ public class Cooja extends Observable {
       updateDesktopSize(getDesktopPane());
     }
 
+    @Override
     public boolean shouldBeEnabled() {
       return true;
     }
   };
   GUIAction showGettingStartedAction = new GUIAction("Getting started") {
     private static final long serialVersionUID = 2382848024856978524L;
+    @Override
     public void actionPerformed(ActionEvent e) {
       loadQuickHelp("GETTING_STARTED");
       JCheckBoxMenuItem checkBox = ((JCheckBoxMenuItem)showQuickHelpAction.getValue("checkbox"));
@@ -4753,13 +4847,15 @@ public class Cooja extends Observable {
       checkBox.doClick();
     }
 
+    @Override
     public boolean shouldBeEnabled() {
       return true;
     }
   };
   GUIAction showKeyboardShortcutsAction = new GUIAction("Keyboard shortcuts") {
 		private static final long serialVersionUID = 2382848024856978524L;
-		public void actionPerformed(ActionEvent e) {
+    @Override
+    public void actionPerformed(ActionEvent e) {
       loadQuickHelp("KEYBOARD_SHORTCUTS");
       JCheckBoxMenuItem checkBox = ((JCheckBoxMenuItem)showQuickHelpAction.getValue("checkbox"));
       if (checkBox == null) {
@@ -4771,18 +4867,21 @@ public class Cooja extends Observable {
       checkBox.doClick();
     }
 
+    @Override
     public boolean shouldBeEnabled() {
       return true;
     }
   };
   GUIAction showBufferSettingsAction = new GUIAction("Buffer sizes...") {
 		private static final long serialVersionUID = 7018661735211901837L;
-		public void actionPerformed(ActionEvent e) {
+    @Override
+    public void actionPerformed(ActionEvent e) {
       if (mySimulation == null) {
         return;
       }
       BufferSettings.showDialog(myDesktopPane, mySimulation);
     }
+    @Override
     public boolean shouldBeEnabled() {
       return mySimulation != null;
     }

--- a/java/org/contikios/cooja/CoojaApplet.java
+++ b/java/org/contikios/cooja/CoojaApplet.java
@@ -34,11 +34,13 @@ public class CoojaApplet extends JApplet {
 
   public static CoojaApplet applet = null;
 
+  @Override
   public void init()
   {
     applet = this;
   }
 
+  @Override
   public void start(){
     String contikiWebPath = getParameter("contiki_web");
     String contikiBuildPath = getParameter("contiki_build");
@@ -59,6 +61,7 @@ public class CoojaApplet extends JApplet {
         "-build=" + contikiBuildPath});
   }
 
+  @Override
   public void stop(){
   }
 }

--- a/java/org/contikios/cooja/EventQueue.java
+++ b/java/org/contikios/cooja/EventQueue.java
@@ -52,6 +52,7 @@ public final class EventQueue {
       this.uuid = uuid;
     }
 
+    @Override
     public final int compareTo(Pair other) {
       if (time < other.time)
       {
@@ -167,6 +168,7 @@ public final class EventQueue {
     return queue.removeIf((Pair p) -> pred.test(p.event));
   }
 
+  @Override
   public String toString() {
     return "EventQueue with " + queue.size() + " events";
   }

--- a/java/org/contikios/cooja/MoteInterfaceHandler.java
+++ b/java/org/contikios/cooja/MoteInterfaceHandler.java
@@ -373,6 +373,7 @@ public class MoteInterfaceHandler {
     polledAfterAll = null;
   }
 
+  @Override
   public String toString() {
     return "Mote interfaces handler (" + moteInterfaces.size() + " mote interfaces)";
   }

--- a/java/org/contikios/cooja/ProjectConfig.java
+++ b/java/org/contikios/cooja/ProjectConfig.java
@@ -526,6 +526,7 @@ public class ProjectConfig {
     return getBooleanValue(callingClass, id, false);
   }
 
+  @Override
   public ProjectConfig clone() {
     try {
       ProjectConfig clone = new ProjectConfig(false);

--- a/java/org/contikios/cooja/RadioConnection.java
+++ b/java/org/contikios/cooja/RadioConnection.java
@@ -229,6 +229,7 @@ public class RadioConnection {
     return onlyInterfered.toArray(new Radio[0]);
   }
 
+  @Override
   public String toString() {
     if (destinationsNonInterfered.size() == 0) {
       return id + ": Radio connection: " + source.getMote() + " -> none";

--- a/java/org/contikios/cooja/SafeRandom.java
+++ b/java/org/contikios/cooja/SafeRandom.java
@@ -83,6 +83,7 @@ public class SafeRandom extends Random {
     this.sim = sim;
   }
   
+  @Override
   synchronized public void setSeed(long seed) {
     assertSimThread();
     super.setSeed(seed);
@@ -92,6 +93,7 @@ public class SafeRandom extends Random {
    * This function is called by all functions returning random numbers
    * @see java.util.Random#next(int)
    */
+  @Override
   protected int next(int bits) {
     assertSimThread();
     return super.next(bits);

--- a/java/org/contikios/cooja/SimEventCentral.java
+++ b/java/org/contikios/cooja/SimEventCentral.java
@@ -97,6 +97,7 @@ public class SimEventCentral {
       return time;
     }
 
+    @Override
     public String toString() {
       return "" + ID;
     }
@@ -133,6 +134,7 @@ public class SimEventCentral {
   }
   private MoteCountListener[] moteCountListeners;
   private Observer moteCountObserver = new Observer() {
+    @Override
     public void update(Observable obs, Object obj) {
       if (obj == null || !(obj instanceof Mote)) {
         return;
@@ -205,6 +207,7 @@ public class SimEventCentral {
   }
   private LogOutputListener[] logOutputListeners;
   private Observer logOutputObserver = new Observer() {
+    @Override
     public void update(Observable obs, Object obj) {
       Mote mote = (Mote) obj;
       String msg = ((Log) obs).getLastLogMessage();
@@ -333,6 +336,7 @@ public class SimEventCentral {
     }
   }
 
+  @Override
   public String toString() {
     return 
     "\nActive mote observations: " + moteObservations.size() +

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -149,6 +149,7 @@ public class Simulation extends Observable implements Runnable {
     hasMillisecondObservers = true;
 
     invokeSimulationThread(new Runnable() {
+      @Override
       public void run() {
         if (!millisecondEvent.isScheduled()) {
           scheduleEvent(
@@ -205,6 +206,7 @@ public class Simulation extends Observable implements Runnable {
   }
 
   private final TimeEvent delayEvent = new TimeEvent() {
+    @Override
     public void execute(long t) {
       if (speedLimitNone) {
         /* As fast as possible: no need to reschedule delay event */
@@ -233,12 +235,14 @@ public class Simulation extends Observable implements Runnable {
         speedLimitLastSimtime = getSimulationTime();
       }
     }
+    @Override
     public String toString() {
       return "DELAY";
     }
   };
 
   private final TimeEvent millisecondEvent = new TimeEvent() {
+    @Override
     public void execute(long t) {
       if (!hasMillisecondObservers) {
         return;
@@ -247,6 +251,7 @@ public class Simulation extends Observable implements Runnable {
       millisecondObservable.newMillisecond(getSimulationTime());
       scheduleEvent(this, t+MILLISECOND);
     }
+    @Override
     public String toString() {
       return "MILLISECOND: " + millisecondObservable.countObservers();
     }
@@ -257,6 +262,7 @@ public class Simulation extends Observable implements Runnable {
     pollRequests.clear();
   }
 
+  @Override
   public void run() {
     lastStartTime = System.currentTimeMillis();
     logger.info("Simulation started, system time: " + lastStartTime);
@@ -395,6 +401,7 @@ public class Simulation extends Observable implements Runnable {
       return;
     }
     TimeEvent stopEvent = new TimeEvent() {
+      @Override
       public void execute(long t) {
         /* Stop simulation */
         stopSimulation();
@@ -777,6 +784,7 @@ public class Simulation extends Observable implements Runnable {
 
     /* Simulation is running, remove mote in simulation loop */
     Runnable removeMote = new Runnable() {
+      @Override
       public void run() {
         motes.remove(mote);
         motesUninit.remove(mote);
@@ -834,6 +842,7 @@ public class Simulation extends Observable implements Runnable {
    */
   public void addMote(final Mote mote) {
     Runnable addMote = new Runnable() {
+      @Override
       public void run() {
         if (mote.getInterfaces().getClock() != null) {
           if (maxMoteStartupDelay > 0) {
@@ -1019,6 +1028,7 @@ public class Simulation extends Observable implements Runnable {
    */
   public void setSpeedLimit(final Double newSpeedLimit) {
     Runnable r = new Runnable() {
+      @Override
       public void run() {
         if (newSpeedLimit == null) {
           speedLimitNone = true;

--- a/java/org/contikios/cooja/VisPlugin.java
+++ b/java/org/contikios/cooja/VisPlugin.java
@@ -68,9 +68,11 @@ public abstract class VisPlugin extends JInternalFrame implements Plugin {
     setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
 
     addInternalFrameListener(new InternalFrameAdapter() {
+      @Override
       public void internalFrameClosing(InternalFrameEvent e) {
         gui.removePlugin(VisPlugin.this, true);
       }
+      @Override
       public void internalFrameActivated(InternalFrameEvent e) {
         /* Highlight mote in COOJA */
         Plugin p = VisPlugin.this;
@@ -83,20 +85,25 @@ public abstract class VisPlugin extends JInternalFrame implements Plugin {
     );
   }
 
+  @Override
   public JInternalFrame getCooja() {
     return this;
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     return null;
   }
 
+  @Override
   public boolean setConfigXML(Collection<Element> configXML, boolean visAvailable) {
     return false;
   }
 
+  @Override
   public void startPlugin() {
   }
+  @Override
   public void closePlugin() {
   }
   

--- a/java/org/contikios/cooja/contikimote/ContikiProcess.java
+++ b/java/org/contikios/cooja/contikimote/ContikiProcess.java
@@ -49,6 +49,7 @@ public class ContikiProcess {
     return processName;
   }
 
+  @Override
   public String toString() {
     return processName + " (" + sourceFile.getPath() + ")";
   }

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiBeeper.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiBeeper.java
@@ -88,6 +88,7 @@ public class ContikiBeeper extends Beeper implements ContikiMoteInterface, Polle
     this.moteMem = new VarMemory(mote.getMemory());
   }
 
+  @Override
   public boolean isBeeping() {
     return moteMem.getByteValueOf("simBeeped") == 1;
   }
@@ -96,6 +97,7 @@ public class ContikiBeeper extends Beeper implements ContikiMoteInterface, Polle
     return new String[]{"beep_interface"};
   }
 
+  @Override
   public void doActionsAfterTick() {
     if (moteMem.getByteValueOf("simBeeped") == 1) {
       this.setChanged();
@@ -105,6 +107,7 @@ public class ContikiBeeper extends Beeper implements ContikiMoteInterface, Polle
     }
   }
 
+  @Override
   public JPanel getInterfaceVisualizer() {
     JPanel panel = new JPanel();
     panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
@@ -114,6 +117,7 @@ public class ContikiBeeper extends Beeper implements ContikiMoteInterface, Polle
 
     Observer observer;
     this.addObserver(observer = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         if (!isBeeping()) {
           return;
@@ -136,6 +140,7 @@ public class ContikiBeeper extends Beeper implements ContikiMoteInterface, Polle
     return panel;
   }
 
+  @Override
   public void releaseInterfaceVisualizer(JPanel panel) {
     Observer observer = (Observer) panel.getClientProperty("intf_obs");
     if (observer == null) {
@@ -146,10 +151,12 @@ public class ContikiBeeper extends Beeper implements ContikiMoteInterface, Polle
     this.deleteObserver(observer);
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     return null;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
   }
 

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiCFS.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiCFS.java
@@ -94,6 +94,7 @@ public class ContikiCFS extends MoteInterface implements ContikiMoteInterface, P
     return new String[]{"cfs_interface"};
   }
 
+  @Override
   public void doActionsAfterTick() {
     if (moteMem.getByteValueOf("simCFSChanged") == 1) {
       lastRead = moteMem.getIntValueOf("simCFSRead");
@@ -149,6 +150,7 @@ public class ContikiCFS extends MoteInterface implements ContikiMoteInterface, P
     return lastWritten;
   }
 
+  @Override
   public JPanel getInterfaceVisualizer() {
     JPanel panel = new JPanel();
     panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
@@ -163,6 +165,7 @@ public class ContikiCFS extends MoteInterface implements ContikiMoteInterface, P
     panel.add(uploadButton);
 
     uploadButton.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         byte[] fileData = readDialogFileBytes(null);
 
@@ -177,6 +180,7 @@ public class ContikiCFS extends MoteInterface implements ContikiMoteInterface, P
 
     Observer observer;
     this.addObserver(observer = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         long currentTime = mote.getSimulation().getSimulationTime();
         lastTimeLabel.setText("Last change at time: " + currentTime);
@@ -194,6 +198,7 @@ public class ContikiCFS extends MoteInterface implements ContikiMoteInterface, P
     return panel;
   }
 
+  @Override
   public void releaseInterfaceVisualizer(JPanel panel) {
     Observer observer = (Observer) panel.getClientProperty("intf_obs");
     if (observer == null) {
@@ -204,10 +209,12 @@ public class ContikiCFS extends MoteInterface implements ContikiMoteInterface, P
     this.deleteObserver(observer);
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     return null;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
   }
 

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiClock.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiClock.java
@@ -99,6 +99,7 @@ public class ContikiClock extends Clock implements ContikiMoteInterface, PolledB
     return new String[]{"clock_interface"};
   }
 
+  @Override
   public void setTime(long newTime) {
     moteTime = newTime;
     if (moteTime > 0) {
@@ -106,27 +107,33 @@ public class ContikiClock extends Clock implements ContikiMoteInterface, PolledB
     }
   }
 
+  @Override
   public void setDrift(long drift) {
     this.timeDrift = drift - (drift % 1000); /* Round to ms */
     setTime(timeDrift);
   }
 
+  @Override
   public long getDrift() {
     return timeDrift;
   }
 
+  @Override
   public long getTime() {
     return moteTime;
   }
   
+  @Override
   public void setDeviation(double deviation) {
     logger.fatal("Can't change deviation");;
   }
 
+  @Override
   public double getDeviation() {
   	return 1.0;
   }
 
+  @Override
   public void doActionsBeforeTick() {
     /* Update time */
     long currentSimulationTime = simulation.getSimulationTime();
@@ -134,6 +141,7 @@ public class ContikiClock extends Clock implements ContikiMoteInterface, PolledB
     moteMem.setInt64ValueOf("simRtimerCurrentTicks", currentSimulationTime);
   }
 
+  @Override
   public void doActionsAfterTick() {
     long currentSimulationTime = mote.getSimulation().getSimulationTime();
 
@@ -173,17 +181,21 @@ public class ContikiClock extends Clock implements ContikiMoteInterface, PolledB
   }
 
 
+  @Override
   public JPanel getInterfaceVisualizer() {
     return null;
   }
 
+  @Override
   public void releaseInterfaceVisualizer(JPanel panel) {
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     return null;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
   }
 }

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiEEPROM.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiEEPROM.java
@@ -95,6 +95,7 @@ public class ContikiEEPROM extends MoteInterface implements ContikiMoteInterface
     return new String[]{"eeprom_interface"};
   }
 
+  @Override
   public void doActionsAfterTick() {
     if (moteMem.getByteValueOf("simEEPROMChanged") == 1) {
       lastRead = moteMem.getIntValueOf("simEEPROMRead");
@@ -186,6 +187,7 @@ public class ContikiEEPROM extends MoteInterface implements ContikiMoteInterface
       textArea.setCaretPosition(0);
   }
   
+  @Override
   public JPanel getInterfaceVisualizer() {
     JPanel panel = new JPanel();
     panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
@@ -207,6 +209,7 @@ public class ContikiEEPROM extends MoteInterface implements ContikiMoteInterface
     panel.add(dataViewScrollPane);
     
     uploadButton.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         byte[] eepromData = readDialogEEPROMBytes(null);
 
@@ -222,6 +225,7 @@ public class ContikiEEPROM extends MoteInterface implements ContikiMoteInterface
     });
 
     clearButton.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         byte[] eepromData = new byte[EEPROM_SIZE];        
 
@@ -235,6 +239,7 @@ public class ContikiEEPROM extends MoteInterface implements ContikiMoteInterface
     
     Observer observer;
     this.addObserver(observer = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         long currentTime = mote.getSimulation().getSimulationTime();
         lastTimeLabel.setText("Last change at time: " + currentTime);
@@ -262,6 +267,7 @@ public class ContikiEEPROM extends MoteInterface implements ContikiMoteInterface
     return panel;
   }
 
+  @Override
   public void releaseInterfaceVisualizer(JPanel panel) {
     Observer observer = (Observer) panel.getClientProperty("intf_obs");
     if (observer == null) {
@@ -272,6 +278,7 @@ public class ContikiEEPROM extends MoteInterface implements ContikiMoteInterface
     this.deleteObserver(observer);
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
       Vector<Element> config = new Vector<Element>();
       Element element;
@@ -284,6 +291,7 @@ public class ContikiEEPROM extends MoteInterface implements ContikiMoteInterface
       return config;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
       for (Element element : configXML) {
         if (element.getName().equals("eeprom")) {

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiLED.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiLED.java
@@ -100,22 +100,27 @@ public class ContikiLED extends LED implements ContikiMoteInterface, PolledAfter
     return new String[]{"leds_interface"};
   }
 
+  @Override
   public boolean isAnyOn() {
     return currentLedValue > 0;
   }
 
+  @Override
   public boolean isGreenOn() {
     return (currentLedValue & LEDS_GREEN) > 0;
   }
 
+  @Override
   public boolean isYellowOn() {
     return (currentLedValue & LEDS_YELLOW) > 0;
   }
 
+  @Override
   public boolean isRedOn() {
     return (currentLedValue & LEDS_RED) > 0;
   }
 
+  @Override
   public void doActionsAfterTick() {
     boolean ledChanged;
 
@@ -133,8 +138,10 @@ public class ContikiLED extends LED implements ContikiMoteInterface, PolledAfter
     }
   }
 
+  @Override
   public JPanel getInterfaceVisualizer() {
     final JPanel panel = new JPanel() {
+      @Override
       public void paintComponent(Graphics g) {
         super.paintComponent(g);
 
@@ -180,6 +187,7 @@ public class ContikiLED extends LED implements ContikiMoteInterface, PolledAfter
 
     Observer observer;
     this.addObserver(observer = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         panel.repaint();
       }
@@ -194,6 +202,7 @@ public class ContikiLED extends LED implements ContikiMoteInterface, PolledAfter
     return panel;
   }
 
+  @Override
   public void releaseInterfaceVisualizer(JPanel panel) {
     Observer observer = (Observer) panel.getClientProperty("intf_obs");
     if (observer == null) {
@@ -204,10 +213,12 @@ public class ContikiLED extends LED implements ContikiMoteInterface, PolledAfter
     this.deleteObserver(observer);
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     return null;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
   }
 

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiMoteID.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiMoteID.java
@@ -86,10 +86,12 @@ public class ContikiMoteID extends MoteID implements ContikiMoteInterface {
     return new String[]{"moteid_interface"};
   }
 
+  @Override
   public int getMoteID() {
     return moteID;
   }
 
+  @Override
   public void setMoteID(int newID) {
     moteID = newID;
     moteMem.setIntValueOf("simMoteID", moteID);
@@ -99,6 +101,7 @@ public class ContikiMoteID extends MoteID implements ContikiMoteInterface {
     notifyObservers();
   }
 
+  @Override
   public JPanel getInterfaceVisualizer() {
     JPanel panel = new JPanel();
     final JLabel idLabel = new JLabel();
@@ -109,6 +112,7 @@ public class ContikiMoteID extends MoteID implements ContikiMoteInterface {
 
     Observer observer;
     this.addObserver(observer = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         idLabel.setText("Mote ID: " + moteID);
       }
@@ -120,6 +124,7 @@ public class ContikiMoteID extends MoteID implements ContikiMoteInterface {
     return panel;
   }
 
+  @Override
   public void releaseInterfaceVisualizer(JPanel panel) {
     Observer observer = (Observer) panel.getClientProperty("intf_obs");
     if (observer == null) {
@@ -130,6 +135,7 @@ public class ContikiMoteID extends MoteID implements ContikiMoteInterface {
     this.deleteObserver(observer);
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     Vector<Element> config = new Vector<Element>();
     Element element;
@@ -142,6 +148,7 @@ public class ContikiMoteID extends MoteID implements ContikiMoteInterface {
     return config;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
     for (Element element : configXML) {
       if (element.getName().equals("id")) {

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiPIR.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiPIR.java
@@ -88,8 +88,10 @@ public class ContikiPIR extends PIR implements ContikiMoteInterface {
   /**
    * Simulates a change in the PIR sensor.
    */
-  public void triggerChange() { 
+  @Override
+  public void triggerChange() {
     mote.getSimulation().invokeSimulationThread(new Runnable() {
+      @Override
       public void run() {
         doTriggerChange();
       }
@@ -104,6 +106,7 @@ public class ContikiPIR extends PIR implements ContikiMoteInterface {
     }
   }
 
+  @Override
   public JPanel getInterfaceVisualizer() {
     JPanel panel = new JPanel();
     final JButton clickButton = new JButton("Signal PIR");
@@ -111,6 +114,7 @@ public class ContikiPIR extends PIR implements ContikiMoteInterface {
     panel.add(clickButton);
 
     clickButton.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         triggerChange();
       }
@@ -119,13 +123,16 @@ public class ContikiPIR extends PIR implements ContikiMoteInterface {
     return panel;
   }
 
+  @Override
   public void releaseInterfaceVisualizer(JPanel panel) {
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     return null;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
   }
 

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiRS232.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiRS232.java
@@ -91,6 +91,7 @@ public class ContikiRS232 extends SerialUI implements ContikiMoteInterface, Poll
     return new String[]{"rs232_interface", "simlog_interface" };
   }
 
+  @Override
   public void doActionsAfterTick() {
     if (moteMem.getByteValueOf("simLoggedFlag") == 1) {
       int len = moteMem.getIntValueOf("simLoggedLength");
@@ -105,10 +106,12 @@ public class ContikiRS232 extends SerialUI implements ContikiMoteInterface, Poll
     }
   }
 
+  @Override
   public void writeString(String message) {
     final byte[] dataToAppend = message.getBytes();
 
     mote.getSimulation().invokeSimulationThread(new Runnable() {
+      @Override
       public void run() {
         /* Append to existing buffer */
         int oldSize = moteMem.getIntValueOf("simSerialReceivingLength");
@@ -134,12 +137,14 @@ public class ContikiRS232 extends SerialUI implements ContikiMoteInterface, Poll
     });
   }
 
+  @Override
   public Mote getMote() {
     return mote;
   }
 
   private TimeEvent pendingBytesEvent = null;
   private Vector<Byte> pendingBytes = new Vector<Byte>();
+  @Override
   public void writeArray(byte[] s) {
     for (byte b: s) {
       pendingBytes.add(b);
@@ -151,6 +156,7 @@ public class ContikiRS232 extends SerialUI implements ContikiMoteInterface, Poll
     }
 
     pendingBytesEvent = new MoteTimeEvent(mote) {
+      @Override
       public void execute(long t) {
         ContikiRS232.this.pendingBytesEvent = null;
         if (pendingBytes.isEmpty()) {
@@ -191,6 +197,7 @@ public class ContikiRS232 extends SerialUI implements ContikiMoteInterface, Poll
       }
     };
     mote.getSimulation().invokeSimulationThread(new Runnable() {
+      @Override
       public void run() {
         mote.getSimulation().scheduleEvent(
             pendingBytesEvent,
@@ -200,6 +207,7 @@ public class ContikiRS232 extends SerialUI implements ContikiMoteInterface, Poll
     });
   }
 
+  @Override
   public void writeByte(final byte b) {
     pendingBytes.add(b);
 
@@ -209,6 +217,7 @@ public class ContikiRS232 extends SerialUI implements ContikiMoteInterface, Poll
     }
 
     pendingBytesEvent = new MoteTimeEvent(mote) {
+      @Override
       public void execute(long t) {
         ContikiRS232.this.pendingBytesEvent = null;
         if (pendingBytes.isEmpty()) {
@@ -259,7 +268,8 @@ public class ContikiRS232 extends SerialUI implements ContikiMoteInterface, Poll
     }
 
     mote.getSimulation().invokeSimulationThread(new Runnable() {
-    	public void run() {
+      @Override
+      public void run() {
     		if (pendingBytesEvent.isScheduled()) {
     			return;
     		}

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiRadio.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiRadio.java
@@ -146,39 +146,48 @@ public class ContikiRadio extends Radio implements ContikiMoteInterface, PolledA
   }
 
   /* Packet radio support */
+  @Override
   public RadioPacket getLastPacketTransmitted() {
     return packetFromMote;
   }
 
+  @Override
   public RadioPacket getLastPacketReceived() {
     return packetToMote;
   }
 
+  @Override
   public void setReceivedPacket(RadioPacket packet) {
     packetToMote = packet;
   }
 
   /* General radio support */
+  @Override
   public boolean isRadioOn() {
     return radioOn;
   }
 
+  @Override
   public boolean isTransmitting() {
     return isTransmitting;
   }
 
+  @Override
   public boolean isReceiving() {
     return myMoteMemory.getByteValueOf("simReceiving") == 1;
   }
 
+  @Override
   public boolean isInterfered() {
     return isInterfered;
   }
 
+  @Override
   public int getChannel() {
     return myMoteMemory.getIntValueOf("simRadioChannel");
   }
 
+  @Override
   public void signalReceptionStart() {
     packetToMote = null;
     if (isInterfered() || isReceiving() || isTransmitting()) {
@@ -198,6 +207,7 @@ public class ContikiRadio extends Radio implements ContikiMoteInterface, PolledA
     this.notifyObservers();
   }
 
+  @Override
   public void signalReceptionEnd() {
     if (isInterfered || packetToMote == null) {
       isInterfered = false;
@@ -216,10 +226,12 @@ public class ContikiRadio extends Radio implements ContikiMoteInterface, PolledA
     this.notifyObservers();
   }
 
+  @Override
   public RadioEvent getLastEvent() {
     return lastEvent;
   }
 
+  @Override
   public void interfereAnyReception() {
     if (isInterfered()) {
       return;
@@ -233,24 +245,29 @@ public class ContikiRadio extends Radio implements ContikiMoteInterface, PolledA
     this.notifyObservers();
   }
 
+  @Override
   public double getCurrentOutputPower() {
     /* TODO Implement method */
     logger.warn("Not implemented, always returning 0 dBm");
     return 0;
   }
 
+  @Override
   public int getOutputPowerIndicatorMax() {
     return 100;
   }
 
+  @Override
   public int getCurrentOutputPowerIndicator() {
     return myMoteMemory.getByteValueOf("simPower");
   }
 
+  @Override
   public double getCurrentSignalStrength() {
     return myMoteMemory.getIntValueOf("simSignalStrength");
   }
 
+  @Override
   public void setCurrentSignalStrength(double signalStrength) {
     myMoteMemory.setIntValueOf("simSignalStrength", (int) signalStrength);
   }
@@ -259,6 +276,7 @@ public class ContikiRadio extends Radio implements ContikiMoteInterface, PolledA
    * 
    * @see org.contikios.cooja.interfaces.Radio#setLQI(int)
    */
+  @Override
   public void setLQI(int lqi){
     if(lqi<0) {
       lqi=0;
@@ -269,14 +287,17 @@ public class ContikiRadio extends Radio implements ContikiMoteInterface, PolledA
     myMoteMemory.setIntValueOf("simLQI", lqi);
   }
 
+  @Override
   public int getLQI(){
     return myMoteMemory.getIntValueOf("simLQI");
   }
 
+  @Override
   public Position getPosition() {
     return mote.getInterfaces().getPosition();
   }
 
+  @Override
   public void doActionsAfterTick() {
     long now = mote.getSimulation().getSimulationTime();
 
@@ -377,6 +398,7 @@ public class ContikiRadio extends Radio implements ContikiMoteInterface, PolledA
     }
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
            ArrayList<Element> config = new ArrayList<Element>();
 
@@ -390,6 +412,7 @@ public class ContikiRadio extends Radio implements ContikiMoteInterface, PolledA
            return config;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML,
                  boolean visAvailable) {
          for (Element element : configXML) {
@@ -400,10 +423,12 @@ public class ContikiRadio extends Radio implements ContikiMoteInterface, PolledA
          }
   }
 
+  @Override
   public Mote getMote() {
     return mote;
   }
 
+  @Override
   public String toString() {
     return "Radio at " + mote;
   }

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiVib.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiVib.java
@@ -92,6 +92,7 @@ public class ContikiVib extends MoteInterface implements ContikiMoteInterface {
    */
   public void triggerChange() {
     mote.getSimulation().invokeSimulationThread(new Runnable() {
+      @Override
       public void run() {
         doTriggerChange();
       }
@@ -108,6 +109,7 @@ public class ContikiVib extends MoteInterface implements ContikiMoteInterface {
 
   /* TODO Energy consumption */
 
+  @Override
   public JPanel getInterfaceVisualizer() {
     JPanel panel = new JPanel();
     final JButton clickButton = new JButton("Vibrate!");
@@ -115,6 +117,7 @@ public class ContikiVib extends MoteInterface implements ContikiMoteInterface {
     panel.add(clickButton);
 
     clickButton.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         triggerChange();
       }
@@ -123,13 +126,16 @@ public class ContikiVib extends MoteInterface implements ContikiMoteInterface {
     return panel;
   }
 
+  @Override
   public void releaseInterfaceVisualizer(JPanel panel) {
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     return null;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
   }
 

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -164,17 +164,21 @@ public abstract class AbstractCompileDialog extends JDialog {
     sourcePanel.add(label);
     contikiField = new JTextField(40);
     final Runnable selectedContikiFile = new Runnable() {
+      @Override
       public void run() {
         setContikiSelection(new File(contikiField.getText()));
       }
     };
     DocumentListener contikiFieldListener = new DocumentListener() {
+      @Override
       public void changedUpdate(DocumentEvent e) {
         selectedContikiFile.run();
       }
+      @Override
       public void insertUpdate(DocumentEvent e) {
         selectedContikiFile.run();
       }
+      @Override
       public void removeUpdate(DocumentEvent e) {
         selectedContikiFile.run();
       }
@@ -182,6 +186,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     sourcePanel.add(contikiField);
     JButton browseButton = new JButton("Browse");
     browseButton.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         JFileChooser fc = new JFileChooser();
 
@@ -221,6 +226,7 @@ public abstract class AbstractCompileDialog extends JDialog {
 
         fc.setFileSelectionMode(JFileChooser.FILES_ONLY);
         fc.addChoosableFileFilter(new FileFilter() {
+          @Override
           public boolean accept(File f) {
             if (f.isDirectory()) {
               return true;
@@ -242,6 +248,7 @@ public abstract class AbstractCompileDialog extends JDialog {
             return false;
           }
 
+          @Override
           public String getDescription() {
             return "Contiki process source or Precompiled firmware";
           }
@@ -259,13 +266,15 @@ public abstract class AbstractCompileDialog extends JDialog {
 
     
     Action cancelAction = new AbstractAction("Cancel") {
+      @Override
       public void actionPerformed(ActionEvent e) {
         AbstractCompileDialog.this.dispose();
       }
     };
     Action compileAction = new AbstractAction("Compile") {
     	private static final long serialVersionUID = 1L;
-    	public void actionPerformed(ActionEvent e) {
+      @Override
+      public void actionPerformed(ActionEvent e) {
     		if (!compileButton.isEnabled()) {
     			return;
     		}
@@ -280,7 +289,8 @@ public abstract class AbstractCompileDialog extends JDialog {
     cleanButton = new JButton("Clean");
     cleanButton.setToolTipText("make clean TARGET=" + getTargetName());
     cleanButton.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
+      @Override
+      public void actionPerformed(ActionEvent e) {
 				try {
 					currentCompilationProcess = CompileContiki.compile(
 							"make clean TARGET=" + getTargetName(),
@@ -304,6 +314,7 @@ public abstract class AbstractCompileDialog extends JDialog {
 
     createButton = new JButton("Create");
     createButton.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
       	/* Write mote type settings (generic) */
       	moteType.setDescription(descriptionField.getText());
@@ -344,6 +355,7 @@ public abstract class AbstractCompileDialog extends JDialog {
 
     setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
     addWindowListener(new WindowAdapter() {
+      @Override
       public void windowClosing(WindowEvent e) {
         abortAnyCompilation();
         contikiSource = null;
@@ -489,6 +501,7 @@ public abstract class AbstractCompileDialog extends JDialog {
       setDialogState(DialogState.IS_COMPILING);
     } else {
       SwingUtilities.invokeAndWait(new Runnable() {
+        @Override
         public void run() {
           setDialogState(DialogState.IS_COMPILING);
         }
@@ -500,6 +513,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     final JMenuItem abortMenuItem = new JMenuItem("Abort compilation");
     abortMenuItem.setEnabled(true);
     abortMenuItem.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         abortAnyCompilation();
       }
@@ -509,6 +523,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     /* Called when last command has finished (success only) */
     final Action compilationSuccessAction = new AbstractAction() {
 			private static final long serialVersionUID = -3815068126197234346L;
+			@Override
 			public void actionPerformed(ActionEvent e) {
         abortMenuItem.setEnabled(false);
 
@@ -525,6 +540,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     /* Called immediately if any command fails */
     final Action compilationFailureAction = new AbstractAction() {
 			private static final long serialVersionUID = -800799353242963993L;
+			@Override
 			public void actionPerformed(ActionEvent e) {
         abortMenuItem.setEnabled(false);
         setDialogState(DialogState.AWAITING_COMPILATION);
@@ -534,6 +550,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     /* Called once per command */
     final Action nextCommandAction = new AbstractAction() {
 			private static final long serialVersionUID = -4525372566302330762L;
+			@Override
 			public void actionPerformed(ActionEvent e) {
         Action nextSuccessAction;
         if (commands.size() == 1) {
@@ -690,12 +707,15 @@ public abstract class AbstractCompileDialog extends JDialog {
   private void addCompileCommandTab(JTabbedPane parent) {
     commandsArea = new JTextArea(10, 1);
     commandsArea.getDocument().addDocumentListener(new DocumentListener() {
+      @Override
       public void changedUpdate(DocumentEvent e) {
         setDialogState(DialogState.AWAITING_COMPILATION);
       }
+      @Override
       public void insertUpdate(DocumentEvent e) {
         setDialogState(DialogState.AWAITING_COMPILATION);
       }
+      @Override
       public void removeUpdate(DocumentEvent e) {
         setDialogState(DialogState.AWAITING_COMPILATION);
       }
@@ -716,6 +736,7 @@ public abstract class AbstractCompileDialog extends JDialog {
   }
 
   private Action defaultAction = new AbstractAction("Use default") {
+    @Override
     public void actionPerformed(ActionEvent e) {
       /* Unselect all */
       for (Component c : moteIntfBox.getComponents()) {
@@ -800,6 +821,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     intfCheckBox.setAlignmentX(Component.LEFT_ALIGNMENT);
     intfCheckBox.setToolTipText(intfClass.getName());
     intfCheckBox.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         if (contikiSource == null &&
             contikiFirmware != null) {

--- a/java/org/contikios/cooja/dialogs/AddMoteDialog.java
+++ b/java/org/contikios/cooja/dialogs/AddMoteDialog.java
@@ -428,21 +428,26 @@ public class AddMoteDialog extends JDialog {
         ActionListener,
         FocusListener,
         PropertyChangeListener {
+    @Override
     public void propertyChange(PropertyChangeEvent e) {
       checkSettings();
     }
+    @Override
     public void focusGained(final FocusEvent e) {
       if (e.getSource() instanceof JFormattedTextField) {
         SwingUtilities.invokeLater(new Runnable() {
+          @Override
           public void run() {
             ((JFormattedTextField) e.getSource()).selectAll();
           }
         });
       }
     }
+    @Override
     public void focusLost(FocusEvent e) {
       checkSettings();
     }
+    @Override
     public void actionPerformed(ActionEvent e) {
       if (e.getActionCommand().equals("cancel")) {
         newMotes = null;

--- a/java/org/contikios/cooja/dialogs/BufferSettings.java
+++ b/java/org/contikios/cooja/dialogs/BufferSettings.java
@@ -94,6 +94,7 @@ public class BufferSettings extends JDialog {
     JFormattedTextField value = addEntry(main, "Log output messages");
     value.setValue(central.getLogOutputBufferSize());
     value.addPropertyChangeListener("value", new PropertyChangeListener() {
+      @Override
       public void propertyChange(PropertyChangeEvent evt) {
         int newVal = ((Number)evt.getNewValue()).intValue();
         if (newVal < 1) {
@@ -133,6 +134,7 @@ public class BufferSettings extends JDialog {
   }
 
   private Action setDefaultAction = new AbstractAction("Set default") {
+    @Override
     public void actionPerformed(ActionEvent e) {
       Object[] options = { "Ok", "Cancel" };
 
@@ -151,6 +153,7 @@ public class BufferSettings extends JDialog {
   };
 
   private Action disposeAction = new AbstractAction("OK") {
+    @Override
     public void actionPerformed(ActionEvent e) {
       dispose();
     }

--- a/java/org/contikios/cooja/dialogs/CompileContiki.java
+++ b/java/org/contikios/cooja/dialogs/CompileContiki.java
@@ -166,6 +166,7 @@ public class CompileContiki {
       }
 
       Thread readInput = new Thread(new Runnable() {
+        @Override
         public void run() {
           try {
             String readLine;
@@ -181,6 +182,7 @@ public class CompileContiki {
       }, "read input stream thread");
 
       Thread readError = new Thread(new Runnable() {
+        @Override
         public void run() {
           try {
             String readLine;
@@ -197,6 +199,7 @@ public class CompileContiki {
 
       final MoteTypeCreationException syncException = new MoteTypeCreationException("");
       Thread handleCompilationResultThread = new Thread(new Runnable() {
+        @Override
         public void run() {
 
           /* Wait for compilation to end */

--- a/java/org/contikios/cooja/dialogs/ConfigurationWizard.java
+++ b/java/org/contikios/cooja/dialogs/ConfigurationWizard.java
@@ -240,6 +240,7 @@ public class ConfigurationWizard extends JDialog {
 
       /* Start test */
       new Thread(new Runnable() {
+        @Override
         public void run() {
           testCounter++;
           PrintStream normalStream = new PrintStream(output.getInputStream(MessageList.NORMAL));
@@ -295,6 +296,7 @@ public class ConfigurationWizard extends JDialog {
 
       /* Start test */
       new Thread(new Runnable() {
+        @Override
         public void run() {
           testCounter++;
           PrintStream normalStream = new PrintStream(output.getInputStream(MessageList.NORMAL));
@@ -351,6 +353,7 @@ public class ConfigurationWizard extends JDialog {
 
       /* Start test */
       new Thread(new Runnable() {
+        @Override
         public void run() {
           testCounter++;
           PrintStream normalStream = new PrintStream(output.getInputStream(MessageList.NORMAL));
@@ -406,6 +409,7 @@ public class ConfigurationWizard extends JDialog {
 
       /* Start test */
       new Thread(new Runnable() {
+        @Override
         public void run() {
           testCounter++;
           PrintStream normalStream = new PrintStream(output.getInputStream(MessageList.NORMAL));
@@ -445,6 +449,7 @@ public class ConfigurationWizard extends JDialog {
     JPanel progressPanel = new JPanel(new BorderLayout());
     button.setEnabled(false);
     button.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         if (progressDialog.isDisplayable()) {
           progressDialog.dispose();
@@ -493,6 +498,7 @@ public class ConfigurationWizard extends JDialog {
       }
     }
     combo.addItemListener(new ItemListener() {
+      @Override
       public void itemStateChanged(ItemEvent e) {
         Cooja.setExternalToolsSetting(name, (String) e.getItem());
       }

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -169,6 +169,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
     }
   }
   
+  @Override
   public boolean canLoadFirmware(File file) {
     /* Disallow loading firmwares without compilation */
     /*
@@ -180,6 +181,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
     return false;
   }
 
+  @Override
   public String getDefaultCompileCommands(final File source) {
     if (moteType == null) {
       /* Not ready to compile yet */
@@ -196,6 +198,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
     } else {
       try {
         SwingUtilities.invokeAndWait(new Runnable() {
+          @Override
           public void run() {
             updateForSource(source);
           }
@@ -217,10 +220,12 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
     Cooja.getExternalToolsSetting("PATH_MAKE") + " " + getExpectedFirmwareFile(source).getName() + " TARGET=cooja" + defines;
   }
 
+  @Override
   public File getExpectedFirmwareFile(File source) {
     return ContikiMoteType.getExpectedFirmwareFile(source);
   }
 
+  @Override
   public Class<? extends MoteInterface>[] getAllMoteInterfaces() {
 	  ProjectConfig projectConfig = moteType.getConfig();
 	  String[] intfNames = projectConfig.getStringArrayValue(ContikiMoteType.class, "MOTE_INTERFACES");
@@ -240,6 +245,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
 	  }
 	  return classes.toArray(new Class[0]);
   }
+  @Override
   public Class<? extends MoteInterface>[] getDefaultMoteInterfaces() {
 	  return getAllMoteInterfaces();
   }
@@ -258,12 +264,15 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
     final JTextField headerTextField = new JTextField();
     headerTextField.setText(((ContikiMoteType)moteType).getNetworkStack().manualHeader);
     headerTextField.getDocument().addDocumentListener(new DocumentListener() {
+      @Override
       public void insertUpdate(DocumentEvent e) {
         updateHeader();
       }
+      @Override
       public void removeUpdate(DocumentEvent e) {
         updateHeader();
       }
+      @Override
       public void changedUpdate(DocumentEvent e) {
         updateHeader();
       }
@@ -282,6 +291,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
     netStackComboBox.setSelectedItem(((ContikiMoteType)moteType).getNetworkStack());
     netStackComboBox.setEnabled(true);
     netStackComboBox.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         ((ContikiMoteType)moteType).setNetworkStack((NetworkStack)netStackComboBox.getSelectedItem());
         netStackHeaderBox.setVisible((NetworkStack)netStackComboBox.getSelectedItem() == NetworkStack.MANUAL);
@@ -319,6 +329,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
     /* Create new tab, fill with current environment data */
     String[] columnNames = { "Variable", "Value" };
     JTable table = new JTable(env, columnNames) {
+      @Override
       public boolean isCellEditable(int row, int column) {
         return false;
       }
@@ -327,12 +338,14 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
     JPanel panel = new JPanel(new BorderLayout());
     JButton button = new JButton("Change environment variables: Open external tools dialog");
     button.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         /* Show external tools dialog */
         ExternalToolsDialog.showDialog(Cooja.getTopParentContainer());
 
         /* Update and select environment tab */
         SwingUtilities.invokeLater(new Runnable() {
+          @Override
           public void run() {
             getDefaultCompileCommands(((ContikiMoteType)moteType).getContikiSourceFile());
             for (int i=0; i < tabbedPane.getTabCount(); i++) {
@@ -353,6 +366,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
     parent.addTab("Environment", null, panel, "Environment variables");
   }
 
+  @Override
   public void writeSettingsToMoteType() {
     /* XXX Do not load the generated firmware.
      * Instead, load the copy in output_dir */
@@ -367,6 +381,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
     ((ContikiMoteType)moteType).setHasSystemSymbols(false);
   }
 
+  @Override
   public void compileContiki()
   throws Exception {
     if (((ContikiMoteType)moteType).libSource == null ||
@@ -404,6 +419,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
     super.compileContiki();
   }
 
+  @Override
   protected String getTargetName() {
   	return "cooja";
   }

--- a/java/org/contikios/cooja/dialogs/CreateSimDialog.java
+++ b/java/org/contikios/cooja/dialogs/CreateSimDialog.java
@@ -98,6 +98,7 @@ public class CreateSimDialog extends JDialog {
     final CreateSimDialog dialog = new CreateSimDialog((Window) parent, simulation.getCooja());
     dialog.setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
     dialog.addWindowListener(new WindowAdapter() {
+      @Override
       public void windowClosing(WindowEvent e) {
         dialog.cancelButton.doClick();
       }
@@ -153,6 +154,7 @@ public class CreateSimDialog extends JDialog {
     InputMap inputMap = dialog.getRootPane().getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
     inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0, false), "dispose");
     AbstractAction cancelAction = new AbstractAction(){
+      @Override
       public void actionPerformed(ActionEvent e) {
         dialog.cancelButton.doClick();
       }
@@ -189,6 +191,7 @@ public class CreateSimDialog extends JDialog {
 
     cancelButton = new JButton("Cancel");
     cancelButton.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         mySimulation = null;
         dispose();
@@ -305,6 +308,7 @@ public class CreateSimDialog extends JDialog {
     randomSeedGenerated = new JCheckBox();
     randomSeedGenerated.setToolTipText("Automatically generate random seed at simulation load");
     randomSeedGenerated.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         if (((JCheckBox)e.getSource()).isSelected()) {
           randomSeed.setEnabled(false);
@@ -337,6 +341,7 @@ public class CreateSimDialog extends JDialog {
   }
 
   private ActionListener createSimulationListener = new ActionListener() {
+    @Override
     public void actionPerformed(ActionEvent e) {
       mySimulation.setTitle(title.getText());
 

--- a/java/org/contikios/cooja/dialogs/ExternalToolsDialog.java
+++ b/java/org/contikios/cooja/dialogs/ExternalToolsDialog.java
@@ -218,12 +218,15 @@ public class ExternalToolsDialog extends JDialog {
       implements
         ActionListener,
         FocusListener {
+    @Override
     public void focusGained(FocusEvent e) {
       // NOP
     }
+    @Override
     public void focusLost(FocusEvent e) {
       compareWithDefaults();
     }
+    @Override
     public void actionPerformed(ActionEvent e) {
       if (e.getActionCommand().equals("reset")) {
         Cooja.loadExternalToolsDefaultSettings();

--- a/java/org/contikios/cooja/dialogs/ImportAppMoteDialog.java
+++ b/java/org/contikios/cooja/dialogs/ImportAppMoteDialog.java
@@ -115,6 +115,7 @@ public class ImportAppMoteDialog extends JDialog {
 
     JButton browseButton = new JButton("Browse");
     browseButton.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         JFileChooser fc = new JFileChooser();
 
@@ -138,6 +139,7 @@ public class ImportAppMoteDialog extends JDialog {
 
         fc.setFileSelectionMode(JFileChooser.FILES_ONLY);
         fc.addChoosableFileFilter(new FileFilter() {
+          @Override
           public boolean accept(File f) {
             if (f.isDirectory()) {
               return true;
@@ -149,6 +151,7 @@ public class ImportAppMoteDialog extends JDialog {
             return false;
           }
 
+          @Override
           public String getDescription() {
             return "Application Mote Java Class";
           }
@@ -167,6 +170,7 @@ public class ImportAppMoteDialog extends JDialog {
 
     ActionListener cancelAction = new ActionListener() {
 
+      @Override
       public void actionPerformed(ActionEvent e) {
         setVisible(false);
         dispose();
@@ -180,6 +184,7 @@ public class ImportAppMoteDialog extends JDialog {
 
     createButton = new JButton("Create");
     createButton.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         String className = classField.getText();
         if (className.length() == 0) {
@@ -227,6 +232,7 @@ public class ImportAppMoteDialog extends JDialog {
 
     setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
     addWindowListener(new WindowAdapter() {
+      @Override
       public void windowClosing(WindowEvent e) {
         cancelButton.doClick();
       }

--- a/java/org/contikios/cooja/dialogs/MessageListUI.java
+++ b/java/org/contikios/cooja/dialogs/MessageListUI.java
@@ -127,6 +127,7 @@ public class MessageListUI extends JList implements MessageList {
     }
   }
 
+  @Override
   public PrintStream getInputStream(final int type) {
     try {
       PipedInputStream input = new PipedInputStream();
@@ -156,12 +157,14 @@ public class MessageListUI extends JList implements MessageList {
     }
   }
 
+  @Override
   public void addMessage(String message) {
     addMessage(message, NORMAL);
   }
 
   private ArrayList<MessageContainer> messages = new ArrayList<MessageContainer>();
 
+  @Override
   public MessageContainer[] getMessages() {
     return messages.toArray(new MessageContainer[0]);
   }
@@ -182,6 +185,7 @@ public class MessageListUI extends JList implements MessageList {
     }
   }
 
+  @Override
   public void addMessage(final String message, final int type) {
     Cooja.setProgressMessage(message, type);
 
@@ -196,6 +200,7 @@ public class MessageListUI extends JList implements MessageList {
     });
   }
 
+  @Override
   public void clearMessages() {
     messages.clear();
     ((DefaultListModel) getModel()).clear();

--- a/java/org/contikios/cooja/dialogs/ProjectDirectoriesDialog.java
+++ b/java/org/contikios/cooja/dialogs/ProjectDirectoriesDialog.java
@@ -136,12 +136,15 @@ public class ProjectDirectoriesDialog extends JDialog {
 
 		table = new JTable(new AbstractTableModel() {
 			private static final long serialVersionUID = 591599455927509191L;
+			@Override
 			public int getColumnCount() {
 				return 2;
 			}
+			@Override
 			public int getRowCount() {
 				return currentProjects.size();
 			}
+			@Override
 			public Object getValueAt(int rowIndex, int columnIndex) {
 				if (columnIndex == 0) {
 					return rowIndex+1;
@@ -164,6 +167,7 @@ public class ProjectDirectoriesDialog extends JDialog {
 		table.setTableHeader(null);
 		table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 		table.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
+			@Override
 			public void valueChanged(ListSelectionEvent e) {
 				if (table.getSelectedRow() < 0) {
 					return;
@@ -176,6 +180,7 @@ public class ProjectDirectoriesDialog extends JDialog {
 		table.getColumnModel().getColumn(0).setMaxWidth(30);
 		table.getColumnModel().getColumn(1).setCellRenderer(new DefaultTableCellRenderer() {
 			private static final long serialVersionUID = 7224219223448831880L;
+			@Override
 			public Component getTableCellRendererComponent(JTable table,
 					Object value, boolean isSelected, boolean hasFocus, int row,
 					int column) {
@@ -206,6 +211,7 @@ public class ProjectDirectoriesDialog extends JDialog {
 
 			button = new JButton("View config");
 			button.addActionListener(new ActionListener() {
+				@Override
 				public void actionPerformed(ActionEvent e) {
 					try {
 						/* Default config */
@@ -228,6 +234,7 @@ public class ProjectDirectoriesDialog extends JDialog {
 
 			button = new JButton("Cancel");
 			button.addActionListener(new ActionListener() {
+				@Override
 				public void actionPerformed(ActionEvent e) {
 					ProjectDirectoriesDialog.this.returnedProjects = null;
 					dispose();
@@ -239,6 +246,7 @@ public class ProjectDirectoriesDialog extends JDialog {
 
 			button = new JButton("Apply for session");
 			button.addActionListener(new ActionListener() {
+				@Override
 				public void actionPerformed(ActionEvent e) {
 					ProjectDirectoriesDialog.this.returnedProjects = currentProjects.toArray(new COOJAProject[0]);
 					dispose();
@@ -250,6 +258,7 @@ public class ProjectDirectoriesDialog extends JDialog {
 			
 			button = new JButton("Save");
 			button.addActionListener(new ActionListener() {
+				@Override
 				public void actionPerformed(ActionEvent e) {
 					Object[] options = { "Ok", "Cancel" };
 
@@ -292,6 +301,7 @@ public class ProjectDirectoriesDialog extends JDialog {
 			sortPane = new JPanel(new BorderLayout());
 			button = new JButton("Move up");
 			button.addActionListener(new ActionListener() {
+				@Override
 				public void actionPerformed(ActionEvent e) {
 					int selectedIndex = table.getSelectedRow();
 					if (selectedIndex <= 0) {
@@ -307,6 +317,7 @@ public class ProjectDirectoriesDialog extends JDialog {
 			
 			button = new JButton("Move down");
 			button.addActionListener(new ActionListener() {
+				@Override
 				public void actionPerformed(ActionEvent e) {
 					int selectedIndex = table.getSelectedRow();
 					if (selectedIndex < 0) {
@@ -327,6 +338,7 @@ public class ProjectDirectoriesDialog extends JDialog {
 				button = new JButton("Remove");
 				
 				button.addActionListener(new ActionListener() {
+					@Override
 					public void actionPerformed(ActionEvent e) {
 						int selectedIndex = table.getSelectedRow();
 						if (selectedIndex < 0) {
@@ -370,6 +382,7 @@ public class ProjectDirectoriesDialog extends JDialog {
 			listPane.setRightComponent(projectPane);
 
 			SwingUtilities.invokeLater(new Runnable() {
+				@Override
 				public void run() {
 					projectPane.setDividerLocation(0.6);
 					listPane.setDividerLocation(0.5);
@@ -522,6 +535,7 @@ class DirectoryTreePanel extends JPanel {
 			private Icon errorIcon = new CheckboxIcon(new Color(255, 0, 0, 128));
 			private Font boldFont = null;
 			private Font normalFont = null;
+			@Override
 			public Component getTreeCellRendererComponent(JTree tree,
 					Object value, boolean sel, boolean expanded, boolean leaf,
 					int row, boolean hasFocus) {
@@ -565,18 +579,21 @@ class DirectoryTreePanel extends JPanel {
 					this.icon = (Icon) UIManager.get("CheckBox.icon");
 					this.color = color;
 				}
+				@Override
 				public int getIconHeight() {
 					if (icon == null) {
 						return 18;
 					}
 					return icon.getIconHeight();
 				}
+				@Override
 				public int getIconWidth() {
 					if (icon == null) {
 						return 18;
 					}
 					return icon.getIconWidth();
 				}
+				@Override
 				public void paintIcon(Component c, Graphics g, int x, int y) {
 					if (icon != null) {
 						try {
@@ -600,6 +617,7 @@ class DirectoryTreePanel extends JPanel {
 		});
 		tree.setModel(new COOJAProjectTreeModel(treeRoot));
 		tree.addMouseListener(new MouseAdapter() {
+			@Override
 			public void mousePressed(MouseEvent e) {
 				TreePath selPath = tree.getPathForLocation(e.getX(), e.getY());
 				if (selPath == null) {
@@ -634,6 +652,7 @@ class DirectoryTreePanel extends JPanel {
 			}
 		});
 		tree.addTreeSelectionListener(new TreeSelectionListener() {
+			@Override
 			public void valueChanged(TreeSelectionEvent e) {
 				TreePath selPath = e.getPath();
 				if (selPath == null) {
@@ -761,6 +780,7 @@ class DirectoryTreePanel extends JPanel {
 			}
 			return false;
 		}
+		@Override
 		public String toString() {
 			if (dir.getName() == null || dir.getName().equals("")) {
 				return dir.getAbsolutePath();
@@ -788,10 +808,12 @@ class DirectoryTreePanel extends JPanel {
 				computerNode.add(deviceNode);
 			}
 		}
+		@Override
 		public Object getRoot() {
 			return computerNode.getUserObject();
 		}
-		public boolean isLeaf(Object node) {  
+		@Override
+		public boolean isLeaf(Object node) {
 			if ((node instanceof DefaultMutableTreeNode)) {
 				node = ((DefaultMutableTreeNode)node).getUserObject();
 			}
@@ -803,6 +825,7 @@ class DirectoryTreePanel extends JPanel {
 
 			return td.dir.isFile();
 		}
+		@Override
 		public int getChildCount(Object parent) {
 			if ((parent instanceof DefaultMutableTreeNode)) {
 				parent = ((DefaultMutableTreeNode)parent).getUserObject();
@@ -825,6 +848,7 @@ class DirectoryTreePanel extends JPanel {
 			}
 			return children.length;
 		}
+		@Override
 		public Object getChild(Object parent, int index) {
 			if ((parent instanceof DefaultMutableTreeNode)) {
 				parent = ((DefaultMutableTreeNode)parent).getUserObject();
@@ -847,6 +871,7 @@ class DirectoryTreePanel extends JPanel {
 			}
 			return new DefaultMutableTreeNode(new TreeDirectory(children[index]));
 		}
+		@Override
 		public int getIndexOfChild(Object parent, Object child) {
 			if ((parent instanceof DefaultMutableTreeNode)) {
 				parent = ((DefaultMutableTreeNode)parent).getUserObject();
@@ -883,11 +908,15 @@ class DirectoryTreePanel extends JPanel {
 			return -1;
 		}
 
+		@Override
 		public void valueForPathChanged(TreePath path, Object newvalue) {}
+		@Override
 		public void addTreeModelListener(TreeModelListener l) {}
+		@Override
 		public void removeTreeModelListener(TreeModelListener l) {}
 
 		private final FileFilter DIRECTORIES = new FileFilter() {
+			@Override
 			public boolean accept(File file) {
 				if (!file.isDirectory()) {
 					return false;
@@ -952,6 +981,7 @@ class ConfigViewer extends JDialog {
 
 		button = new JButton("Close");
 		button.addActionListener(new ActionListener() {
+			@Override
 			public void actionPerformed(ActionEvent e) {
 				dispose();
 			}

--- a/java/org/contikios/cooja/dialogs/SerialUI.java
+++ b/java/org/contikios/cooja/dialogs/SerialUI.java
@@ -73,6 +73,7 @@ public abstract class SerialUI extends Log implements SerialPort {
   private int historyPos = -1;
 
   /* Log */
+  @Override
   public String getLastLogMessage() {
     return lastLogMessage;
   }
@@ -82,6 +83,7 @@ public abstract class SerialUI extends Log implements SerialPort {
     public abstract void notifyNewData();
   }
   private SerialDataObservable serialDataObservable = new SerialDataObservable() {
+    @Override
     public void notifyNewData() {
       if (this.countObservers() == 0) {
         return;
@@ -90,12 +92,15 @@ public abstract class SerialUI extends Log implements SerialPort {
       notifyObservers(SerialUI.this);
     }
   };
+  @Override
   public void addSerialDataObserver(Observer o) {
     serialDataObservable.addObserver(o);
   }
+  @Override
   public void deleteSerialDataObserver(Observer o) {
     serialDataObservable.deleteObserver(o);
   }
+  @Override
   public byte getLastSerialData() {
     return lastSerialData;
   }
@@ -126,6 +131,7 @@ public abstract class SerialUI extends Log implements SerialPort {
 
 
   /* Mote interface visualizer */
+  @Override
   public JPanel getInterfaceVisualizer() {
     JPanel panel = new JPanel(new BorderLayout());
     JPanel commandPane = new JPanel(new BorderLayout());
@@ -135,6 +141,7 @@ public abstract class SerialUI extends Log implements SerialPort {
     JButton sendButton = new JButton("Send data");
 
     ActionListener sendCommandAction = new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         final String command = trim(commandField.getText());
         if (command == null) {
@@ -158,6 +165,7 @@ public abstract class SerialUI extends Log implements SerialPort {
           commandField.setText("");
           if (getMote().getSimulation().isRunning()) {
             getMote().getSimulation().invokeSimulationThread(new Runnable() {
+              @Override
               public void run() {
                 writeString(command);
               }
@@ -179,6 +187,7 @@ public abstract class SerialUI extends Log implements SerialPort {
 
     /* History */
     commandField.addKeyListener(new KeyAdapter() {
+      @Override
       public void keyPressed(KeyEvent e) {
         switch (e.getKeyCode()) {
         case KeyEvent.VK_UP: {
@@ -219,6 +228,7 @@ public abstract class SerialUI extends Log implements SerialPort {
     logTextPane.setOpaque(false);
     logTextPane.setEditable(false);
     logTextPane.addKeyListener(new KeyAdapter() {
+      @Override
       public void keyPressed(KeyEvent e) {
         if ((e.getModifiers() & (MouseEvent.SHIFT_MASK|MouseEvent.CTRL_MASK)) != 0) {
           return;
@@ -230,9 +240,11 @@ public abstract class SerialUI extends Log implements SerialPort {
     /* Mote interface observer */
     Observer observer;
     this.addObserver(observer = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         final String logMessage = getLastLogMessage();
         EventQueue.invokeLater(new Runnable() {
+          @Override
           public void run() {
             appendToTextArea(logTextPane, logMessage);
           }
@@ -248,6 +260,7 @@ public abstract class SerialUI extends Log implements SerialPort {
     return panel;
   }
 
+  @Override
   public void releaseInterfaceVisualizer(JPanel panel) {
     Observer observer = (Observer) panel.getClientProperty("intf_obs");
     if (observer == null) {
@@ -259,6 +272,7 @@ public abstract class SerialUI extends Log implements SerialPort {
   }
 
   private static final String HISTORY_SEPARATOR = "~;";
+  @Override
   public Collection<Element> getConfigXML() {
     StringBuilder sb = new StringBuilder();
     for (String s: history) {
@@ -279,6 +293,7 @@ public abstract class SerialUI extends Log implements SerialPort {
     return config;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
     for (Element element : configXML) {
       if (element.getName().equals("history")) {
@@ -291,9 +306,11 @@ public abstract class SerialUI extends Log implements SerialPort {
     }
   }
 
+  @Override
   public void close() {
   }
 
+  @Override
   public void flushInput() {
   }
 

--- a/java/org/contikios/cooja/dialogs/TableColumnAdjuster.java
+++ b/java/org/contikios/cooja/dialogs/TableColumnAdjuster.java
@@ -275,6 +275,7 @@ public class TableColumnAdjuster implements PropertyChangeListener, TableModelLi
   //
   //  Implement the PropertyChangeListener
   //
+  @Override
   public void propertyChange(PropertyChangeEvent e) {
     //  When the TableModel changes we need to update the listeners
     //  and column widths
@@ -294,6 +295,7 @@ public class TableColumnAdjuster implements PropertyChangeListener, TableModelLi
   //
   //  Implement the TableModelListener
   //
+  @Override
   public void tableChanged(final TableModelEvent e) {
     if (e.getType() == TableModelEvent.INSERT) {
       adjustColumnsForNewRows(e.getFirstRow(), e.getLastRow());

--- a/java/org/contikios/cooja/dialogs/UpdateAggregator.java
+++ b/java/org/contikios/cooja/dialogs/UpdateAggregator.java
@@ -70,6 +70,7 @@ public abstract class UpdateAggregator<A> {
     this.maxPending = maxEvents;
     pending = new ArrayList<A>();
     t = new Timer(interval, new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         consume.run();
       }
@@ -83,6 +84,7 @@ public abstract class UpdateAggregator<A> {
    * Consumer: called from event queue
    */
   private Runnable consume = new Runnable() {
+    @Override
     public void run() {
       if (pending.isEmpty()) {
         return;

--- a/java/org/contikios/cooja/emulatedmote/RadioByte.java
+++ b/java/org/contikios/cooja/emulatedmote/RadioByte.java
@@ -42,6 +42,7 @@ public class RadioByte implements RadioPacket {
     this.data[0] = (byte) intData;
   }
 
+  @Override
   public byte[] getPacketData() {
     return data;
   }

--- a/java/org/contikios/cooja/interfaces/ApplicationLED.java
+++ b/java/org/contikios/cooja/interfaces/ApplicationLED.java
@@ -40,18 +40,22 @@ public class ApplicationLED extends LED {
        return new String[]{"leds_interface"};
      }
 
+     @Override
      public boolean isAnyOn() {
        return currentLedValue > 0;
      }
 
+     @Override
      public boolean isGreenOn() {
        return (currentLedValue & LEDS_GREEN) > 0;
      }
 
+     @Override
      public boolean isYellowOn() {
        return (currentLedValue & LEDS_YELLOW) > 0;
      }
 
+     @Override
      public boolean isRedOn() {
        return (currentLedValue & LEDS_RED) > 0;
      }
@@ -67,8 +71,10 @@ public class ApplicationLED extends LED {
        }
      }
 
+     @Override
      public JPanel getInterfaceVisualizer() {
        final JPanel panel = new JPanel() {
+         @Override
          public void paintComponent(Graphics g) {
            super.paintComponent(g);
 
@@ -114,6 +120,7 @@ public class ApplicationLED extends LED {
 
        Observer observer;
        this.addObserver(observer = new Observer() {
+         @Override
          public void update(Observable obs, Object obj) {
            panel.repaint();
          }
@@ -128,6 +135,7 @@ public class ApplicationLED extends LED {
        return panel;
      }
 
+     @Override
      public void releaseInterfaceVisualizer(JPanel panel) {
        Observer observer = (Observer) panel.getClientProperty("intf_obs");
        if (observer == null) {
@@ -138,6 +146,7 @@ public class ApplicationLED extends LED {
        this.deleteObserver(observer);
      }
 
+     @Override
      public Collection<Element> getConfigXML() {
        return null;
      }

--- a/java/org/contikios/cooja/interfaces/ApplicationRadio.java
+++ b/java/org/contikios/cooja/interfaces/ApplicationRadio.java
@@ -96,19 +96,23 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
   }
 
   /* Packet radio support */
+  @Override
   public RadioPacket getLastPacketTransmitted() {
     return packetFromMote;
   }
 
+  @Override
   public RadioPacket getLastPacketReceived() {
     return packetToMote;
   }
 
+  @Override
   public void setReceivedPacket(RadioPacket packet) {
     packetToMote = packet;
   }
 
   /* General radio support */
+  @Override
   public void signalReceptionStart() {
     packetToMote = null;
     if (isInterfered() || isReceiving() || isTransmitting()) {
@@ -123,6 +127,7 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
     this.notifyObservers();
   }
 
+  @Override
   public void signalReceptionEnd() {
     //System.out.println("SignalReceptionEnded for node: " + mote.getID() + " intf:" + interfered);
     if (isInterfered() || packetToMote == null) {
@@ -144,6 +149,7 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
     this.notifyObservers();
   }
 
+  @Override
   public boolean isTransmitting() {
     return isTransmitting;
   }
@@ -152,23 +158,28 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
     return transmissionEndTime;
   }
 
+  @Override
   public boolean isReceiving() {
     return isReceiving;
   }
 
+  @Override
   public int getChannel() {
     return radioChannel;
   }
 
+  @Override
   public Position getPosition() {
     return mote.getInterfaces().getPosition();
   }
 
+  @Override
   public RadioEvent getLastEvent() {
     return lastEvent;
   }
 
   /* Note: this must be called exactly as many times as the reception ended */
+  @Override
   public void interfereAnyReception() {
     interfered++;
     if (!isInterfered()) {
@@ -181,26 +192,32 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
     }
   }
 
+  @Override
   public boolean isInterfered() {
     return isInterfered;
   }
 
+  @Override
   public double getCurrentOutputPower() {
     return outputPower;
   }
 
+  @Override
   public int getOutputPowerIndicatorMax() {
     return outputPowerIndicator;
   }
 
+  @Override
   public int getCurrentOutputPowerIndicator() {
     return outputPowerIndicator;
   }
 
+  @Override
   public double getCurrentSignalStrength() {
     return signalStrength;
   }
 
+  @Override
   public void setCurrentSignalStrength(double signalStrength) {
     this.signalStrength = signalStrength;
   }
@@ -215,6 +232,7 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
    */
   public void startTransmittingPacket(final RadioPacket packet, final long duration) {
     Runnable startTransmission = new Runnable() {
+      @Override
       public void run() {
         if (isTransmitting) {
           logger.warn("Already transmitting, aborting new transmission");
@@ -238,6 +256,7 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
 
         /* Finish transmission */
         simulation.scheduleEvent(new MoteTimeEvent(mote) {
+          @Override
           public void execute(long t) {
             isTransmitting = false;
             lastEvent = RadioEvent.TRANSMISSION_FINISHED;
@@ -282,6 +301,7 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
     notifyObservers();
   }
 
+  @Override
   public JPanel getInterfaceVisualizer() {
     JPanel panel = new JPanel(new BorderLayout());
     Box box = Box.createVerticalBox();
@@ -300,6 +320,7 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
         "21", "22", "23", "24", "25", "26", "27", "28", "29", "30"
     });
     channelMenu.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         JComboBox m = (JComboBox) e.getSource();
         String s = (String) m.getSelectedItem();
@@ -317,6 +338,7 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
     }
     final JFormattedTextField outputPower = new JFormattedTextField(new Double(getCurrentOutputPower()));
     outputPower.addPropertyChangeListener("value", new PropertyChangeListener() {
+      @Override
       public void propertyChange(PropertyChangeEvent evt) {
         setOutputPower(((Number)outputPower.getValue()).doubleValue());
       }
@@ -332,6 +354,7 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
     box.add(outputPower);
 
     updateButton.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         ssLabel.setText("Signal strength (not auto-updated): "
             + String.format("%1.1f", getCurrentSignalStrength()) + " dBm");
@@ -339,6 +362,7 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
     });
 
     final Observer observer = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         if (isTransmitting()) {
           statusLabel.setText("Transmitting");
@@ -367,15 +391,18 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
     return panel;
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     /* TODO Save channel info? */
     /* TODO Save output power? */
     return null;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
   }
 
+  @Override
   public Mote getMote() {
     return mote;
   }
@@ -392,17 +419,21 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
     this.setChanged();
     this.notifyObservers();
   }
+  @Override
   public boolean isRadioOn() {
     return radioOn;
   }
 
   /* Noise source radio support */
+  @Override
   public int getNoiseLevel() {
     return noiseSignal;
   }
+  @Override
   public void addNoiseLevelListener(NoiseLevelListener l) {
     noiseListeners.add(l);
   }
+  @Override
   public void removeNoiseLevelListener(NoiseLevelListener l) {
     noiseListeners.remove(l);
   }
@@ -417,15 +448,19 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
     }
   }
 
+  @Override
   public double getDirection() {
     return 0;
   }
+  @Override
   public double getRelativeGain(double radians, double distance) {
     /* Simple sinus-based gain */
     return 5.0*Math.sin(5.0*radians)/(0.01*distance);
   }
+  @Override
   public void addDirectionChangeListener(DirectionChangeListener l) {
   }
+  @Override
   public void removeDirectionChangeListener(DirectionChangeListener l) {
   }
 

--- a/java/org/contikios/cooja/interfaces/ApplicationSerialPort.java
+++ b/java/org/contikios/cooja/interfaces/ApplicationSerialPort.java
@@ -22,16 +22,20 @@ public class ApplicationSerialPort extends SerialUI {
     dataReceived('\n');
   }
 
+  @Override
   public Mote getMote() {
     return mote;
   }
 
+  @Override
   public void writeArray(byte[] s) {
     ((AbstractApplicationMote) getMote()).writeArray(s);
   }
+  @Override
   public void writeByte(byte b) {
     ((AbstractApplicationMote)getMote()).writeByte(b);
   }
+  @Override
   public void writeString(String s) {
     ((AbstractApplicationMote)getMote()).writeString(s);
   }

--- a/java/org/contikios/cooja/interfaces/Battery.java
+++ b/java/org/contikios/cooja/interfaces/Battery.java
@@ -62,14 +62,18 @@ public class Battery extends MoteInterface {
   public Battery(Mote mote) {
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     return null;
   }
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
   }
+  @Override
   public JPanel getInterfaceVisualizer() {
     return null;
   }
+  @Override
   public void releaseInterfaceVisualizer(JPanel panel) {
   }
 

--- a/java/org/contikios/cooja/interfaces/Mote2MoteRelations.java
+++ b/java/org/contikios/cooja/interfaces/Mote2MoteRelations.java
@@ -83,6 +83,7 @@ public class Mote2MoteRelations extends MoteInterface {
   private Cooja gui;
 
   private Observer logObserver = new Observer() {
+    @Override
     public void update(Observable o, Object arg) {
       String msg = ((Log) o).getLastLogMessage();
       handleNewLog(msg);
@@ -96,6 +97,7 @@ public class Mote2MoteRelations extends MoteInterface {
     this.gui = mote.getSimulation().getCooja();
   }
 
+  @Override
   public void added() {
     super.added();
     
@@ -108,9 +110,11 @@ public class Mote2MoteRelations extends MoteInterface {
 
     /* Observe other motes: if removed, remove our relations to them too */
     mote.getSimulation().getEventCentral().addMoteCountListener(moteCountListener = new MoteCountListener() {
+      @Override
       public void moteWasAdded(Mote mote) {
         /* Ignored */
       }
+      @Override
       public void moteWasRemoved(Mote mote) {
         /* This mote was removed - cleanup by removed() */
         if (Mote2MoteRelations.this.mote == mote) {
@@ -127,6 +131,7 @@ public class Mote2MoteRelations extends MoteInterface {
     });
   }
   
+  @Override
   public void removed() {
     super.removed();
 
@@ -239,6 +244,7 @@ public class Mote2MoteRelations extends MoteInterface {
     }
   }
 
+  @Override
   public JPanel getInterfaceVisualizer() {
     JPanel panel = new JPanel();
     panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
@@ -249,6 +255,7 @@ public class Mote2MoteRelations extends MoteInterface {
 
     Observer observer;
     this.addObserver(observer = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         countLabel.setText("Mote has " + relations.size() + " mote relations");
       }
@@ -260,6 +267,7 @@ public class Mote2MoteRelations extends MoteInterface {
     return panel;
   }
 
+  @Override
   public void releaseInterfaceVisualizer(JPanel panel) {
     Observer observer = (Observer) panel.getClientProperty("intf_obs");
     if (observer == null) {
@@ -269,10 +277,12 @@ public class Mote2MoteRelations extends MoteInterface {
     this.deleteObserver(observer);
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     return null;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
   }
 

--- a/java/org/contikios/cooja/interfaces/MoteAttributes.java
+++ b/java/org/contikios/cooja/interfaces/MoteAttributes.java
@@ -85,6 +85,7 @@ public class MoteAttributes extends MoteInterface {
   private HashMap<String, Object> attributes = new HashMap<String, Object>();
 
   private Observer logObserver = new Observer() {
+    @Override
     public void update(Observable o, Object arg) {
       String msg = ((Log) o).getLastLogMessage();
       handleNewLog(msg);
@@ -95,6 +96,7 @@ public class MoteAttributes extends MoteInterface {
     this.mote = mote;
   }
 
+  @Override
   public void added() {
     super.added();
     
@@ -106,6 +108,7 @@ public class MoteAttributes extends MoteInterface {
     }
   }
   
+  @Override
   public void removed() {
     super.removed();
 
@@ -169,6 +172,7 @@ public class MoteAttributes extends MoteInterface {
       return sb.toString();
   }
   
+  @Override
   public JPanel getInterfaceVisualizer() {
     JPanel panel = new JPanel();
     panel.setLayout(new BorderLayout());
@@ -180,6 +184,7 @@ public class MoteAttributes extends MoteInterface {
 
     Observer observer;
     this.addObserver(observer = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
           attributes.setText(getText());
       }
@@ -191,6 +196,7 @@ public class MoteAttributes extends MoteInterface {
     return panel;
   }
 
+  @Override
   public void releaseInterfaceVisualizer(JPanel panel) {
     Observer observer = (Observer) panel.getClientProperty("intf_obs");
     if (observer == null) {
@@ -200,10 +206,12 @@ public class MoteAttributes extends MoteInterface {
     this.deleteObserver(observer);
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     return null;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
   }
 

--- a/java/org/contikios/cooja/interfaces/MoteID.java
+++ b/java/org/contikios/cooja/interfaces/MoteID.java
@@ -58,6 +58,7 @@ public abstract class MoteID extends MoteInterface {
    */
   public abstract void setMoteID(int id);
   
+  @Override
   public Collection<Element> getConfigXML() {
     ArrayList<Element> config = new ArrayList<Element>();
     Element element = new Element("id");
@@ -66,6 +67,7 @@ public abstract class MoteID extends MoteInterface {
     return config;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
     for (Element element : configXML) {
       if (element.getName().equals("id")) {

--- a/java/org/contikios/cooja/interfaces/Position.java
+++ b/java/org/contikios/cooja/interfaces/Position.java
@@ -131,6 +131,7 @@ public class Position extends MoteInterface {
     return getDistanceTo(m.getInterfaces().getPosition());
   }
 
+  @Override
   public JPanel getInterfaceVisualizer() {
     JPanel panel = new JPanel();
     panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
@@ -145,6 +146,7 @@ public class Position extends MoteInterface {
 
     Observer observer;
     this.addObserver(observer = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         positionLabel.setText("x=" + form.format(getXCoordinate()) + " "
             + "y=" + form.format(getYCoordinate()) + " "
@@ -158,6 +160,7 @@ public class Position extends MoteInterface {
     return panel;
   }
 
+  @Override
   public void releaseInterfaceVisualizer(JPanel panel) {
     Observer observer = (Observer) panel.getClientProperty("intf_obs");
     if (observer == null) {
@@ -168,6 +171,7 @@ public class Position extends MoteInterface {
     this.deleteObserver(observer);
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     Vector<Element> config = new Vector<Element>();
     Element element;
@@ -190,6 +194,7 @@ public class Position extends MoteInterface {
     return config;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
     double x = 0, y = 0, z = 0;
 

--- a/java/org/contikios/cooja/interfaces/Radio.java
+++ b/java/org/contikios/cooja/interfaces/Radio.java
@@ -227,6 +227,7 @@ public abstract class Radio extends MoteInterface {
   public abstract Mote getMote();
 
 
+  @Override
   public JPanel getInterfaceVisualizer() {
     JPanel panel = new JPanel(new BorderLayout());
     Box box = Box.createVerticalBox();
@@ -244,6 +245,7 @@ public abstract class Radio extends MoteInterface {
     box.add(channelLabel);
 
     updateButton.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         ssLabel.setText("Signal strength (not auto-updated): "
             + String.format("%1.1f", getCurrentSignalStrength()) + " dBm");
@@ -251,6 +253,7 @@ public abstract class Radio extends MoteInterface {
     });
 
     final Observer observer = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         if (isTransmitting()) {
           statusLabel.setText("Transmitting");
@@ -279,6 +282,7 @@ public abstract class Radio extends MoteInterface {
     return panel;
   }
 
+  @Override
   public void releaseInterfaceVisualizer(JPanel panel) {
     Observer observer = (Observer) panel.getClientProperty("intf_obs");
     if (observer == null) {

--- a/java/org/contikios/cooja/interfaces/RimeAddress.java
+++ b/java/org/contikios/cooja/interfaces/RimeAddress.java
@@ -100,6 +100,7 @@ public class RimeAddress extends MoteInterface {
     return addrString;
   }
 
+  @Override
   public JPanel getInterfaceVisualizer() {
     JPanel panel = new JPanel();
     final JLabel ipLabel = new JLabel();
@@ -110,6 +111,7 @@ public class RimeAddress extends MoteInterface {
 
     Observer observer;
     this.addObserver(observer = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         ipLabel.setText("Rime address: " + getAddressString());
       }
@@ -120,6 +122,7 @@ public class RimeAddress extends MoteInterface {
     return panel;
   }
 
+  @Override
   public void releaseInterfaceVisualizer(JPanel panel) {
     Observer observer = (Observer) panel.getClientProperty("intf_obs");
     if (observer == null) {
@@ -130,6 +133,7 @@ public class RimeAddress extends MoteInterface {
     this.deleteObserver(observer);
   }
 
+  @Override
   public void removed() {
     super.removed();
     if (memMonitor != null) {
@@ -137,10 +141,12 @@ public class RimeAddress extends MoteInterface {
     }
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     return null;
   }
 
+  @Override
   public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
   }
 }

--- a/java/org/contikios/cooja/motes/AbstractApplicationMoteType.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMoteType.java
@@ -85,6 +85,7 @@ public abstract class AbstractApplicationMoteType implements MoteType {
     this.description = "Application Mote Type #" + identifier;
   }
 
+  @Override
   public boolean configureAndInit(Container parentContainer, Simulation simulation, boolean visAvailable)
   throws MoteTypeCreationException {
     if (identifier == null) {
@@ -112,30 +113,37 @@ public abstract class AbstractApplicationMoteType implements MoteType {
     return true;
   }
 
+  @Override
   public String getIdentifier() {
     return identifier;
   }
 
+  @Override
   public void setIdentifier(String identifier) {
     this.identifier = identifier;
   }
 
+  @Override
   public String getDescription() {
     return description;
   }
 
+  @Override
   public void setDescription(String description) {
     this.description = description;
   }
 
+  @Override
   public Class<? extends MoteInterface>[] getMoteInterfaceClasses() {
     return moteInterfaceClasses;
   }
 
+  @Override
   public void setMoteInterfaceClasses(Class<? extends MoteInterface>[] moteInterfaces) {
     throw new RuntimeException("Can not change the mote interface classes");
   }
 
+  @Override
   public JComponent getTypeVisualizer() {
     StringBuilder sb = new StringBuilder();
     // Identifier
@@ -157,35 +165,43 @@ public abstract class AbstractApplicationMoteType implements MoteType {
     return label;
   }
 
+  @Override
   public File getContikiSourceFile() {
     return null; /* Contiki-independent */
   }
 
+  @Override
   public File getContikiFirmwareFile() {
     return null; /* Contiki-independent */
   }
 
+  @Override
   public void setContikiSourceFile(File file) {
     /* Contiki-independent */
   }
 
+  @Override
   public void setContikiFirmwareFile(File file) {
     /* Contiki-independent */
   }
 
+  @Override
   public String getCompileCommands() {
     /* Contiki-independent */
     return null;
   }
 
+  @Override
   public void setCompileCommands(String commands) {
     /* Contiki-independent */
   }
 
+  @Override
   public ProjectConfig getConfig() {
     return myConfig;
   }
 
+  @Override
   public Collection<Element> getConfigXML(Simulation simulation) {
     ArrayList<Element> config = new ArrayList<Element>();
     Element element;
@@ -201,6 +217,7 @@ public abstract class AbstractApplicationMoteType implements MoteType {
     return config;
   }
 
+  @Override
   public boolean setConfigXML(Simulation simulation,
       Collection<Element> configXML, boolean visAvailable)
   throws MoteTypeCreationException {
@@ -221,15 +238,19 @@ public abstract class AbstractApplicationMoteType implements MoteType {
     private int id = -1;
     public SimpleMoteID(Mote mote) {
     }
+    @Override
     public int getMoteID() {
       return id;
     }
+    @Override
     public void setMoteID(int newID) {
       this.id = newID;
     }
+    @Override
     public JPanel getInterfaceVisualizer() {
       return null;
     }
+    @Override
     public void releaseInterfaceVisualizer(JPanel panel) {
     }
   }

--- a/java/org/contikios/cooja/motes/AbstractWakeupMote.java
+++ b/java/org/contikios/cooja/motes/AbstractWakeupMote.java
@@ -46,15 +46,18 @@ public abstract class AbstractWakeupMote implements Mote {
   private long nextWakeupTime = -1;
 
   private final TimeEvent executeMoteEvent = new MoteTimeEvent(this) {
+    @Override
     public void execute(long t) {
       AbstractWakeupMote.this.execute(t);
     }
+    @Override
     public String toString() {
       return "EXECUTE " + AbstractWakeupMote.this.getClass().getName();
     }
   };
 
   
+  @Override
   public Simulation getSimulation() {
       return simulation;
   }
@@ -90,6 +93,7 @@ public abstract class AbstractWakeupMote implements Mote {
     else {
       /* Schedule wakeup asap */
       simulation.invokeSimulationThread(new Runnable() {
+        @Override
         public void run() {
           scheduleNextWakeup(t);
         }
@@ -140,16 +144,19 @@ public abstract class AbstractWakeupMote implements Mote {
     return true;
   }
 
+  @Override
   public void removed() {
   }
   
   private HashMap<String, Object> properties = null;
+  @Override
   public void setProperty(String key, Object obj) {
     if (properties == null) {
       properties = new HashMap<String, Object>();
     }
     properties.put(key, obj);
   }
+  @Override
   public Object getProperty(String key) {
     if (properties == null) {
       return null;

--- a/java/org/contikios/cooja/motes/DisturberMoteType.java
+++ b/java/org/contikios/cooja/motes/DisturberMoteType.java
@@ -72,6 +72,7 @@ public class DisturberMoteType extends AbstractApplicationMoteType {
     setDescription("Disturber Mote Type #" + identifier);
   }
 
+  @Override
   public boolean configureAndInit(Container parentContainer,
       Simulation simulation, boolean visAvailable) 
   throws MoteTypeCreationException {
@@ -82,6 +83,7 @@ public class DisturberMoteType extends AbstractApplicationMoteType {
     return true;
   }
   
+  @Override
   public Mote generateMote(Simulation simulation) {
     return new DisturberMote(this, simulation);
   }
@@ -102,6 +104,7 @@ public class DisturberMoteType extends AbstractApplicationMoteType {
       super(moteType, simulation);
     }
     
+    @Override
     public void execute(long time) {
       if (radio == null) {
         radio = (ApplicationRadio) getInterfaces().getRadio();
@@ -112,12 +115,15 @@ public class DisturberMoteType extends AbstractApplicationMoteType {
       radio.startTransmittingPacket(radioPacket, DURATION);
     }
 
+    @Override
     public void receivedPacket(RadioPacket p) {
       /* Ignore */
     }
+    @Override
     public void sentPacket(RadioPacket p) {
       /* Send another packet after a small pause */
       getSimulation().scheduleEvent(new MoteTimeEvent(this) {
+        @Override
         public void execute(long t) {
           /*logger.info("Sending another radio packet on channel: " + radio.getChannel());*/
           radio.startTransmittingPacket(radioPacket, DURATION);
@@ -125,6 +131,7 @@ public class DisturberMoteType extends AbstractApplicationMoteType {
       }, getSimulation().getSimulationTime() + DELAY);
     }
 
+    @Override
     public String toString() {
       return "Disturber " + getID();
     }

--- a/java/org/contikios/cooja/motes/ImportAppMoteType.java
+++ b/java/org/contikios/cooja/motes/ImportAppMoteType.java
@@ -74,6 +74,7 @@ public class ImportAppMoteType extends AbstractApplicationMoteType {
     setDescription("Imported App Mote Type #" + identifier);
   }
 
+  @Override
   public Collection<Element> getConfigXML(Simulation simulation) {
     Collection<Element> config = super.getConfigXML(simulation);
 
@@ -93,6 +94,7 @@ public class ImportAppMoteType extends AbstractApplicationMoteType {
     return config;
   }
 
+  @Override
   public boolean setConfigXML(Simulation simulation,
       Collection<Element> configXML, boolean visAvailable)
   throws MoteTypeCreationException {
@@ -110,6 +112,7 @@ public class ImportAppMoteType extends AbstractApplicationMoteType {
     return super.setConfigXML(simulation, configXML, visAvailable);
   }
 
+  @Override
   public boolean configureAndInit(Container parentContainer,
       Simulation simulation, boolean visAvailable)
   throws MoteTypeCreationException {
@@ -169,6 +172,7 @@ public class ImportAppMoteType extends AbstractApplicationMoteType {
     return mte;
   }
 
+  @Override
   public Mote generateMote(Simulation simulation) {
     try {
       return moteConstructor.newInstance(ImportAppMoteType.this, simulation);

--- a/java/org/contikios/cooja/plugins/BaseRSSIconf.java
+++ b/java/org/contikios/cooja/plugins/BaseRSSIconf.java
@@ -93,6 +93,7 @@ public class BaseRSSIconf extends VisPlugin {
 		radioMedium = (AbstractRadioMedium) sim.getRadioMedium();
 
 		changeObserver = new Observer() {
+			@Override
 			public void update(Observable obs, Object obj) {
 				logger.debug("Changed");
 				model.fireTableDataChanged();
@@ -108,6 +109,7 @@ public class BaseRSSIconf extends VisPlugin {
 		motesTable = new JTable(model) {
 			private static final long serialVersionUID = -4680013510092815210L;
 
+			@Override
 			public TableCellEditor getCellEditor(int row, int column) {
 				combo.removeAllItems();
 				if (column == IDX_Mote) {
@@ -130,6 +132,7 @@ public class BaseRSSIconf extends VisPlugin {
 				.setCellRenderer(new DefaultTableCellRenderer() { // TODO ????
 							private static final long serialVersionUID = 4470088575039698508L;
 
+							@Override
 							public void setValue(Object value) {
 								if (!(value instanceof Double)) {
 									setText(value.toString());
@@ -143,6 +146,7 @@ public class BaseRSSIconf extends VisPlugin {
 				.setCellRenderer(new DefaultTableCellRenderer() {
 					private static final long serialVersionUID = -7170745293267593460L;
 
+					@Override
 					public void setValue(Object value) {
 						if (!(value instanceof Double)) {
 							setText(value.toString());
@@ -172,6 +176,7 @@ public class BaseRSSIconf extends VisPlugin {
 	final AbstractTableModel model = new AbstractTableModel() {
 		private static final long serialVersionUID = 9101118401527171218L;
 
+		@Override
 		public String getColumnName(int column) {
 			if (column < 0 || column >= COLUMN_NAMES.length) {
 				return "";
@@ -179,14 +184,17 @@ public class BaseRSSIconf extends VisPlugin {
 			return COLUMN_NAMES[column];
 		}
 
+		@Override
 		public int getRowCount() {
 			return radioMedium.getRegisteredRadios().length;
 		}
 
+		@Override
 		public int getColumnCount() {
 			return COLUMN_NAMES.length;
 		}
 
+		@Override
 		public Object getValueAt(int row, int column) {
 			if (row < 0 || row >= radioMedium.getRegisteredRadios().length) {
 				return "";
@@ -204,6 +212,7 @@ public class BaseRSSIconf extends VisPlugin {
 			return "";
 		}
 
+		@Override
 		public void setValueAt(Object value, int row, int column) {
 			if (row < 0 || row >= radioMedium.getRegisteredRadios().length) {
 				return;
@@ -225,6 +234,7 @@ public class BaseRSSIconf extends VisPlugin {
 			}
 		}
 
+		@Override
 		public boolean isCellEditable(int row, int column) {
 			if (row < 0 || row >= radioMedium.getRegisteredRadios().length) {
 				return false;
@@ -243,11 +253,13 @@ public class BaseRSSIconf extends VisPlugin {
 			return false;
 		}
 
+		@Override
 		public Class<? extends Object> getColumnClass(int c) {
 			return getValueAt(0, c).getClass();
 		}
 	};
 
+	@Override
 	public void closePlugin() {
 		radioMedium.deleteRadioMediumObserver(changeObserver);
 		sim.deleteObserver(changeObserver);

--- a/java/org/contikios/cooja/plugins/DGRMConfigurator.java
+++ b/java/org/contikios/cooja/plugins/DGRMConfigurator.java
@@ -113,6 +113,7 @@ public class DGRMConfigurator extends VisPlugin {
 
     /* Listen for graph updates */
     radioMedium.addRadioTransmissionObserver(radioMediumObserver = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         model.fireTableDataChanged();
       }
@@ -121,7 +122,8 @@ public class DGRMConfigurator extends VisPlugin {
     /* Represent directed graph by table */
     graphTable = new JTable(model) {
 			private static final long serialVersionUID = -4680013510092815210L;
-			public TableCellEditor getCellEditor(int row, int column) {
+      @Override
+      public TableCellEditor getCellEditor(int row, int column) {
 				combo.removeAllItems();
         if (column == IDX_RATIO) {
           for (double d=1.0; d >= 0.0; d -= 0.1) {
@@ -148,7 +150,8 @@ public class DGRMConfigurator extends VisPlugin {
 
     graphTable.getColumnModel().getColumn(IDX_RATIO).setCellRenderer(new DefaultTableCellRenderer() {
 			private static final long serialVersionUID = 4470088575039698508L;
-			public void setValue(Object value) {
+      @Override
+      public void setValue(Object value) {
         if (!(value instanceof Double)) {
           setText(value.toString());
           return;
@@ -159,6 +162,7 @@ public class DGRMConfigurator extends VisPlugin {
     });
     graphTable.getColumnModel().getColumn(IDX_SIGNAL).setCellRenderer(new DefaultTableCellRenderer() {
 			private static final long serialVersionUID = -7170745293267593460L;
+			@Override
 			public void setValue(Object value) {
         if (!(value instanceof Long)) {
           setText(value.toString());
@@ -170,7 +174,8 @@ public class DGRMConfigurator extends VisPlugin {
     });
     graphTable.getColumnModel().getColumn(IDX_LQI).setCellRenderer(new DefaultTableCellRenderer() {
 		private static final long serialVersionUID = -4669897764928372246L;
-		public void setValue(Object value) {
+      @Override
+      public void setValue(Object value) {
 	    if (!(value instanceof Long)) {
 	      setText(value.toString());
 	      return;
@@ -181,7 +186,8 @@ public class DGRMConfigurator extends VisPlugin {
     });
     graphTable.getColumnModel().getColumn(IDX_DELAY).setCellRenderer(new DefaultTableCellRenderer() {
 			private static final long serialVersionUID = -4669897764928372246L;
-			public void setValue(Object value) {
+      @Override
+      public void setValue(Object value) {
         if (!(value instanceof Long)) {
           setText(value.toString());
           return;
@@ -201,6 +207,7 @@ public class DGRMConfigurator extends VisPlugin {
     JPanel southPanel = new JPanel(new GridLayout(1, 3));
     JButton button = new JButton("Add");
     button.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         doAddLink();
       }
@@ -208,6 +215,7 @@ public class DGRMConfigurator extends VisPlugin {
     southPanel.add(button);
     button = new JButton("Remove");
     button.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
       	doRemoveSelectedLink();
       }
@@ -217,6 +225,7 @@ public class DGRMConfigurator extends VisPlugin {
     southPanel.add(button);
     button = new JButton("Import");
     button.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
       	doImportFromFile();
       }
@@ -228,7 +237,8 @@ public class DGRMConfigurator extends VisPlugin {
     add(BorderLayout.SOUTH, southPanel);
 
     graphTable.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
-    	public void valueChanged(ListSelectionEvent e) {
+      @Override
+      public void valueChanged(ListSelectionEvent e) {
     		ListSelectionModel lsm = (ListSelectionModel)e.getSource();
     		if (e.getValueIsAdjusting()) {
     			return;
@@ -334,6 +344,7 @@ public class DGRMConfigurator extends VisPlugin {
 
 	private void importEdges(DirectedGraphMedium.Edge[] edges) {
 		Arrays.sort(edges, new Comparator<DirectedGraphMedium.Edge>() {
+			@Override
 			public int compare(Edge o1, Edge o2) {
 				return o1.source.getMote().getID() - o2.source.getMote().getID();
 			}
@@ -398,18 +409,22 @@ public class DGRMConfigurator extends VisPlugin {
 
   final AbstractTableModel model = new AbstractTableModel() {
 		private static final long serialVersionUID = 9101118401527171218L;
-		public String getColumnName(int column) {
+    @Override
+    public String getColumnName(int column) {
       if (column < 0 || column >= COLUMN_NAMES.length) {
         return "";
       }
       return COLUMN_NAMES[column];
     }
+    @Override
     public int getRowCount() {
       return radioMedium.getEdges().length;
     }
+    @Override
     public int getColumnCount() {
       return COLUMN_NAMES.length;
     }
+    @Override
     public Object getValueAt(int row, int column) {
       if (row < 0 || row >= radioMedium.getEdges().length) {
         return "";
@@ -438,6 +453,7 @@ public class DGRMConfigurator extends VisPlugin {
       }
       return "";
     }
+    @Override
     public void setValueAt(Object value, int row, int column) {
       if (row < 0 || row >= radioMedium.getEdges().length) {
         return;
@@ -466,6 +482,7 @@ public class DGRMConfigurator extends VisPlugin {
       }
     }
 
+    @Override
     public boolean isCellEditable(int row, int column) {
       if (row < 0 || row >= radioMedium.getEdges().length) {
         return false;
@@ -495,11 +512,13 @@ public class DGRMConfigurator extends VisPlugin {
       return false;
     }
 
+    @Override
     public Class<? extends Object> getColumnClass(int c) {
       return getValueAt(0, c).getClass();
     }
   };
 
+  @Override
   public void closePlugin() {
     radioMedium.deleteRadioTransmissionObserver(radioMediumObserver);
   }

--- a/java/org/contikios/cooja/plugins/EventListener.java
+++ b/java/org/contikios/cooja/plugins/EventListener.java
@@ -129,6 +129,7 @@ public class EventListener extends VisPlugin {
       myMote = mote;
     }
 
+    @Override
     public void update(Observable obs, Object obj) {
       final MoteInterface moteInterface = (MoteInterface) obs;
       int moteID = myMote.getID();
@@ -138,6 +139,7 @@ public class EventListener extends VisPlugin {
           + "'" + " changed at time "
           + myParent.mySimulation.getSimulationTime(), new AbstractAction(
           "View interface visualizer") {
+        @Override
         public void actionPerformed(ActionEvent e) {
           MoteInterfaceViewer plugin =
             (MoteInterfaceViewer) mySimulation.getCooja().tryStartPlugin(
@@ -153,6 +155,7 @@ public class EventListener extends VisPlugin {
       super(parent, objectToObserve);
     }
 
+    @Override
     public void update(Observable obs, Object obj) {
       myParent.actOnChange("'" + Cooja.getDescriptionOf(obs.getClass()) + "'"
           + " changed at time " + myParent.mySimulation.getSimulationTime(),
@@ -264,6 +267,7 @@ public class EventListener extends VisPlugin {
     mySimulation.stopSimulation();
 
     SwingUtilities.invokeLater(new Runnable() {
+      @Override
       public void run() {
         messageLabel.setText(message);
         actionButton.setAction(action);
@@ -273,6 +277,7 @@ public class EventListener extends VisPlugin {
   }
 
   private ActionListener interfaceCheckBoxListener = new ActionListener() {
+    @Override
     public void actionPerformed(ActionEvent e) {
       Class<? extends MoteInterface> interfaceClass = (Class<? extends MoteInterface>) ((JCheckBox) e
           .getSource()).getClientProperty("interface_class");
@@ -303,6 +308,7 @@ public class EventListener extends VisPlugin {
   };
 
   private ActionListener generalCheckBoxListener = new ActionListener() {
+    @Override
     public void actionPerformed(ActionEvent e) {
       Observable observable = (Observable) ((JCheckBox) e.getSource())
           .getClientProperty("observable");
@@ -323,6 +329,7 @@ public class EventListener extends VisPlugin {
     }
   };
 
+  @Override
   public void closePlugin() {
     // Remove all existing observers
     for (EventObserver obs : allObservers) {
@@ -330,6 +337,7 @@ public class EventListener extends VisPlugin {
     }
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     Vector<Element> config = new Vector<Element>();
 
@@ -362,6 +370,7 @@ public class EventListener extends VisPlugin {
     return config;
   }
 
+  @Override
   public boolean setConfigXML(Collection<Element> configXML, boolean visAvailable) {
 
     /* Load general observers */

--- a/java/org/contikios/cooja/plugins/LogListener.java
+++ b/java/org/contikios/cooja/plugins/LogListener.java
@@ -168,11 +168,13 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
   private static final int UPDATE_INTERVAL = 250;
   private UpdateAggregator<LogData> logUpdateAggregator = new UpdateAggregator<LogData>(UPDATE_INTERVAL) {
     private Runnable scroll = new Runnable() {
+      @Override
       public void run() {
         logTable.scrollRectToVisible(
             new Rectangle(0, logTable.getHeight() - 2, 1, logTable.getHeight()));
       }
     };
+    @Override
     protected void handle(List<LogData> ls) {
       boolean isVisible = true;
       if (logTable.getRowCount() > 0) {
@@ -236,6 +238,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
     colorCheckbox = new JCheckBoxMenuItem("Mote-specific coloring", backgroundColors);
     showMenu.add(colorCheckbox);
     colorCheckbox.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         backgroundColors = colorCheckbox.isSelected();
         repaint();
@@ -244,6 +247,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
     hideDebugCheckbox = new JCheckBoxMenuItem("Hide \"DEBUG: \" messages");
     showMenu.add(hideDebugCheckbox);
     hideDebugCheckbox.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         hideDebug = hideDebugCheckbox.isSelected();
         setFilter(getFilter());
@@ -253,6 +257,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
     inverseFilterCheckbox = new JCheckBoxMenuItem("Inverse filter");
     showMenu.add(inverseFilterCheckbox);
     inverseFilterCheckbox.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         inverseFilter = inverseFilterCheckbox.isSelected();
         if (inverseFilter) {
@@ -268,18 +273,22 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
 
     model = new AbstractTableModel() {
       private static final long serialVersionUID = 3065150390849332924L;
+      @Override
       public String getColumnName(int col) {
       	if (col == COLUMN_TIME && formatTimeString) {
     			return "Time";
       	}
         return COLUMN_NAMES[col];
       }
+      @Override
       public int getRowCount() {
         return logs.size();
       }
+      @Override
       public int getColumnCount() {
         return COLUMN_NAMES.length;
       }
+      @Override
       public Object getValueAt(int row, int col) {
         LogData log = logs.get(row);
         if (col == COLUMN_TIME) {
@@ -297,6 +306,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
 
     logTable = new JTable(model) {
       private static final long serialVersionUID = -930616018336483196L;
+      @Override
       public String getToolTipText(MouseEvent e) {
         java.awt.Point p = e.getPoint();
         int rowIndex = rowAtPoint(p);
@@ -323,6 +333,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
     };
     DefaultTableCellRenderer cellRenderer = new DefaultTableCellRenderer() {
       private static final long serialVersionUID = -340743275865216182L;
+      @Override
       public Component getTableCellRendererComponent(JTable table,
           Object value, boolean isSelected, boolean hasFocus, int row,
           int column) {
@@ -351,6 +362,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
     logTable.setAutoResizeMode(JTable.AUTO_RESIZE_LAST_COLUMN);
     logTable.setFont(new Font("Monospaced", Font.PLAIN, 12));
     logTable.addKeyListener(new KeyAdapter() {
+      @Override
       public void keyPressed(KeyEvent e) {
         if (e.getKeyCode() == KeyEvent.VK_SPACE) {
           showInAllAction.actionPerformed(null);
@@ -365,7 +377,8 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
 
     /* Toggle time format */
     logTable.getTableHeader().addMouseListener(new MouseAdapter() {
-    	public void mouseClicked(MouseEvent e) {
+      @Override
+      public void mouseClicked(MouseEvent e) {
         int colIndex = logTable.columnAtPoint(e.getPoint());
         int columnIndex = logTable.convertColumnIndexToModel(colIndex);
         if (columnIndex != COLUMN_TIME) {
@@ -376,7 +389,8 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
     	}
 		});
     logTable.addMouseListener(new MouseAdapter() {
-    	public void mouseClicked(MouseEvent e) {
+      @Override
+      public void mouseClicked(MouseEvent e) {
         int colIndex = logTable.columnAtPoint(e.getPoint());
         int columnIndex = logTable.convertColumnIndexToModel(colIndex);
         if (columnIndex != COLUMN_FROM) {
@@ -470,6 +484,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
         logs.add(data);
       }
       java.awt.EventQueue.invokeLater(new Runnable() {
+        @Override
         public void run() {
           model.fireTableDataChanged();
           logTable.scrollRectToVisible(
@@ -480,6 +495,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
 
     /* Column width adjustment */
     java.awt.EventQueue.invokeLater(new Runnable() {
+      @Override
       public void run() {
         /* Make sure this happens *after* adding history */
         adjuster.setDynamicAdjustment(true);
@@ -489,17 +505,21 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
     /* Start observing motes for new log output */
     logUpdateAggregator.start();
     simulation.getEventCentral().addLogOutputListener(logOutputListener = new LogOutputListener() {
+      @Override
       public void moteWasAdded(Mote mote) {
         /* Update title */
         updateTitle();
       }
+      @Override
       public void moteWasRemoved(Mote mote) {
         /* Update title */
         updateTitle();
       }
+      @Override
       public void newLogOutput(LogOutputEvent ev) {
         registerNewLogOutput(ev);
       }
+      @Override
       public void removedLogOutput(LogOutputEvent ev) {
       }
     });
@@ -513,12 +533,14 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
     filterPanel.add(filterLabel);
     filterPanel.add(filterTextField);
     filterTextField.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         String str = filterTextField.getText();
         setFilter(str);
 
         /* Autoscroll */
         SwingUtilities.invokeLater(new Runnable() {
+          @Override
           public void run() {
             int s = logTable.getSelectedRow();
             if (s < 0) {
@@ -582,6 +604,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
         + simulation.getEventCentral().getLogOutputObservationsCount() + " log interfaces");*/
   }
 
+  @Override
   public void closePlugin() {
     /* Stop observing motes */
     appendToFile(null, null);
@@ -589,6 +612,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
     simulation.getEventCentral().removeLogOutputListener(logOutputListener);
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     ArrayList<Element> config = new ArrayList<Element>();
     Element element;
@@ -621,12 +645,14 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
     return config;
   }
 
+  @Override
   public boolean setConfigXML(Collection<Element> configXML, boolean visAvailable) {
     for (Element element : configXML) {
       String name = element.getName();
       if ("filter".equals(name)) {
         final String str = element.getText();
         EventQueue.invokeLater(new Runnable() {
+          @Override
           public void run() {
             setFilter(str);
           }
@@ -674,7 +700,8 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
       	regexp = null;
       }
     	RowFilter<Object, Object> wrapped = new RowFilter<Object, Object>() {
-    		public boolean include(RowFilter.Entry<? extends Object, ? extends Object> entry) {
+        @Override
+        public boolean include(RowFilter.Entry<? extends Object, ? extends Object> entry) {
     		  if (regexp != null) {
     				boolean pass = regexp.include(entry);
     				if (inverseFilter && pass) {
@@ -704,6 +731,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
 
   public void trySelectTime(final long time) {
     java.awt.EventQueue.invokeLater(new Runnable() {
+      @Override
       public void run() {
         for (int i=0; i < logs.size(); i++) {
           if (logs.get(i).ev.getTime() < time) {
@@ -744,6 +772,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
   private Action saveAction = new AbstractAction("Save to file") {
     private static final long serialVersionUID = -4140706275748686944L;
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       JFileChooser fc = new JFileChooser();
       File suggest = new File(Cooja.getExternalToolsSetting("LOG_LISTENER_SAVEFILE", "loglistener.txt"));
@@ -832,6 +861,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
 
   private Action appendAction = new AbstractAction("Append to file") {
     private static final long serialVersionUID = -3041714249257346688L;
+    @Override
     public void actionPerformed(ActionEvent e) {
       JCheckBoxMenuItem cb = (JCheckBoxMenuItem) e.getSource();
       appendToFile = cb.isSelected();
@@ -872,6 +902,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
 
   private Action timeLineAction = new AbstractAction("Timeline") {
     private static final long serialVersionUID = -6358463434933029699L;
+    @Override
     public void actionPerformed(ActionEvent e) {
       int view = logTable.getSelectedRow();
       if (view < 0) {
@@ -895,6 +926,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
 
   private Action radioLoggerAction = new AbstractAction("Radio Logger") {
     private static final long serialVersionUID = -3041714249257346688L;
+    @Override
     public void actionPerformed(ActionEvent e) {
       int view = logTable.getSelectedRow();
       if (view < 0) {
@@ -922,6 +954,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
         putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_SPACE, 0, true));
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       timeLineAction.actionPerformed(null);
       radioLoggerAction.actionPerformed(null);
@@ -931,6 +964,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
   private Action clearAction = new AbstractAction("Clear all messages") {
     private static final long serialVersionUID = -2115620313183440224L;
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       clear();
     }
@@ -947,6 +981,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
   private Action copyAction = new AbstractAction("Copy selected") {
     private static final long serialVersionUID = -8433490108577001803L;
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
 
@@ -970,6 +1005,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
   private Action copyAllAction = new AbstractAction("Copy all data") {
     private static final long serialVersionUID = -5038884975254178373L;
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
 
@@ -991,6 +1027,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
   private Action copyAllMessagesAction = new AbstractAction("Copy all messages") {
     private static final long serialVersionUID = -5038884975254178373L;
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
 
@@ -1005,6 +1042,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
     }
   };
 
+  @Override
   public String getQuickHelp() {
     return
         "<b>Log Listener</b>" +
@@ -1031,12 +1069,15 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
 
     final LogData ld = new LogData(ev);
     RowFilter.Entry<? extends TableModel, ? extends Integer> entry = new RowFilter.Entry<TableModel, Integer>() {
+      @Override
       public TableModel getModel() {
         return model;
       }
+      @Override
       public int getValueCount() {
         return model.getColumnCount();
       }
+      @Override
       public Object getValue(int index) {
         if (index == COLUMN_TIME) {
           return ld.getTime();
@@ -1049,6 +1090,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
         }
         return null;
       }
+      @Override
       public Integer getIdentifier() {
         return null;
       }

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -69,10 +69,13 @@ public class LogScriptEngine {
 
   /* Log output listener */
   private LogOutputListener logOutputListener = new LogOutputListener() {
+    @Override
     public void moteWasAdded(Mote mote) {
     }
+    @Override
     public void moteWasRemoved(Mote mote) {
     }
+    @Override
     public void newLogOutput(LogOutputEvent ev) {
       handleNewMoteOutput(
           ev.getMote(),
@@ -81,6 +84,7 @@ public class LogScriptEngine {
           ev.msg
       );
     }
+    @Override
     public void removedLogOutput(LogOutputEvent ev) {
     }
   };
@@ -176,6 +180,7 @@ public class LogScriptEngine {
    */
   public void fakeMoteLogOutput(final String msg, final Mote mote) {
     simulation.invokeSimulationThread(new Runnable() {
+      @Override
       public void run() {
         handleNewMoteOutput(
             mote,
@@ -282,6 +287,7 @@ public class LogScriptEngine {
       logger.fatal("Error when creating engine: " + e.getMessage(), e);
     }
     ThreadGroup group = new ThreadGroup("script") {
+      @Override
       public void uncaughtException(Thread t, Throwable e) {
         while (e.getCause() != null) {
           e = e.getCause();
@@ -295,6 +301,7 @@ public class LogScriptEngine {
       }
     };
     scriptThread = new Thread(group, new Runnable() {
+      @Override
       public void run() {
         try {
           ((Invocable)engine).getInterface(Runnable.class).run();
@@ -346,6 +353,7 @@ public class LogScriptEngine {
     engine.put("node", scriptMote);
 
     Runnable activate = new Runnable() {
+      @Override
       public void run() {
         startRealTime = System.currentTimeMillis();
         startTime = simulation.getSimulationTime();
@@ -366,6 +374,7 @@ public class LogScriptEngine {
   }
 
   private final TimeEvent timeoutEvent = new TimeEvent() {
+    @Override
     public void execute(long t) {
       if (!scriptActive) {
         return;
@@ -377,6 +386,7 @@ public class LogScriptEngine {
     }
   };
   private final TimeEvent timeoutProgressEvent = new TimeEvent() {
+    @Override
     public void execute(long t) {
       nextProgress = t + timeout/20;
       simulation.scheduleEvent(this, nextProgress);
@@ -390,20 +400,24 @@ public class LogScriptEngine {
   };
 
   private Runnable stopSimulationRunnable = new Runnable() {
+    @Override
     public void run() {
       simulation.stopSimulation();
     }
   };
   private Runnable quitRunnable = new Runnable() {
+    @Override
     public void run() {
       simulation.stopSimulation();
       new Thread() {
+        @Override
         public void run() {
           try { Thread.sleep(500); } catch (InterruptedException e) { }
           simulation.getCooja().doQuit(false, exitCode);
         };
       }.start();
       new Thread() {
+        @Override
         public void run() {
           try { Thread.sleep(2000); } catch (InterruptedException e) { }
           logger.warn("Killing Cooja");
@@ -414,11 +428,13 @@ public class LogScriptEngine {
   };
 
   private ScriptLog scriptLog = new ScriptLog() {
+    @Override
     public void log(String msg) {
       if (scriptLogObserver != null) {
         scriptLogObserver.update(null, msg);
       }
     }
+    @Override
     public void append(String filename, String msg) {
       try{
         FileWriter fstream = new FileWriter(filename, true);
@@ -429,6 +445,7 @@ public class LogScriptEngine {
         logger.warn("Test append failed: " + filename + ": " + e.getMessage());
       }
     }
+    @Override
     public void writeFile(String filename, String msg) {
       try{
         FileWriter fstream = new FileWriter(filename, false);
@@ -440,11 +457,13 @@ public class LogScriptEngine {
       }
     }
 
+    @Override
     public void testOK() {
       exitCode = 0;
       log("TEST OK\n");
       deactive();
     }
+    @Override
     public void testFailed() {
       exitCode = 1;
       log("TEST FAILED\n");
@@ -465,9 +484,11 @@ public class LogScriptEngine {
       throw new RuntimeException("test script killed");
     }
 
+    @Override
     public void generateMessage(final long delay, final String msg) {
       final Mote currentMote = (Mote) engine.get("mote");
       final TimeEvent generateEvent = new TimeEvent() {
+        @Override
         public void execute(long t) {
           if (scriptThread == null ||
               !scriptThread.isAlive()) {
@@ -486,6 +507,7 @@ public class LogScriptEngine {
         }
       };
       simulation.invokeSimulationThread(new Runnable() {
+        @Override
         public void run() {
           simulation.scheduleEvent(
               generateEvent,

--- a/java/org/contikios/cooja/plugins/MoteInformation.java
+++ b/java/org/contikios/cooja/plugins/MoteInformation.java
@@ -113,6 +113,7 @@ public class MoteInformation extends VisPlugin implements MotePlugin {
     button = new JButton("Mote type information");
     button.setPreferredSize(size);
     button.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         simulation.getCooja().tryStartPlugin(MoteTypeInformation.class, simulation.getCooja(), simulation, mote);
       }
@@ -134,6 +135,7 @@ public class MoteInformation extends VisPlugin implements MotePlugin {
     button = new JButton("Mote interface viewer");
     button.setPreferredSize(size);
     button.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         simulation.getCooja().tryStartPlugin(MoteInterfaceViewer.class, simulation.getCooja(), simulation, mote);
       }
@@ -167,6 +169,7 @@ public class MoteInformation extends VisPlugin implements MotePlugin {
     button = new JButton("Remove");
     button.setPreferredSize(size);
     button.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         /* TODO In simulation event (if running) */
         simulation.removeMote(MoteInformation.this.mote);
@@ -184,9 +187,11 @@ public class MoteInformation extends VisPlugin implements MotePlugin {
     setSize(new Dimension(getWidth()+15, getHeight()+15));
   }
 
+  @Override
   public void closePlugin() {
   }
 
+  @Override
   public Mote getMote() {
     return mote;
   }

--- a/java/org/contikios/cooja/plugins/MoteInterfaceViewer.java
+++ b/java/org/contikios/cooja/plugins/MoteInterfaceViewer.java
@@ -102,6 +102,7 @@ public class MoteInterfaceViewer extends VisPlugin implements HasQuickHelp, Mote
     }
 
     selectInterfaceComboBox.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
 
         // Release old interface visualizer if any
@@ -177,6 +178,7 @@ public class MoteInterfaceViewer extends VisPlugin implements HasQuickHelp, Mote
     return false;
   }
 
+  @Override
   public void closePlugin() {
     // Release old interface visualizer if any
     if (selectedMoteInterface != null && currentInterfaceVisualizer != null) {
@@ -184,6 +186,7 @@ public class MoteInterfaceViewer extends VisPlugin implements HasQuickHelp, Mote
     }
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     Vector<Element> config = new Vector<Element>();
 
@@ -201,6 +204,7 @@ public class MoteInterfaceViewer extends VisPlugin implements HasQuickHelp, Mote
     return config;
   }
 
+  @Override
   public boolean setConfigXML(Collection<Element> configXML, boolean visAvailable) {
     for (Element element : configXML) {
       if (element.getName().equals("interface")) {
@@ -209,6 +213,7 @@ public class MoteInterfaceViewer extends VisPlugin implements HasQuickHelp, Mote
         String[] scrollPos = element.getText().split(",");
         final Point pos = new Point(Integer.parseInt(scrollPos[0]), Integer.parseInt(scrollPos[1]));
         EventQueue.invokeLater(new Runnable() {
+          @Override
           public void run()  {
             mainScrollPane.getViewport().setViewPosition(pos);
           }
@@ -218,6 +223,7 @@ public class MoteInterfaceViewer extends VisPlugin implements HasQuickHelp, Mote
     return true;
   }
 
+  @Override
   public String getQuickHelp() {
     String help = "<b>" + Cooja.getDescriptionOf(this) + "</b>";
     help += "<p>Lists mote interfaces, and allows mote inspection and interaction via mote interface visualizers.";
@@ -235,6 +241,7 @@ public class MoteInterfaceViewer extends VisPlugin implements HasQuickHelp, Mote
     return help;
   }
 
+  @Override
   public Mote getMote() {
     return mote;
   }

--- a/java/org/contikios/cooja/plugins/MoteTypeInformation.java
+++ b/java/org/contikios/cooja/plugins/MoteTypeInformation.java
@@ -80,6 +80,7 @@ public class MoteTypeInformation extends VisPlugin {
     nrMotesTypes = simulation.getMoteTypes().length;
 
     simulation.addObserver(simObserver = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         if (MoteTypeInformation.this.simulation.getMoteTypes().length == nrMotesTypes) {
           return;
@@ -120,6 +121,7 @@ public class MoteTypeInformation extends VisPlugin {
   }
 
 
+  @Override
   public void closePlugin() {
     simulation.deleteObserver(simObserver);
   }

--- a/java/org/contikios/cooja/plugins/Notes.java
+++ b/java/org/contikios/cooja/plugins/Notes.java
@@ -76,22 +76,26 @@ public class Notes extends VisPlugin {
       JMenuItem headerMenuItem = new JMenuItem("Toggle decorations");
       headerMenuItem.setEnabled(true);
       headerMenuItem.addActionListener(new ActionListener() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           setDecorationsVisible(!decorationsVisible);
         }
       });
       popup.add(headerMenuItem);
       notes.addMouseListener(new MouseAdapter() {
+        @Override
         public void mousePressed(MouseEvent e) {
           if (e.isPopupTrigger()) {
             popup.show(Notes.this, e.getX(), e.getY());
           }
         }
+        @Override
         public void mouseReleased(MouseEvent e) {
           if (e.isPopupTrigger()) {
             popup.show(Notes.this, e.getX(), e.getY());
           }
         }
+        @Override
         public void mouseClicked(MouseEvent e) {
           if (e.isPopupTrigger()) {
             popup.show(Notes.this, e.getX(), e.getY());
@@ -132,6 +136,7 @@ public class Notes extends VisPlugin {
 
     Notes.this.revalidate();
     SwingUtilities.invokeLater(new Runnable() {
+      @Override
       public void run() {
         Notes.this.repaint();
       }
@@ -140,6 +145,7 @@ public class Notes extends VisPlugin {
     decorationsVisible = visible;
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     ArrayList<Element> config = new ArrayList<Element>();
     Element element;
@@ -155,6 +161,7 @@ public class Notes extends VisPlugin {
     return config;
   }
 
+  @Override
   public boolean setConfigXML(Collection<Element> configXML, boolean visAvailable) {
     for (Element element : configXML) {
       if (element.getName().equals("notes")) {

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -146,6 +146,7 @@ public class ScriptRunner extends VisPlugin {
       final String file = EXAMPLE_SCRIPTS[i];
       JMenuItem exampleItem = new JMenuItem(EXAMPLE_SCRIPTS[i+1]);
       exampleItem.addActionListener(new ActionListener() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           String script = loadScript(file);
           if (script == null) {
@@ -185,6 +186,7 @@ public class ScriptRunner extends VisPlugin {
 
     final JCheckBoxMenuItem activateMenuItem = new JCheckBoxMenuItem("Activate");
     activateMenuItem.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent ev) {
         try {
           setScriptActive(!isActive());
@@ -198,6 +200,7 @@ public class ScriptRunner extends VisPlugin {
     final JMenuItem runTestMenuItem = new JMenuItem("Save simulation and run with script");
     runMenu.add(runTestMenuItem);
     runTestMenuItem.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         exportAndRun();
       }
@@ -211,13 +214,16 @@ public class ScriptRunner extends VisPlugin {
     );
 
     MenuListener toggleMenuItems = new MenuListener() {
+      @Override
       public void menuSelected(MenuEvent e) {
         activateMenuItem.setSelected(isActive());
         runTestMenuItem.setEnabled(!isActive());
         examplesMenu.setEnabled(!isActive());
       }
+      @Override
       public void menuDeselected(MenuEvent e) {
       }
+      @Override
       public void menuCanceled(MenuEvent e) {
       }
     };
@@ -278,6 +284,7 @@ public class ScriptRunner extends VisPlugin {
     }
   }
 
+  @Override
   public void startPlugin() {
 	/* start simulation */
 	if (!Cooja.isVisualized()) {
@@ -334,6 +341,7 @@ public class ScriptRunner extends VisPlugin {
       if (Cooja.isVisualized()) {
         /* Attach visualized log observer */
         engine.setScriptLogObserver(new Observer() {
+          @Override
           public void update(Observable obs, Object obj) {
             logTextArea.append((String) obj);
             logTextArea.setCaretPosition(logTextArea.getText().length());
@@ -353,6 +361,7 @@ public class ScriptRunner extends VisPlugin {
             logWriter.flush();
           }
           engine.setScriptLogObserver(new Observer() {
+            @Override
             public void update(Observable obs, Object obj) {
               try {
                 if (logWriter != null) {
@@ -507,6 +516,7 @@ public class ScriptRunner extends VisPlugin {
       /* GUI components */
       final MessageListUI testOutput = new MessageListUI();
       final AbstractAction abort = new AbstractAction() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           process.destroy();
           if (progressDialog.isDisplayable()) {
@@ -529,6 +539,7 @@ public class ScriptRunner extends VisPlugin {
       progressDialog.setSize(800, 300);
       progressDialog.setLocationRelativeTo(ScriptRunner.this);
       progressDialog.addWindowListener(new WindowAdapter() {
+        @Override
         public void windowClosed(WindowEvent e) {
           abort.actionPerformed(null);
         }
@@ -536,6 +547,7 @@ public class ScriptRunner extends VisPlugin {
       progressDialog.setVisible(true);
 
       Thread readInput = new Thread(new Runnable() {
+        @Override
         public void run() {
           String line;
           try {
@@ -584,6 +596,7 @@ public class ScriptRunner extends VisPlugin {
       });
 
       Thread readError = new Thread(new Runnable() {
+        @Override
         public void run() {
           String line;
           try {
@@ -621,6 +634,7 @@ public class ScriptRunner extends VisPlugin {
     logTextArea.setText("");
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     ArrayList<Element> config = new ArrayList<Element>();
     Element element;
@@ -646,6 +660,7 @@ public class ScriptRunner extends VisPlugin {
     return engine != null;
 
   }
+  @Override
   public void closePlugin() {
     try {
       setScriptActive(false);
@@ -653,6 +668,7 @@ public class ScriptRunner extends VisPlugin {
     }
   }
 
+  @Override
   public boolean setConfigXML(Collection<Element> configXML, boolean visAvailable) {
     for (Element element : configXML) {
       String name = element.getName();
@@ -697,6 +713,7 @@ public class ScriptRunner extends VisPlugin {
       super("linkfile");
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
       JMenuItem menuItem = (JMenuItem) e.getSource();
       Action action = menuItem.getAction();
@@ -718,6 +735,7 @@ public class ScriptRunner extends VisPlugin {
       fileChooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
       fileChooser.setDialogTitle("Select script file");
       fileChooser.setFileFilter(new FileFilter() {
+        @Override
         public boolean accept(File file) {
           if (file.isDirectory()) { return true; }
           if (file.getName().endsWith(".js")) {
@@ -725,6 +743,7 @@ public class ScriptRunner extends VisPlugin {
           }
           return false;
         }
+        @Override
         public String getDescription() {
           return "Javascript";
         }

--- a/java/org/contikios/cooja/plugins/SimControl.java
+++ b/java/org/contikios/cooja/plugins/SimControl.java
@@ -195,8 +195,10 @@ public class SimControl extends VisPlugin implements HasQuickHelp {
 
     /* Observe current simulation */
     simulation.addObserver(simObserver = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         SwingUtilities.invokeLater(new Runnable() {
+          @Override
           public void run() {
             updateValues();
           }
@@ -223,6 +225,7 @@ public class SimControl extends VisPlugin implements HasQuickHelp {
       super(name);
       this.maxSpeed = maxSpeed;
     }
+    @Override
     public void actionPerformed(ActionEvent e) {
       simulation.setSpeedLimit(maxSpeed);
     }
@@ -272,6 +275,7 @@ public class SimControl extends VisPlugin implements HasQuickHelp {
     }
   }
 
+  @Override
   public void closePlugin() {
     /* Remove simulation observer */
     if (simObserver != null) {
@@ -283,6 +287,7 @@ public class SimControl extends VisPlugin implements HasQuickHelp {
   }
 
   private Timer updateLabelTimer = new Timer(LABEL_UPDATE_INTERVAL, new ActionListener() {
+    @Override
     public void actionPerformed(ActionEvent e) {
       simulationTime.setText(getTimeString());
 
@@ -305,28 +310,33 @@ public class SimControl extends VisPlugin implements HasQuickHelp {
   });
 
   private Action startAction = new AbstractAction("Start") {
+    @Override
     public void actionPerformed(ActionEvent e) {
       simulation.startSimulation();
       stopButton.requestFocus();
     }
   };
   private Action stopAction = new AbstractAction("Pause") {
+    @Override
     public void actionPerformed(ActionEvent e) {
       simulation.stopSimulation();
       startButton.requestFocus();
     }
   };
   private Action stepAction = new AbstractAction("Step") {
+    @Override
     public void actionPerformed(ActionEvent e) {
       simulation.stepMillisecondSimulation();
     }
   };
   private Action reloadAction = new AbstractAction("Reload") {
+    @Override
     public void actionPerformed(ActionEvent e) {
       simulation.getCooja().reloadCurrentSimulation(simulation.isRunning());
     }
   };
 
+  @Override
   public String getQuickHelp() {
     return "<b>Control Panel</b>" +
         "<p>The control panel controls the simulation. " +

--- a/java/org/contikios/cooja/plugins/SimInformation.java
+++ b/java/org/contikios/cooja/plugins/SimInformation.java
@@ -195,6 +195,7 @@ public class SimInformation extends VisPlugin {
 
     // Register as simulation observer
     simulation.addObserver(simObserver = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         if (simulation == null) {
           return;
@@ -223,6 +224,7 @@ public class SimInformation extends VisPlugin {
 
   }
 
+  @Override
   public void closePlugin() {
     // Remove log observer from all log interfaces
     if (simObserver != null) {
@@ -234,6 +236,7 @@ public class SimInformation extends VisPlugin {
   }
 
   private Timer updateLabelTimer = new Timer(LABEL_UPDATE_INTERVAL, new ActionListener() {
+    @Override
     public void actionPerformed(ActionEvent e) {
       labelSimTime.setText("" + simulation.getSimulationTimeMillis());
 

--- a/java/org/contikios/cooja/plugins/TimeLine.java
+++ b/java/org/contikios/cooja/plugins/TimeLine.java
@@ -198,6 +198,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     zoomMenu.add(new JMenuItem(zoomSliderAction));
     viewMenu.add(new JCheckBoxMenuItem(executionDetailsAction) {
 	    private static final long serialVersionUID = 8314556794750277113L;
+	    @Override
 	    public boolean isSelected() {
       		return executionDetails;
 	    }
@@ -210,6 +211,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     showRadioTXRXCheckbox = createEventCheckbox("Radio traffic", "Show radio transmissions, receptions, and collisions");
     showRadioTXRXCheckbox.setName("showRadioRXTX");
     showRadioTXRXCheckbox.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         showRadioRXTX = ((JCheckBox) e.getSource()).isSelected();
         recalculateMoteHeight();
@@ -220,6 +222,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     showRadioOnoffCheckbox.setSelected(showRadioOnoff);
     showRadioOnoffCheckbox.setName("showRadioHW");
     showRadioOnoffCheckbox.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         showRadioOnoff = ((JCheckBox) e.getSource()).isSelected();
         recalculateMoteHeight();
@@ -230,6 +233,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     showRadioChannelsCheckbox.setSelected(showRadioChannels);
     showRadioChannelsCheckbox.setName("showRadioChannels");
     showRadioChannelsCheckbox.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         showRadioChannels = ((JCheckBox) e.getSource()).isSelected();
         recalculateMoteHeight();
@@ -240,6 +244,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     showLedsCheckBox.setSelected(showLeds);
     showLedsCheckBox.setName("showLEDs");
     showLedsCheckBox.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         showLeds = ((JCheckBox) e.getSource()).isSelected();
         recalculateMoteHeight();
@@ -250,6 +255,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     showLogsCheckBox.setSelected(showLogOutputs);
     showLogsCheckBox.setName("showLogOutput");
     showLogsCheckBox.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         showLogOutputs = ((JCheckBox) e.getSource()).isSelected();
         
@@ -272,6 +278,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     showWatchpointsCheckBox.setSelected(showWatchpoints);
     showWatchpointsCheckBox.setName("showWatchpoints");
     showWatchpointsCheckBox.addActionListener(new ActionListener() {
+      @Override
       public void actionPerformed(ActionEvent e) {
         showWatchpoints = ((JCheckBox) e.getSource()).isSelected();
         recalculateMoteHeight();
@@ -313,14 +320,18 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     /* Automatically add/delete motes.
      * This listener also observes mote log outputs. */
     simulation.getEventCentral().addLogOutputListener(newMotesListener = new LogOutputListener() {
+      @Override
       public void moteWasAdded(Mote mote) {
         addMote(mote);
       }
+      @Override
       public void moteWasRemoved(Mote mote) {
         removeMote(mote);
       }
+      @Override
       public void removedLogOutput(LogOutputEvent ev) {
       }
+      @Override
       public void newLogOutput(LogOutputEvent ev) {
         /* Log output */
         Mote mote = ev.getMote();
@@ -343,6 +354,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     repaintTimelineTimer.start();
 
     gui.addMoteHighlightObserver(moteHighlightObserver = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         if (!(obj instanceof Mote)) {
           return;
@@ -351,6 +363,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
         final Timer timer = new Timer(100, null);
         final Mote mote = (Mote) obj;
         timer.addActionListener(new ActionListener() {
+          @Override
           public void actionPerformed(ActionEvent e) {
             /* Count down */
             if (timer.getDelay() < 90) {
@@ -379,6 +392,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     this.setSize(gui.getDesktopPane().getWidth(), 166);
   }
 
+  @Override
   public void startPlugin() {
       super.startPlugin();
       
@@ -398,6 +412,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
 
   private Action removeMoteAction = new AbstractAction() {
     private static final long serialVersionUID = 2924285037480429045L;
+    @Override
     public void actionPerformed(ActionEvent e) {
       JComponent b = (JComponent) e.getSource();
       Mote m = (Mote) b.getClientProperty("mote");
@@ -406,7 +421,8 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
   };
   private Action removeAllOtherMotesAction = new AbstractAction() {
   	private static final long serialVersionUID = 2924285037480429045L;
-  	public void actionPerformed(ActionEvent e) {
+    @Override
+    public void actionPerformed(ActionEvent e) {
   		JComponent b = (JComponent) e.getSource();
   		Mote m = (Mote) b.getClientProperty("mote");
   		MoteEvents[] mes = allMoteEvents.toArray(new MoteEvents[0]);
@@ -420,6 +436,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
   };
   private Action sortMoteAction = new AbstractAction() {
     private static final long serialVersionUID = 621116674700872058L;
+    @Override
     public void actionPerformed(ActionEvent e) {
       JComponent b = (JComponent) e.getSource();
       Mote m = (Mote) b.getClientProperty("mote");
@@ -445,6 +462,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
   };
   private Action topMoteAction = new AbstractAction() {
 		private static final long serialVersionUID = 4683178751482241843L;
+		@Override
 		public void actionPerformed(ActionEvent e) {
   		JComponent b = (JComponent) e.getSource();
   		Mote m = (Mote) b.getClientProperty("mote");
@@ -464,6 +482,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
   };
   private Action addMoteAction = new AbstractAction("Show motes...") {
     private static final long serialVersionUID = 7546685285707302865L;
+    @Override
     public void actionPerformed(ActionEvent e) {
 
       JComboBox<Object> source = new JComboBox<Object>();
@@ -505,6 +524,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     lastRepaintSimulationTime = -1; /* Force repaint */
     repaintTimelineTimer.getActionListeners()[0].actionPerformed(null); /* Force size update*/
     SwingUtilities.invokeLater(new Runnable() {
+      @Override
       public void run() {
         int w = timeline.getVisibleRect().width;
 
@@ -589,6 +609,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
 
   private Action zoomInAction = new AbstractAction("Zoom in (Ctrl+)") {
     private static final long serialVersionUID = -2592452356547803615L;
+    @Override
     public void actionPerformed(ActionEvent e) {
       Rectangle r = timeline.getVisibleRect();
       int pixelX = r.x + r.width/2;
@@ -606,6 +627,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
 
   private Action zoomOutAction = new AbstractAction("Zoom out (Ctrl-)") {
     private static final long serialVersionUID = 6837091379835151725L;
+    @Override
     public void actionPerformed(ActionEvent e) {
       Rectangle r = timeline.getVisibleRect();
       int pixelX = r.x + r.width/2;
@@ -623,6 +645,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
 
   private Action zoomSliderAction = new AbstractAction("Zoom slider (Ctrl+Mouse)") {
     private static final long serialVersionUID = -4288046377707363837L;
+    @Override
     public void actionPerformed(ActionEvent e) {
       final int zoomLevel = zoomGetLevel();
       final JSlider zoomSlider = new JSlider(JSlider.VERTICAL, 0, ZOOM_LEVELS.length-1, zoomLevel);
@@ -633,6 +656,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       final long centerTime = (long) (popupLocation.x*currentPixelDivisor);
 
       zoomSlider.addChangeListener(new ChangeListener() {
+        @Override
         public void stateChanged(ChangeEvent e) {
           final int zoomLevel = zoomSlider.getValue();
           zoomFinishLevel(zoomLevel, centerTime, 0.5);
@@ -651,6 +675,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
    */
   private Action saveDataAction = new AbstractAction("Save to file...") {
     private static final long serialVersionUID = 975176793514425718L;
+    @Override
     public void actionPerformed(ActionEvent e) {
       JFileChooser fc = new JFileChooser();
       int returnVal = fc.showSaveDialog(Cooja.getTopParentContainer());
@@ -717,9 +742,11 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
 
   private Action clearAction = new AbstractAction("Clear all timeline data") {
     private static final long serialVersionUID = -4592530582786872403L;
+    @Override
     public void actionPerformed(ActionEvent e) {
       if (simulation.isRunning()) {
         simulation.invokeSimulationThread(new Runnable() {
+          @Override
           public void run() {
             clear();
           }
@@ -745,6 +772,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     long radioOn = 0;
     long onTimeRX = 0, onTimeTX = 0, onTimeInterfered = 0;
 
+    @Override
     public String toString() {
       return toString(true, true, true, true);
     }
@@ -773,6 +801,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
   }
   private Action statisticsAction = new AbstractAction("Print statistics to console") {
     private static final long serialVersionUID = 8671605486913497397L;
+    @Override
     public void actionPerformed(ActionEvent e) {
       if (simulation.isRunning()) {
         simulation.stopSimulation();
@@ -916,6 +945,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
 
   public void trySelectTime(final long toTime) {
     java.awt.EventQueue.invokeLater(new Runnable() {
+      @Override
       public void run() {
         /* Mark selected time in time ruler */
         final int toPixel = (int) (toTime / currentPixelDivisor);
@@ -937,6 +967,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
 
   private Action radioLoggerAction = new AbstractAction("Show in " + Cooja.getDescriptionOf(RadioLogger.class)) {
     private static final long serialVersionUID = 7690116136861949864L;
+    @Override
     public void actionPerformed(ActionEvent e) {
       if (popupLocation == null) {
         return;
@@ -957,6 +988,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
   };
   private Action logListenerAction = new AbstractAction("Show in " + Cooja.getDescriptionOf(LogListener.class)) {
     private static final long serialVersionUID = -8626118368774023257L;
+    @Override
     public void actionPerformed(ActionEvent e) {
       if (popupLocation == null) {
         return;
@@ -978,6 +1010,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
 
   private Action showInAllAction = new AbstractAction("Show in " + Cooja.getDescriptionOf(LogListener.class) + " and " + Cooja.getDescriptionOf(RadioLogger.class)) {
     private static final long serialVersionUID = -2458733078524773995L;
+    @Override
     public void actionPerformed(ActionEvent e) {
       logListenerAction.actionPerformed(null);
       radioLoggerAction.actionPerformed(null);
@@ -987,6 +1020,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
   private boolean executionDetails = false;
   private Action executionDetailsAction = new AbstractAction("Show execution details in tooltips") {
     private static final long serialVersionUID = -8626118368774023257L;
+    @Override
     public void actionPerformed(ActionEvent e) {
     	executionDetails = !executionDetails;
     }
@@ -1063,6 +1097,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       );
       moteEvents.addLED(startupEv);
       Observer observer = new Observer() {
+        @Override
         public void update(Observable o, Object arg) {
           LEDEvent ev = new LEDEvent(
               simulation.getSimulationTime(),
@@ -1093,6 +1128,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       moteEvents.addRadioRXTX(startupRXTX);
       Observer observer = new Observer() {
         int lastChannel = -1;
+        @Override
         public void update(Observable o, Object arg) {
           RadioEvent radioEv = moteRadio.getLastEvent();
 
@@ -1173,6 +1209,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     if (mote instanceof WatchpointMote) {
       final WatchpointMote watchpointMote = ((WatchpointMote)mote);
       WatchpointListener listener = new WatchpointListener() {
+        @Override
         public void watchpointTriggered(Watchpoint watchpoint) {
           WatchpointEvent ev = new WatchpointEvent(simulation.getSimulationTime(), watchpoint);
 
@@ -1186,6 +1223,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
 
           moteEvents.addWatchpoint(ev);
         }
+        @Override
         public void watchpointsChanged() {
         }
       };
@@ -1266,6 +1304,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     }
   }
 
+  @Override
   public void closePlugin() {
     /* Remove repaint timer */
     repaintTimelineTimer.stop();
@@ -1283,6 +1322,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     activeMoteObservers.clear();
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     ArrayList<Element> config = new ArrayList<Element>();
     Element element;
@@ -1337,6 +1377,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     return config;
   }
 
+  @Override
   public boolean setConfigXML(Collection<Element> configXML, boolean visAvailable) {
     showRadioRXTX = false;
     showRadioChannels = false;
@@ -1414,13 +1455,15 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       JMenu advancedMenu = new JMenu("Advanced");
       advancedMenu.add(new JCheckBoxMenuItem(executionDetailsAction) {
 				private static final long serialVersionUID = 8314556794750277113L;
-				public boolean isSelected() {
+        @Override
+        public boolean isSelected() {
       		return executionDetails;
       	}
       });
 
       addMouseListener(new MouseAdapter() {
       	long lastClick = -1;
+        @Override
         public void mouseClicked(MouseEvent e) {
           if (e.isPopupTrigger()) {
             popupLocation = new Point(e.getX(), e.getY());
@@ -1449,12 +1492,14 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
           }
           lastClick = System.currentTimeMillis();
         }
+        @Override
         public void mousePressed(MouseEvent e) {
           if (e.isPopupTrigger()) {
             popupLocation = new Point(e.getX(), e.getY());
             popupMenu.show(Timeline.this, e.getX(), e.getY());
           }
         }
+        @Override
         public void mouseReleased(MouseEvent e) {
           if (e.isPopupTrigger()) {
             popupLocation = new Point(e.getX(), e.getY());
@@ -1470,6 +1515,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       private int zoomInitialMouseY;
       private long zoomCenterTime = -1;
       private double zoomCenter = -1;
+      @Override
       public void mouseDragged(MouseEvent e) {
         super.mouseDragged(e);
         if (e.isControlDown()) {
@@ -1502,6 +1548,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
           repaint();
         }
       }
+      @Override
       public void mousePressed(MouseEvent e) {
         if (e.isControlDown()) {
           /* Zoom with mouse */
@@ -1564,6 +1611,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
           popUpToolTip.show();
         }
       }
+      @Override
       public void mouseReleased(MouseEvent e) {
         zoomCenterTime = -1;
         if (popUpToolTip != null) {
@@ -1574,6 +1622,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
         mousePixelPositionX = -1;
         repaint();
       }
+      @Override
       public void mouseWheelMoved(MouseWheelEvent e) {
         if (e.isControlDown()) {
           final int nticks = e.getWheelRotation();
@@ -1587,6 +1636,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     };
 
     private final Color SEPARATOR_COLOR = new Color(220, 220, 220);
+    @Override
     public void paintComponent(Graphics g) {
       Rectangle bounds = g.getClipBounds();
       /*logger.info("Clip bounds: " + bounds);*/
@@ -1870,6 +1920,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       popupMenu.add(keepMoteOnlyItem);
 
       addMouseListener(new MouseAdapter() {
+        @Override
         public void mouseClicked(MouseEvent e) {
           Mote m = getMote(e.getPoint());
           if (m == null) {
@@ -1901,6 +1952,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       return null;
     }
 
+    @Override
     protected void paintComponent(Graphics g) {
       g.setColor(COLOR_BACKGROUND);
       g.fillRect(0, 0, getWidth(), getHeight());
@@ -1922,6 +1974,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       }
     }
 
+    @Override
     public String getToolTipText(MouseEvent event) {
       Point p = event.getPoint();
       Mote m = getMote(p);
@@ -1995,9 +2048,11 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     public NoHistoryEvent(long time) {
       super(time);
     }
+    @Override
     public Color getEventColor() {
       return Color.CYAN;
     }
+    @Override
     public String toString() {
       return "No events has been captured yet";
     }
@@ -2015,6 +2070,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       this(time, ev);
       this.details = details;
     }
+    @Override
     public Color getEventColor() {
       if (state == RXTXRadioEvent.IDLE) {
         return null;
@@ -2029,6 +2085,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
         return null;
       }
     }
+    @Override
     public String toString() {
       if (state == RXTXRadioEvent.IDLE) {
         return "Radio idle from " + time + "<br>";
@@ -2065,6 +2122,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       this.channel = channel;
       this.radioOn = radioOn;
     }
+    @Override
     public Color getEventColor() {
       if (channel >= 0) {
         if (!radioOn) {
@@ -2075,6 +2133,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       }
       return null;
     }
+    @Override
     public String toString() {
       String str = "Radio channel " + channel + "<br>";
       return str;
@@ -2090,12 +2149,14 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     public RadioHWEvent(long time, boolean on, int channel) {
     	this(time, on);
     }
+    @Override
     public Color getEventColor() {
     	if (on) {
     	    return Color.GRAY;
     	}
     	return null;
     }
+    @Override
     public String toString() {
       String str = "Radio HW was turned " + (on?"on":"off") + "<br>";
       return str;
@@ -2113,6 +2174,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       this.blue = blue;
       this.color = new Color(red?255:0, green?255:0, blue?255:0);
     }
+    @Override
     public Color getEventColor() {
       if (!red && !green && !blue) {
         return null;
@@ -2123,6 +2185,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       }
     }
     /* LEDs are painted in three lines */
+    @Override
     public void paintInterval(Graphics g, int lineHeightOffset, long end) {
       MoteEvent ev = this;
       while (ev != null && ev.time < end) {
@@ -2175,6 +2238,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
         ev = ev.next;
       }
     }
+    @Override
     public String toString() {
       return
       "LED state:<br>" +
@@ -2189,6 +2253,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       super(ev.getTime());
       this.logEvent = ev;
     }
+    @Override
     public Color getEventColor() {
       if (logEventFilterPlugin != null) {
         /* Ask log listener for event color to use */
@@ -2197,6 +2262,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       return Color.GRAY;
     }
     /* Default paint method */
+    @Override
     public void paintInterval(Graphics g, int lineHeightOffset, long end) {
       LogEvent ev = this;
       while (ev != null && ev.time < end) {
@@ -2232,6 +2298,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
         ev = (LogEvent) ev.next;
       }
     }
+    @Override
     public String toString() {
       return "Mote " + logEvent.getMote() + " says:<br>" + logEvent.getMessage() + "<br>";
     }
@@ -2242,6 +2309,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       super(time);
       this.watchpoint = watchpoint;
     }
+    @Override
     public Color getEventColor() {
       Color c = watchpoint.getColor();
       if (c == null) {
@@ -2249,6 +2317,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       }
       return c;
     }
+    @Override
     public String toString() {
       String desc = watchpoint.getDescription();
       desc = desc.replace("\n", "<br>");
@@ -2258,6 +2327,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     }
 
     /* Default paint method */
+    @Override
     public void paintInterval(Graphics g, int lineHeightOffset, long end) {
       MoteEvent ev = this;
       while (ev != null && ev.time < end) {
@@ -2411,6 +2481,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
 
   private long lastRepaintSimulationTime = -1;
   private Timer repaintTimelineTimer = new Timer(TIMELINE_UPDATE_INTERVAL, new ActionListener() {
+    @Override
     public void actionPerformed(ActionEvent e) {
       /* Only set new size if simulation time has changed */
       long now = simulation.getSimulationTime();
@@ -2455,6 +2526,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     }
   });
 
+  @Override
   public String getQuickHelp() {
     return
         "<b>Timeline</b>" +

--- a/java/org/contikios/cooja/plugins/skins/AddressVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/AddressVisualizerSkin.java
@@ -69,11 +69,13 @@ public class AddressVisualizerSkin implements VisualizerSkin {
   private Visualizer visualizer = null;
 
   private Observer addrObserver = new Observer() {
+    @Override
     public void update(Observable obs, Object obj) {
       visualizer.repaint();
     }
   };
   private MoteCountListener newMotesListener = new MoteCountListener() {
+    @Override
     public void moteWasAdded(Mote mote) {
       IPAddress ipAddr = mote.getInterfaces().getIPAddress();
       if (ipAddr != null) {
@@ -84,6 +86,7 @@ public class AddressVisualizerSkin implements VisualizerSkin {
         rimeAddr.addObserver(addrObserver);
       }
     }
+    @Override
     public void moteWasRemoved(Mote mote) {
       IPAddress ipAddr = mote.getInterfaces().getIPAddress();
       if (ipAddr != null) {
@@ -96,6 +99,7 @@ public class AddressVisualizerSkin implements VisualizerSkin {
     }
   };
 
+  @Override
   public void setActive(Simulation simulation, Visualizer vis) {
     this.simulation = simulation;
     this.visualizer = vis;
@@ -109,6 +113,7 @@ public class AddressVisualizerSkin implements VisualizerSkin {
     visualizer.registerMoteMenuAction(CopyAddressAction.class);
   }
 
+  @Override
   public void setInactive() {
     simulation.getEventCentral().removeMoteCountListener(newMotesListener);
     for (Mote m: simulation.getMotes()) {
@@ -119,10 +124,12 @@ public class AddressVisualizerSkin implements VisualizerSkin {
     visualizer.unregisterMoteMenuAction(CopyAddressAction.class);
   }
 
+  @Override
   public Color[] getColorOf(Mote mote) {
     return null;
   }
 
+  @Override
   public void paintBeforeMotes(Graphics g) {
   }
 
@@ -142,6 +149,7 @@ public class AddressVisualizerSkin implements VisualizerSkin {
     return null;
   }
   
+  @Override
   public void paintAfterMotes(Graphics g) {
     FontMetrics fm = g.getFontMetrics();
     g.setColor(Color.BLACK);
@@ -163,20 +171,24 @@ public class AddressVisualizerSkin implements VisualizerSkin {
   }
 
   public static class CopyAddressAction implements MoteMenuAction {
+    @Override
     public boolean isEnabled(Visualizer visualizer, Mote mote) {
       return true;
     }
 
+    @Override
     public String getDescription(Visualizer visualizer, Mote mote) {
       return "Copy address to clipboard: \"" + getMoteString(mote) + "\"";
     }
 
+    @Override
     public void doAction(Visualizer visualizer, Mote mote) {
       Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
       StringSelection stringSelection = new StringSelection(getMoteString(mote));
       clipboard.setContents(stringSelection, null);
     }
   };
+  @Override
   public Visualizer getVisualizer() {
     return visualizer;
   }

--- a/java/org/contikios/cooja/plugins/skins/AttributeVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/AttributeVisualizerSkin.java
@@ -63,17 +63,20 @@ public class AttributeVisualizerSkin implements VisualizerSkin {
   private Visualizer visualizer = null;
 
   private Observer attributesObserver = new Observer() {
+    @Override
     public void update(Observable obs, Object obj) {
       visualizer.repaint();
     }
   };
   private MoteCountListener newMotesListener = new MoteCountListener() {
+    @Override
     public void moteWasAdded(Mote mote) {
       MoteAttributes intf = mote.getInterfaces().getInterfaceOfType(MoteAttributes.class);
       if (intf != null) {
         intf.addObserver(attributesObserver);
       }
     }
+    @Override
     public void moteWasRemoved(Mote mote) {
       MoteAttributes intf = mote.getInterfaces().getInterfaceOfType(MoteAttributes.class);
       if (intf != null) {
@@ -82,6 +85,7 @@ public class AttributeVisualizerSkin implements VisualizerSkin {
     }
   };
 
+  @Override
   public void setActive(Simulation simulation, Visualizer vis) {
     this.simulation = simulation;
     this.visualizer = vis;
@@ -92,6 +96,7 @@ public class AttributeVisualizerSkin implements VisualizerSkin {
     }
   }
 
+  @Override
   public void setInactive() {
     simulation.getEventCentral().removeMoteCountListener(newMotesListener);
     for (Mote m: simulation.getMotes()) {
@@ -99,6 +104,7 @@ public class AttributeVisualizerSkin implements VisualizerSkin {
     }
   }
 
+  @Override
   public Color[] getColorOf(Mote mote) {
     String[] as = getAttributesStrings(mote);
     if (as == null) {
@@ -138,6 +144,7 @@ public class AttributeVisualizerSkin implements VisualizerSkin {
       return null;
     }
   }
+  @Override
   public void paintBeforeMotes(Graphics g) {
   }
 
@@ -154,6 +161,7 @@ public class AttributeVisualizerSkin implements VisualizerSkin {
     return text.split("\n");
   }
   
+  @Override
   public void paintAfterMotes(Graphics g) {
     FontMetrics fm = g.getFontMetrics();
     g.setColor(Color.BLACK);
@@ -197,6 +205,7 @@ public class AttributeVisualizerSkin implements VisualizerSkin {
     }
   }
 
+  @Override
   public Visualizer getVisualizer() {
     return visualizer;
   }

--- a/java/org/contikios/cooja/plugins/skins/GridVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/GridVisualizerSkin.java
@@ -54,17 +54,21 @@ public class GridVisualizerSkin implements VisualizerSkin {
 
   private Visualizer visualizer = null;
 
+  @Override
   public void setActive(Simulation simulation, Visualizer vis) {
     this.visualizer = vis;
   }
 
+  @Override
   public void setInactive() {
   }
 
+  @Override
   public Color[] getColorOf(Mote mote) {
     return null;
   }
 
+  @Override
   public void paintBeforeMotes(Graphics g) {
 
     /* Background grid every 10 meters */
@@ -116,9 +120,11 @@ public class GridVisualizerSkin implements VisualizerSkin {
     }
   }
 
+  @Override
   public void paintAfterMotes(Graphics g) {
   }
 
+  @Override
   public Visualizer getVisualizer() {
     return visualizer;
   }

--- a/java/org/contikios/cooja/plugins/skins/IDVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/IDVisualizerSkin.java
@@ -58,21 +58,26 @@ public class IDVisualizerSkin implements VisualizerSkin {
   private Simulation simulation = null;
   private Visualizer visualizer = null;
 
+  @Override
   public void setActive(Simulation simulation, Visualizer vis) {
     this.simulation = simulation;
     this.visualizer = vis;
   }
 
+  @Override
   public void setInactive() {
   }
 
+  @Override
   public Color[] getColorOf(Mote mote) {
     return null;
   }
 
+  @Override
   public void paintBeforeMotes(Graphics g) {
   }
 
+  @Override
   public void paintAfterMotes(Graphics g) {
     FontMetrics fm = g.getFontMetrics();
     g.setColor(Color.BLACK);
@@ -89,6 +94,7 @@ public class IDVisualizerSkin implements VisualizerSkin {
     }
   }
 
+  @Override
   public Visualizer getVisualizer() {
     return visualizer;
   }

--- a/java/org/contikios/cooja/plugins/skins/LEDVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/LEDVisualizerSkin.java
@@ -63,17 +63,20 @@ public class LEDVisualizerSkin implements VisualizerSkin {
   private Visualizer visualizer = null;
 
   private Observer ledObserver = new Observer() {
+    @Override
     public void update(Observable obs, Object obj) {
       visualizer.repaint();
     }
   };
   private MoteCountListener newMotesListener = new MoteCountListener() {
+    @Override
     public void moteWasAdded(Mote mote) {
       LED led = mote.getInterfaces().getLED();
       if (led != null) {
         led.addObserver(ledObserver);
       }
     }
+    @Override
     public void moteWasRemoved(Mote mote) {
       LED led = mote.getInterfaces().getLED();
       if (led != null) {
@@ -82,6 +85,7 @@ public class LEDVisualizerSkin implements VisualizerSkin {
     }
   };
 
+  @Override
   public void setActive(Simulation simulation, Visualizer vis) {
     this.simulation = simulation;
     this.visualizer = vis;
@@ -92,6 +96,7 @@ public class LEDVisualizerSkin implements VisualizerSkin {
     }
   }
 
+  @Override
   public void setInactive() {
     simulation.getEventCentral().removeMoteCountListener(newMotesListener);
     for (Mote m: simulation.getMotes()) {
@@ -99,13 +104,16 @@ public class LEDVisualizerSkin implements VisualizerSkin {
     }
   }
 
+  @Override
   public Color[] getColorOf(Mote mote) {
     return null;
   }
 
+  @Override
   public void paintBeforeMotes(Graphics g) {
   }
 
+  @Override
   public void paintAfterMotes(Graphics g) {
     /* Paint LEDs left of each mote */
     Mote[] allMotes = simulation.getMotes();
@@ -146,6 +154,7 @@ public class LEDVisualizerSkin implements VisualizerSkin {
     }
   }
 
+  @Override
   public Visualizer getVisualizer() {
     return visualizer;
   }

--- a/java/org/contikios/cooja/plugins/skins/LogVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/LogVisualizerSkin.java
@@ -68,19 +68,24 @@ public class LogVisualizerSkin implements VisualizerSkin {
   private Visualizer visualizer = null;
 
   private LogOutputListener logOutputListener = new LogOutputListener() {
+    @Override
     public void moteWasAdded(Mote mote) {
       visualizer.repaint();
     }
+    @Override
     public void moteWasRemoved(Mote mote) {
       visualizer.repaint();
     }
+    @Override
     public void newLogOutput(LogOutputEvent ev) {
       visualizer.repaint();
     }
+    @Override
     public void removedLogOutput(LogOutputEvent ev) {
     }
   };
 
+  @Override
   public void setActive(Simulation simulation, Visualizer vis) {
     this.simulation = simulation;
     this.visualizer = vis;
@@ -88,17 +93,21 @@ public class LogVisualizerSkin implements VisualizerSkin {
     simulation.getEventCentral().addLogOutputListener(logOutputListener);
   }
 
+  @Override
   public void setInactive() {
     simulation.getEventCentral().removeLogOutputListener(logOutputListener);
   }
 
+  @Override
   public Color[] getColorOf(Mote mote) {
     return null;
   }
 
+  @Override
   public void paintBeforeMotes(Graphics g) {
   }
 
+  @Override
   public void paintAfterMotes(Graphics g) {
     FontMetrics fm = g.getFontMetrics();
     g.setColor(Color.BLACK);
@@ -129,6 +138,7 @@ public class LogVisualizerSkin implements VisualizerSkin {
     }
   }
 
+  @Override
   public Visualizer getVisualizer() {
     return visualizer;
   }

--- a/java/org/contikios/cooja/plugins/skins/MoteTypeVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/MoteTypeVisualizerSkin.java
@@ -69,6 +69,7 @@ public class MoteTypeVisualizerSkin implements VisualizerSkin {
     new Color[] {Color.RED},
   };
   
+  @Override
   public void setActive(Simulation simulation, Visualizer vis) {
     this.simulation = simulation;
     this.visualizer = vis;
@@ -77,11 +78,13 @@ public class MoteTypeVisualizerSkin implements VisualizerSkin {
     visualizer.registerMoteMenuAction(DeleteAllAction.class);
   }
 
+  @Override
   public void setInactive() {
     /* Unregister menu actions */
     visualizer.unregisterMoteMenuAction(DeleteAllAction.class);
   }
 
+  @Override
   public Color[] getColorOf(Mote mote) {
     MoteType[] types = simulation.getMoteTypes();
     MoteType type = mote.getType();
@@ -93,21 +96,26 @@ public class MoteTypeVisualizerSkin implements VisualizerSkin {
     return null;
   }
 
+  @Override
   public void paintBeforeMotes(Graphics g) {
   }
 
+  @Override
   public void paintAfterMotes(Graphics g) {
   }
 
   public static class DeleteAllAction implements MoteMenuAction {
+    @Override
     public boolean isEnabled(Visualizer visualizer, Mote mote) {
       return true;
     }
 
+    @Override
     public String getDescription(Visualizer visualizer, Mote mote) {
       return "Delete all motes of type: " + mote.getType().getDescription();
     }
 
+    @Override
     public void doAction(Visualizer visualizer, Mote mote) {
       /* Remove all motes of this type */
       /* TODO Confirm? */
@@ -121,6 +129,7 @@ public class MoteTypeVisualizerSkin implements VisualizerSkin {
     }
   };
 
+  @Override
   public Visualizer getVisualizer() {
     return visualizer;
   }

--- a/java/org/contikios/cooja/plugins/skins/PositionVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/PositionVisualizerSkin.java
@@ -62,17 +62,20 @@ public class PositionVisualizerSkin implements VisualizerSkin {
   private Visualizer visualizer = null;
 
   private Observer positionObserver = new Observer() {
+    @Override
     public void update(Observable obs, Object obj) {
       visualizer.repaint();
     }
   };
   private MoteCountListener simObserver = new MoteCountListener() {
+    @Override
     public void moteWasAdded(Mote mote) {
       Position p = mote.getInterfaces().getPosition();
       if (p != null) {
         p.addObserver(positionObserver);
       }
     }
+    @Override
     public void moteWasRemoved(Mote mote) {
       Position p = mote.getInterfaces().getPosition();
       if (p != null) {
@@ -81,6 +84,7 @@ public class PositionVisualizerSkin implements VisualizerSkin {
     }
   };
 
+  @Override
   public void setActive(Simulation simulation, Visualizer vis) {
     this.simulation = simulation;
     this.visualizer = vis;
@@ -91,6 +95,7 @@ public class PositionVisualizerSkin implements VisualizerSkin {
     }
   }
 
+  @Override
   public void setInactive() {
     simulation.getEventCentral().removeMoteCountListener(simObserver);
     for (Mote m: simulation.getMotes()) {
@@ -98,13 +103,16 @@ public class PositionVisualizerSkin implements VisualizerSkin {
     }
   }
 
+  @Override
   public Color[] getColorOf(Mote mote) {
     return null;
   }
 
+  @Override
   public void paintBeforeMotes(Graphics g) {
   }
 
+  @Override
   public void paintAfterMotes(Graphics g) {
     g.setColor(Color.BLACK);
 
@@ -153,6 +161,7 @@ public class PositionVisualizerSkin implements VisualizerSkin {
     }
   }
 
+  @Override
   public Visualizer getVisualizer() {
     return visualizer;
   }

--- a/java/org/contikios/cooja/positioners/EllipsePositioner.java
+++ b/java/org/contikios/cooja/positioners/EllipsePositioner.java
@@ -66,6 +66,7 @@ public class EllipsePositioner extends Positioner {
     currentAngle = 0;
   }
 
+  @Override
   public double[] getNextPosition() {
     currentAngle += deltaAngle;
     return new double[] {

--- a/java/org/contikios/cooja/positioners/LinearPositioner.java
+++ b/java/org/contikios/cooja/positioners/LinearPositioner.java
@@ -122,6 +122,7 @@ public class LinearPositioner extends Positioner {
     this.addedInZ = 0;
   }
 
+  @Override
   public double[] getNextPosition() {
     double[] newPosition = new double[] {
         startX + addedInX*xInterval,

--- a/java/org/contikios/cooja/positioners/ManualPositioner.java
+++ b/java/org/contikios/cooja/positioners/ManualPositioner.java
@@ -91,6 +91,7 @@ public class ManualPositioner extends Positioner {
     }
   }
 
+  @Override
   public double[] getNextPosition() {
     /* Generate the rest randomly? */
     if (skipRemainder) {
@@ -149,16 +150,19 @@ public class ManualPositioner extends Positioner {
       panel.add(new JLabel("Z:"));
 
       FocusListener focusListener = new FocusListener() {
+        @Override
         public void focusGained(FocusEvent e) {
           final JFormattedTextField source = ((JFormattedTextField)e.getSource());
           SwingUtilities.invokeLater(
               new Runnable() {
+                @Override
                 public void run() {
                   source.selectAll();
                 }
               }
           );
         }
+        @Override
         public void focusLost(FocusEvent e) {
         }
       };
@@ -191,6 +195,7 @@ public class ManualPositioner extends Positioner {
 
       button = new JButton("Next");
       button.addActionListener(new ActionListener() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           dispose();
         }
@@ -200,6 +205,7 @@ public class ManualPositioner extends Positioner {
 
       button = new JButton("Skip remainder (random)");
       button.addActionListener(new ActionListener() {
+        @Override
         public void actionPerformed(ActionEvent e) {
           shouldSkipRemainder = true;
           dispose();

--- a/java/org/contikios/cooja/positioners/RandomPositioner.java
+++ b/java/org/contikios/cooja/positioners/RandomPositioner.java
@@ -66,6 +66,7 @@ public class RandomPositioner extends Positioner {
     this.endZ = endZ;
   }
 
+  @Override
   public double[] getNextPosition() {
     return new double[] {
         startX + random.nextDouble()*(endX - startX),

--- a/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
+++ b/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
@@ -222,6 +222,7 @@ public abstract class AbstractRadioMedium extends RadioMedium {
 	 * new transmissions.
 	 */
 	private Observer radioEventsObserver = new Observer() {
+		@Override
 		public void update(Observable obs, Object obj) {
 			if (!(obs instanceof Radio)) {
 				logger.fatal("Radio event dispatched by non-radio object");
@@ -275,6 +276,7 @@ public abstract class AbstractRadioMedium extends RadioMedium {
 							/* EXPERIMENTAL: Simulating propagation delay */
 							final Radio delayedRadio = r;
 							TimeEvent delayedEvent = new TimeEvent() {
+								@Override
 								public void execute(long t) {
 									delayedRadio.signalReceptionStart();
 								}
@@ -311,6 +313,7 @@ public abstract class AbstractRadioMedium extends RadioMedium {
 							/* EXPERIMENTAL: Simulating propagation delay */
 							final Radio delayedRadio = dstRadio;
 							TimeEvent delayedEvent = new TimeEvent() {
+								@Override
 								public void execute(long t) {
 									delayedRadio.signalReceptionEnd();
 								}
@@ -366,6 +369,7 @@ public abstract class AbstractRadioMedium extends RadioMedium {
 							final CustomDataRadio delayedRadio = (CustomDataRadio) dstRadio;
 							final Object delayedData = data;
 							TimeEvent delayedEvent = new TimeEvent() {
+								@Override
 								public void execute(long t) {
 									delayedRadio.receiveCustomData(delayedData);
 								}
@@ -412,6 +416,7 @@ public abstract class AbstractRadioMedium extends RadioMedium {
 							final Radio delayedRadio = dstRadio;
 							final RadioPacket delayedPacket = packet;
 							TimeEvent delayedEvent = new TimeEvent() {
+								@Override
 								public void execute(long t) {
 									delayedRadio.setReceivedPacket(delayedPacket);
 								}
@@ -429,14 +434,17 @@ public abstract class AbstractRadioMedium extends RadioMedium {
 		}
 	};
 	
+	@Override
 	public void registerMote(Mote mote, Simulation sim) {
 		registerRadioInterface(mote.getInterfaces().getRadio(), sim);
 	}
 	
+	@Override
 	public void unregisterMote(Mote mote, Simulation sim) {
 		unregisterRadioInterface(mote.getInterfaces().getRadio(), sim);
 	}
 	
+	@Override
 	public void registerRadioInterface(Radio radio, Simulation sim) {
 		if (radio == null) {
 			logger.warn("No radio to register");
@@ -451,6 +459,7 @@ public abstract class AbstractRadioMedium extends RadioMedium {
 		updateSignalStrengths();
 	}
 	
+	@Override
 	public void unregisterRadioInterface(Radio radio, Simulation sim) {
 		if (!registeredRadios.contains(radio)) {
 			logger.warn("No radio to unregister: " + radio);
@@ -537,14 +546,17 @@ public abstract class AbstractRadioMedium extends RadioMedium {
 	 * @see addRadioMediumObserver
 	 * @param observer the Observer to register
 	 */
+	@Override
 	public void addRadioTransmissionObserver(Observer observer) {
 		radioTransmissionObservable.addObserver(observer);
 	}
 	
+	@Override
 	public Observable getRadioTransmissionObservable() {
 		return radioTransmissionObservable;
 	}
 	
+	@Override
 	public void deleteRadioTransmissionObserver(Observer observer) {
 		radioTransmissionObservable.deleteObserver(observer);
 	}
@@ -572,9 +584,11 @@ public abstract class AbstractRadioMedium extends RadioMedium {
 		radioMediumObservable.deleteObserver(observer);
 	}
 	
+	@Override
 	public RadioConnection getLastConnection() {
 		return lastConnection;
 	}
+	@Override
 	public Collection<Element> getConfigXML() {
 		Collection<Element> config = new ArrayList<Element>();
 		for(Entry<Radio, Double> ent: baseRssi.entrySet()){
@@ -596,11 +610,13 @@ public abstract class AbstractRadioMedium extends RadioMedium {
 	
 	private Collection<Element> delayedConfiguration = null;
 	
+	@Override
 	public boolean setConfigXML(final Collection<Element> configXML, boolean visAvailable) {
 		delayedConfiguration = configXML;
 		return true;
 	}
 	
+	@Override
 	public void simulationFinishedLoading() {
 		if (delayedConfiguration == null) {
 			return;

--- a/java/org/contikios/cooja/radiomediums/DGRMDestinationRadio.java
+++ b/java/org/contikios/cooja/radiomediums/DGRMDestinationRadio.java
@@ -55,6 +55,7 @@ public class DGRMDestinationRadio extends DestinationRadio {
 		return channel;
 	}
 
+	@Override
 	protected Object clone() {
 		DGRMDestinationRadio clone = new DGRMDestinationRadio(this.radio);
 		clone.ratio = this.ratio;
@@ -65,6 +66,7 @@ public class DGRMDestinationRadio extends DestinationRadio {
 		return clone;
 	}
 	
+	@Override
 	public Collection<Element> getConfigXML() {
 		Collection<Element> config = super.getConfigXML();
 		Element element;
@@ -92,6 +94,7 @@ public class DGRMDestinationRadio extends DestinationRadio {
 		return config;
 	}
 	
+	@Override
 	public boolean setConfigXML(final Collection<Element> configXML, Simulation simulation) {
 		if (!super.setConfigXML(configXML, simulation)) {
 			return false;

--- a/java/org/contikios/cooja/radiomediums/DestinationRadio.java
+++ b/java/org/contikios/cooja/radiomediums/DestinationRadio.java
@@ -50,6 +50,7 @@ public class DestinationRadio {
 		this.radio = dest;
 	}
 
+	@Override
 	public String toString() {
 		return radio.getMote().toString();
 	}

--- a/java/org/contikios/cooja/radiomediums/DirectedGraphMedium.java
+++ b/java/org/contikios/cooja/radiomediums/DirectedGraphMedium.java
@@ -86,6 +86,7 @@ public class DirectedGraphMedium extends AbstractRadioMedium {
     requestEdgeAnalysis();
   }
 
+  @Override
   public void removed() {
     super.removed();
   }
@@ -132,6 +133,7 @@ public class DirectedGraphMedium extends AbstractRadioMedium {
     return edgesDirty;
   }
 
+  @Override
   public void unregisterRadioInterface(Radio radio, Simulation sim) {
     super.unregisterRadioInterface(radio, sim);
 
@@ -145,6 +147,7 @@ public class DirectedGraphMedium extends AbstractRadioMedium {
 
 
   
+  @Override
   public void updateSignalStrengths() {
 
     /* Reset signal strengths (Default: SS_NOTHING) */
@@ -242,6 +245,7 @@ public class DirectedGraphMedium extends AbstractRadioMedium {
     return edgesTable.get(source);
   }
 
+  @Override
   public RadioConnection createConnections(Radio source) {
     if (edgesDirty) {
       analyzeEdges();
@@ -334,6 +338,7 @@ public class DirectedGraphMedium extends AbstractRadioMedium {
     return newConn;
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     Collection<Element> config = super.getConfigXML();
 
@@ -348,6 +353,7 @@ public class DirectedGraphMedium extends AbstractRadioMedium {
   }
 
   private Collection<Element> delayedConfiguration = null;
+  @Override
   public boolean setConfigXML(Collection<Element> configXML, boolean visAvailable) {
     super.setConfigXML(configXML, visAvailable);
 
@@ -358,7 +364,8 @@ public class DirectedGraphMedium extends AbstractRadioMedium {
     return true;
   }
   
-public void simulationFinishedLoading() {
+  @Override
+  public void simulationFinishedLoading() {
     if (delayedConfiguration == null) {
       return;
     }

--- a/java/org/contikios/cooja/radiomediums/LogisticLoss.java
+++ b/java/org/contikios/cooja/radiomediums/LogisticLoss.java
@@ -166,6 +166,7 @@ public class LogisticLoss extends AbstractRadioMedium {
         random = simulation.getRandomGenerator();
         sim = simulation;
         dgrm = new DirectedGraphMedium() {
+                @Override
                 protected void analyzeEdges() {
                     /* Create edges according to distances.
                      * XXX May be slow for mobile networks */
@@ -207,16 +208,19 @@ public class LogisticLoss extends AbstractRadioMedium {
         /* Register as position observer.
          * If any positions change, re-analyze potential receivers. */
         final Observer positionObserver = new Observer() {
+                @Override
                 public void update(Observable o, Object arg) {
                     dgrm.requestEdgeAnalysis();
                 }
             };
         /* Re-analyze potential receivers if radios are added/removed. */
         simulation.getEventCentral().addMoteCountListener(new MoteCountListener() {
+                @Override
                 public void moteWasAdded(Mote mote) {
                     mote.getInterfaces().getPosition().addObserver(positionObserver);
                     dgrm.requestEdgeAnalysis();
                 }
+                @Override
                 public void moteWasRemoved(Mote mote) {
                     mote.getInterfaces().getPosition().deleteObserver(positionObserver);
                     dgrm.requestEdgeAnalysis();
@@ -231,12 +235,14 @@ public class LogisticLoss extends AbstractRadioMedium {
         Visualizer.registerVisualizerSkin(LogisticLossVisualizerSkin.class);
     }
 
+    @Override
     public void removed() {
         super.removed();
 
         Visualizer.unregisterVisualizerSkin(LogisticLossVisualizerSkin.class);
     }
   
+    @Override
     public RadioConnection createConnections(Radio sender) {
         RadioConnection newConnection = new RadioConnection(sender);
 
@@ -405,6 +411,7 @@ public class LogisticLoss extends AbstractRadioMedium {
         }
     }
 
+    @Override
     public void updateSignalStrengths() {
         /* Override: uses distance as signal strength factor */
 
@@ -468,6 +475,7 @@ public class LogisticLoss extends AbstractRadioMedium {
         }
     }
 
+    @Override
     public Collection<Element> getConfigXML() {
         Collection<Element> config = super.getConfigXML();
         Element element;
@@ -520,6 +528,7 @@ public class LogisticLoss extends AbstractRadioMedium {
         return config;
     }
 
+    @Override
     public boolean setConfigXML(Collection<Element> configXML, boolean visAvailable) {
         super.setConfigXML(configXML, visAvailable);
         for (Element element : configXML) {

--- a/java/org/contikios/cooja/radiomediums/SilentRadioMedium.java
+++ b/java/org/contikios/cooja/radiomediums/SilentRadioMedium.java
@@ -47,18 +47,22 @@ public class SilentRadioMedium extends AbstractRadioMedium {
     super(simulation);
   }
 
+  @Override
   public RadioConnection createConnections(Radio radio) {
     return null;
   }
   
+  @Override
   public void updateSignalStrengths() {
   }
   
 
+  @Override
   public Collection<Element> getConfigXML() {
     return null;
   }
   
+  @Override
   public boolean setConfigXML(Collection<Element> configXML, boolean visAvailable) {
     return true;
   }

--- a/java/org/contikios/cooja/radiomediums/UDGM.java
+++ b/java/org/contikios/cooja/radiomediums/UDGM.java
@@ -96,6 +96,7 @@ public class UDGM extends AbstractRadioMedium {
     super(simulation);
     random = simulation.getRandomGenerator();
     dgrm = new DirectedGraphMedium() {
+      @Override
       protected void analyzeEdges() {
         /* Create edges according to distances.
          * XXX May be slow for mobile networks */
@@ -124,16 +125,19 @@ public class UDGM extends AbstractRadioMedium {
     /* Register as position observer.
      * If any positions change, re-analyze potential receivers. */
     final Observer positionObserver = new Observer() {
+      @Override
       public void update(Observable o, Object arg) {
         dgrm.requestEdgeAnalysis();
       }
     };
     /* Re-analyze potential receivers if radios are added/removed. */
     simulation.getEventCentral().addMoteCountListener(new MoteCountListener() {
+      @Override
       public void moteWasAdded(Mote mote) {
         mote.getInterfaces().getPosition().addObserver(positionObserver);
         dgrm.requestEdgeAnalysis();
       }
+      @Override
       public void moteWasRemoved(Mote mote) {
         mote.getInterfaces().getPosition().deleteObserver(positionObserver);
         dgrm.requestEdgeAnalysis();
@@ -148,6 +152,7 @@ public class UDGM extends AbstractRadioMedium {
     Visualizer.registerVisualizerSkin(UDGMVisualizerSkin.class);
   }
 
+  @Override
   public void removed() {
   	super.removed();
   	
@@ -164,6 +169,7 @@ public class UDGM extends AbstractRadioMedium {
     dgrm.requestEdgeAnalysis();
   }
 
+  @Override
   public RadioConnection createConnections(Radio sender) {
     RadioConnection newConnection = new RadioConnection(sender);
 
@@ -279,6 +285,7 @@ public class UDGM extends AbstractRadioMedium {
     return 1.0 - ratio*(1.0-SUCCESS_RATIO_RX);
   }
 
+  @Override
   public void updateSignalStrengths() {
     /* Override: uses distance as signal strength factor */
     
@@ -348,6 +355,7 @@ public class UDGM extends AbstractRadioMedium {
     }
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     Collection<Element> config = super.getConfigXML();
     Element element;
@@ -375,6 +383,7 @@ public class UDGM extends AbstractRadioMedium {
     return config;
   }
 
+  @Override
   public boolean setConfigXML(Collection<Element> configXML, boolean visAvailable) {
     super.setConfigXML(configXML, visAvailable);
     for (Element element : configXML) {

--- a/java/org/contikios/cooja/radiomediums/UDGMConstantLoss.java
+++ b/java/org/contikios/cooja/radiomediums/UDGMConstantLoss.java
@@ -51,6 +51,7 @@ public class UDGMConstantLoss extends UDGM {
     super(simulation);
   }
 
+  @Override
   public double getRxSuccessProbability(Radio source, Radio dest) {
     double distance = source.getPosition().getDistanceTo(dest.getPosition());
     double moteTransmissionRange = TRANSMITTING_RANGE

--- a/java/org/contikios/cooja/util/ArrayQueue.java
+++ b/java/org/contikios/cooja/util/ArrayQueue.java
@@ -124,18 +124,22 @@ public class ArrayQueue<E> extends AbstractList<E> implements RandomAccess, Clon
     }
   }
 
+  @Override
   public int size() {
     return size;
   }
 
+  @Override
   public boolean isEmpty() {
     return size == 0;
   }
 
+  @Override
   public boolean contains(Object element) {
     return indexOf(element) >= 0;
   }
 
+  @Override
   public int indexOf(Object element) {
     return indexOf(element, 0);
   }
@@ -163,6 +167,7 @@ public class ArrayQueue<E> extends AbstractList<E> implements RandomAccess, Clon
     return -1;
   }
 
+  @Override
   public int lastIndexOf(Object element) {
     final int capacity = queueData.length;
     if (element == null) {
@@ -182,11 +187,13 @@ public class ArrayQueue<E> extends AbstractList<E> implements RandomAccess, Clon
     return -1;
   }
 
+  @Override
   public E get(int index) {
     // getPos() will ensure that the index is valid
     return queueData[getPos(index)];
   }
 
+  @Override
   public E set(int index, E element) {
     int pos = getPos(index);
     E oldValue = queueData[pos];
@@ -194,6 +201,7 @@ public class ArrayQueue<E> extends AbstractList<E> implements RandomAccess, Clon
     return oldValue;
   }
 
+  @Override
   public void add(int index, E element) {
     // Make sure there is space for the new element.
     ensureCapacity(size + 1);
@@ -232,6 +240,7 @@ public class ArrayQueue<E> extends AbstractList<E> implements RandomAccess, Clon
     }
   }
 
+  @Override
   public E remove(int index) {
     E value;
     // This method also checks that the index is valid
@@ -268,6 +277,7 @@ public class ArrayQueue<E> extends AbstractList<E> implements RandomAccess, Clon
     return value;
   }
 
+  @Override
   public boolean remove(Object element) {
     int index = indexOf(element);
     if (index >= 0) {
@@ -277,6 +287,7 @@ public class ArrayQueue<E> extends AbstractList<E> implements RandomAccess, Clon
     return false;
   }
 
+  @Override
   public void clear() {
     final int capacity = queueData.length;
     for (int i = 0; i < size; i++) {
@@ -290,7 +301,7 @@ public class ArrayQueue<E> extends AbstractList<E> implements RandomAccess, Clon
    * Returns a shallow copy of this queue (the elements themselves are not
    * copied).
    */
-  @SuppressWarnings("unchecked")
+  @Override @SuppressWarnings("unchecked")
   public ArrayQueue<E> clone() {
     try {
       ArrayQueue<E> v = (ArrayQueue<E>) super.clone();
@@ -305,13 +316,14 @@ public class ArrayQueue<E> extends AbstractList<E> implements RandomAccess, Clon
     }
   }
 
+  @Override
   public Object[] toArray() {
     Object[] array = new Object[size];
     copy(array);
     return array;
   }
 
-  @SuppressWarnings("unchecked")
+  @Override @SuppressWarnings("unchecked")
   public <T> T[] toArray(T[] array) {
     if (array.length < size) {
       array = (T[]) java.lang.reflect
@@ -331,6 +343,7 @@ public class ArrayQueue<E> extends AbstractList<E> implements RandomAccess, Clon
     throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
   }
 
+  @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append(getClass().getName()).append('[')

--- a/java/org/contikios/cooja/util/JSyntaxAddBreakpoint.java
+++ b/java/org/contikios/cooja/util/JSyntaxAddBreakpoint.java
@@ -50,6 +50,7 @@ public class JSyntaxAddBreakpoint extends DefaultSyntaxAction {
     super("addbreakpoint");
   }
   
+  @Override
   public void actionPerformed(ActionEvent e) {
     JMenuItem menuItem = (JMenuItem) e.getSource();
     Action action = menuItem.getAction();

--- a/java/org/contikios/cooja/util/JSyntaxRemoveBreakpoint.java
+++ b/java/org/contikios/cooja/util/JSyntaxRemoveBreakpoint.java
@@ -50,6 +50,7 @@ public class JSyntaxRemoveBreakpoint extends DefaultSyntaxAction {
     super("removebreakpoint");
   }
 
+  @Override
   public void actionPerformed(ActionEvent e) {
     JMenuItem menuItem = (JMenuItem) e.getSource();
     Action action = menuItem.getAction();

--- a/java/org/contikios/cooja/util/MoteSerialSocketConnection.java
+++ b/java/org/contikios/cooja/util/MoteSerialSocketConnection.java
@@ -71,6 +71,7 @@ public class MoteSerialSocketConnection {
     /* Simulated -> socket */
     motePort = (SerialPort) mote.getInterfaces().getLog();
     motePort.addSerialDataObserver(moteObserver = new Observer() {
+      @Override
       public void update(Observable obs, Object obj) {
         try {
           if (socketOut == null) {
@@ -99,6 +100,7 @@ public class MoteSerialSocketConnection {
     socketOut = new DataOutputStream(socket.getOutputStream());
     socketOut.flush();
     Thread socketThread = new Thread(new Runnable() {
+      @Override
       public void run() {
         int numRead = 0;
         byte[] data = new byte[16*1024];


### PR DESCRIPTION
This adds the @Override annotation to methods
that override a method. This will give compiler
warnings when renaming methods and forgetting
to rename the methods in the subclasses.

Since we are touching all these lines, also
replace tabs with spaces where it's reasonable
to do so.