### PR TITLE
build.xml: remove run64 target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -127,24 +127,6 @@ The COOJA Simulator
     </java>
   </target>
 
-  <target name="run64" depends="init, compile, jar, copy configs">
-    <java fork="yes" dir="${build}" classname="org.contikios.cooja.Cooja" maxmemory="512m">
-      <sysproperty key="user.language" value="en"/>
-      <jvmarg value="-d64 -XX:+ShowMessageBoxOnError"/>
-      <arg line="${args}"/>
-      <env key="LD_LIBRARY_PATH" value="."/>
-      <classpath>
-        <pathelement path="${build}"/>
-        <pathelement location="lib/jdom.jar"/>
-        <pathelement location="lib/log4j-core-${log4j.version}.jar"/>
-        <pathelement location="lib/log4j-api-${log4j.version}.jar"/>
-        <pathelement location="lib/log4j-1.2-api-${log4j.version}.jar" />
-        <pathelement location="lib/syntaxpane-1.2.0.jar"/>
-        <pathelement location="lib/swingx-all-1.6.4.jar"/>
-      </classpath>
-    </java>
-  </target>
-
   <target name="run_errorbox" depends="init, compile, jar, copy configs">
     <java fork="yes" dir="${build}" classname="org.contikios.cooja.Cooja" maxmemory="512m">
       <sysproperty key="user.language" value="en"/>


### PR DESCRIPTION
The JVM option -d64 was removed in Java 10,
and Java 10 was end of lifed in March 2018.