### PR TITLE
Add javadoc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 build
 /dist
+/javadoc
 /apps/mspsim/lib
 /apps/mrm/mrm.jar
 /apps/avrora/cooja-avrora.jar


### PR DESCRIPTION
This directory contains generated files
that should not be added to the repository.