### PR TITLE
Use UTF-8 as charset

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -28,6 +28,8 @@
 
 package org.contikios.cooja;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -61,9 +63,10 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
-import java.net.URL;
 import java.net.URI;
+import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.AccessControlException;
@@ -80,7 +83,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
-
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
@@ -117,17 +119,10 @@ import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 import javax.swing.filechooser.FileFilter;
-
 import org.apache.log4j.BasicConfigurator;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.apache.log4j.xml.DOMConfigurator;
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.JDOMException;
-import org.jdom.input.SAXBuilder;
-import org.jdom.output.Format;
-import org.jdom.output.XMLOutputter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.MoteType.MoteTypeCreationException;
 import org.contikios.cooja.VisPlugin.PluginRequiresVisualizationException;
 import org.contikios.cooja.contikimote.ContikiMoteType;
@@ -145,6 +140,12 @@ import org.contikios.cooja.plugins.SimControl;
 import org.contikios.cooja.plugins.SimInformation;
 import org.contikios.cooja.util.ExecuteJAR;
 import org.contikios.cooja.util.ScnObservable;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+import org.jdom.input.SAXBuilder;
+import org.jdom.output.Format;
+import org.jdom.output.XMLOutputter;
 
 /**
  * Main file of COOJA Simulator. Typically contains a visualizer for the
@@ -4512,7 +4513,7 @@ public class Cooja extends Observable {
         /* Load quickhelp.txt */
         try {
           quickHelpProperties = new Properties();
-          quickHelpProperties.load(new FileReader("quickhelp.txt"));
+          quickHelpProperties.load(Files.newBufferedReader(Paths.get("quickhelp.txt"), UTF_8));
         } catch (Exception e) {
           quickHelpProperties = null;
           help = "<html><b>Failed to read quickhelp.txt:</b><p>" + e.getMessage() + "</html>";

--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -28,11 +28,14 @@
 
 package org.contikios.cooja;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.*;
 import java.lang.reflect.*;
 import java.net.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Vector;
-
 import org.contikios.cooja.MoteType.MoteTypeCreationException;
 import org.contikios.cooja.contikimote.ContikiMoteType;
 import org.contikios.cooja.dialogs.MessageContainer;
@@ -140,14 +143,14 @@ public abstract class CoreComm {
           .getExternalToolsSetting("CORECOMM_TEMPLATE_FILENAME");
 
       if ((new File(mainTemplate)).exists()) {
-        reader = new FileReader(mainTemplate);
+        reader = Files.newBufferedReader(Paths.get(mainTemplate), UTF_8);
       } else {
         InputStream input = CoreComm.class
             .getResourceAsStream('/' + mainTemplate);
         if (input == null) {
           throw new FileNotFoundException(mainTemplate + " not found");
         }
-        reader = new InputStreamReader(input);
+        reader = new InputStreamReader(input, UTF_8);
       }
 
       templateFileReader = new BufferedReader(reader);
@@ -159,7 +162,7 @@ public abstract class CoreComm {
       }
 
       sourceFileWriter = new BufferedWriter(new OutputStreamWriter(
-          new FileOutputStream("org/contikios/cooja/corecomm/" + destFilename)));
+          new FileOutputStream("org/contikios/cooja/corecomm/" + destFilename), UTF_8));
 
       // Replace special fields in template
       String line;

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -29,6 +29,8 @@
  */
 package org.contikios.cooja.contikimote;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.Container;
 import java.io.BufferedReader;
 import java.io.File;
@@ -47,35 +49,32 @@ import java.util.Map;
 import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.swing.JComponent;
 import javax.swing.JLabel;
-
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
-
+import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.AbstractionLevelDescription;
 import org.contikios.cooja.ClassDescription;
-import org.contikios.cooja.CoreComm;
 import org.contikios.cooja.Cooja;
+import org.contikios.cooja.CoreComm;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.ProjectConfig;
-import org.contikios.cooja.mote.memory.SectionMoteMemory;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.dialogs.CompileContiki;
 import org.contikios.cooja.dialogs.ContikiMoteCompileDialog;
-import org.contikios.cooja.dialogs.MessageList;
 import org.contikios.cooja.dialogs.MessageContainer;
+import org.contikios.cooja.dialogs.MessageList;
 import org.contikios.cooja.mote.memory.ArrayMemory;
 import org.contikios.cooja.mote.memory.MemoryInterface;
 import org.contikios.cooja.mote.memory.MemoryInterface.Symbol;
 import org.contikios.cooja.mote.memory.MemoryLayout;
+import org.contikios.cooja.mote.memory.SectionMoteMemory;
 import org.contikios.cooja.mote.memory.UnknownVariableException;
 import org.contikios.cooja.mote.memory.VarMemory;
 import org.contikios.cooja.util.StringUtils;
+import org.jdom.Element;
 
 /**
  * The Cooja mote type holds the native library used to communicate with an
@@ -975,7 +974,7 @@ public class ContikiMoteType implements MoteType {
               libraryFile.getParentFile()
       );
       BufferedReader input = new BufferedReader(
-              new InputStreamReader(p.getInputStream())
+              new InputStreamReader(p.getInputStream(), UTF_8)
       );
       p.getErrorStream().close();
       while ((line = input.readLine()) != null) {

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiRS232.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiRS232.java
@@ -30,10 +30,11 @@
 
 package org.contikios.cooja.contikimote.interfaces;
 
-import java.util.Vector;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
-import org.apache.logging.log4j.Logger;
+import java.util.Vector;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.*;
 import org.contikios.cooja.contikimote.ContikiMote;
 import org.contikios.cooja.contikimote.ContikiMoteInterface;
@@ -108,7 +109,7 @@ public class ContikiRS232 extends SerialUI implements ContikiMoteInterface, Poll
 
   @Override
   public void writeString(String message) {
-    final byte[] dataToAppend = message.getBytes();
+    final byte[] dataToAppend = message.getBytes(UTF_8);
 
     mote.getSimulation().invokeSimulationThread(new Runnable() {
       @Override

--- a/java/org/contikios/cooja/dialogs/CompileContiki.java
+++ b/java/org/contikios/cooja/dialogs/CompileContiki.java
@@ -30,6 +30,8 @@
 
 package org.contikios.cooja.dialogs;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -41,15 +43,14 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.regex.Pattern;
 import java.util.regex.Matcher;
-
+import java.util.regex.Pattern;
 import javax.swing.Action;
-
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-
+import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.MoteType.MoteTypeCreationException;
@@ -148,9 +149,9 @@ public class CompileContiki {
       compileProcess = Runtime.getRuntime().exec(command, env, directory);
 
       final BufferedReader processNormal = new BufferedReader(
-          new InputStreamReader(compileProcess.getInputStream()));
+          new InputStreamReader(compileProcess.getInputStream(), UTF_8));
       final BufferedReader processError = new BufferedReader(
-          new InputStreamReader(compileProcess.getErrorStream()));
+          new InputStreamReader(compileProcess.getErrorStream(), UTF_8));
 
       if (outputFile != null) {
         if (outputFile.exists()) {
@@ -365,19 +366,19 @@ public class CompileContiki {
       Reader reader;
       String mainTemplate = Cooja.getExternalToolsSetting("CONTIKI_MAIN_TEMPLATE_FILENAME");
       if ((new File(mainTemplate)).exists()) {
-        reader = new FileReader(mainTemplate);
+        reader = Files.newBufferedReader(Paths.get(mainTemplate), UTF_8);
       } else {
         /* Try JAR, or fail */
         InputStream input = CompileContiki.class.getResourceAsStream('/' + mainTemplate);
         if (input == null) {
           throw new FileNotFoundException(mainTemplate + " not found");
         }
-        reader = new InputStreamReader(input);
+        reader = new InputStreamReader(input, UTF_8);
       }
 
       templateReader = new BufferedReader(reader);
       sourceFileWriter = new BufferedWriter(new OutputStreamWriter(
-          new FileOutputStream(sourceFile)));
+          new FileOutputStream(sourceFile), UTF_8));
 
       // Replace special fields in template
       String line;

--- a/java/org/contikios/cooja/dialogs/ConfigurationWizard.java
+++ b/java/org/contikios/cooja/dialogs/ConfigurationWizard.java
@@ -30,6 +30,8 @@
 
 package org.contikios.cooja.dialogs;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.BorderLayout;
 import java.awt.Container;
 import java.awt.Dimension;
@@ -49,9 +51,10 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.lang.reflect.Constructor;
-import java.util.Map;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
-
+import java.util.Map;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -63,14 +66,13 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JProgressBar;
 import javax.swing.JScrollPane;
-
-import org.contikios.cooja.CoreComm;
 import org.contikios.cooja.Cooja;
+import org.contikios.cooja.CoreComm;
 import org.contikios.cooja.MoteType.MoteTypeCreationException;
-import org.contikios.cooja.mote.memory.SectionMoteMemory;
 import org.contikios.cooja.contikimote.ContikiMoteType;
 import org.contikios.cooja.contikimote.ContikiMoteType.SectionParser;
 import org.contikios.cooja.mote.memory.MemoryInterface.Symbol;
+import org.contikios.cooja.mote.memory.SectionMoteMemory;
 import org.contikios.cooja.mote.memory.VarMemory;
 
 /* TODO Test common section */
@@ -559,15 +561,19 @@ public class ConfigurationWizard extends JDialog {
     BufferedReader templateReader = null;
     try {
       if ((new File(testTemplate)).exists()) {
-        templateReader = new BufferedReader(new FileReader(testTemplate));
+        templateReader = Files.newBufferedReader(Paths.get(testTemplate), UTF_8);
       } else {
         InputStream input = ConfigurationWizard.class.getResourceAsStream('/' + testTemplate);
         if (input == null) {
           throw new FileNotFoundException("File not found: " + testTemplate);
         }
-        templateReader = new BufferedReader(new InputStreamReader(input));
+        templateReader = new BufferedReader(new InputStreamReader(input, UTF_8));
       }
     } catch (FileNotFoundException e) {
+      e.printStackTrace(errorStream);
+      testOutput.addMessage("### Error: " + e.getMessage(), MessageList.ERROR);
+      return false;
+    } catch (IOException e) {
       e.printStackTrace(errorStream);
       testOutput.addMessage("### Error: " + e.getMessage(), MessageList.ERROR);
       return false;
@@ -589,7 +595,7 @@ public class ConfigurationWizard extends JDialog {
     }
     BufferedWriter cLibraryWriter = null;
     try {
-      cLibraryWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(cLibrarySourceFile)));
+      cLibraryWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(cLibrarySourceFile), UTF_8));
       String line;
       while ((line = templateReader.readLine()) != null) {
         line = line.replaceFirst("\\[CLASS_NAME\\]", javaLibraryName);

--- a/java/org/contikios/cooja/dialogs/MessageListUI.java
+++ b/java/org/contikios/cooja/dialogs/MessageListUI.java
@@ -30,6 +30,8 @@
 
 package org.contikios.cooja.dialogs;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -48,7 +50,6 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
-
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.DefaultListModel;
 import javax.swing.JCheckBoxMenuItem;
@@ -58,9 +59,8 @@ import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
 import javax.swing.ListModel;
 import javax.swing.ListSelectionModel;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-
+import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.Cooja;
 
 /**
@@ -132,7 +132,7 @@ public class MessageListUI extends JList implements MessageList {
     try {
       PipedInputStream input = new PipedInputStream();
       PipedOutputStream output = new PipedOutputStream(input);
-      final BufferedReader stringInput = new BufferedReader(new InputStreamReader(input));
+      final BufferedReader stringInput = new BufferedReader(new InputStreamReader(input, UTF_8));
 
       Thread readThread = new Thread(new Runnable() {
         @Override

--- a/java/org/contikios/cooja/interfaces/ApplicationSerialPort.java
+++ b/java/org/contikios/cooja/interfaces/ApplicationSerialPort.java
@@ -1,5 +1,7 @@
 package org.contikios.cooja.interfaces;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.dialogs.SerialUI;
 import org.contikios.cooja.motes.AbstractApplicationMote;
@@ -15,7 +17,7 @@ public class ApplicationSerialPort extends SerialUI {
    * @param log Trigger log event from application
    */
   public void triggerLog(String log) {
-    byte[] bytes = log.getBytes();
+    byte[] bytes = log.getBytes(UTF_8);
     for (byte b: bytes) {
       dataReceived(b);
     }

--- a/java/org/contikios/cooja/plugins/BufferListener.java
+++ b/java/org/contikios/cooja/plugins/BufferListener.java
@@ -29,6 +29,8 @@
 
 package org.contikios.cooja.plugins;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -51,12 +53,12 @@ import java.awt.event.MouseEvent;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.regex.PatternSyntaxException;
-
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.Box;
@@ -82,11 +84,8 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
-
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
-
+import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.Mote;
@@ -107,6 +106,7 @@ import org.contikios.cooja.motes.AbstractEmulatedMote;
 import org.contikios.cooja.util.ArrayQueue;
 import org.contikios.cooja.util.IPUtils;
 import org.contikios.cooja.util.StringUtils;
+import org.jdom.Element;
 
 /**
  * @author Fredrik Osterlind, Niclas Finne
@@ -1131,7 +1131,7 @@ public class BufferListener extends VisPlugin {
       }
 
       try {
-        PrintWriter outStream = new PrintWriter(new FileWriter(saveFile));
+        PrintWriter outStream = new PrintWriter(Files.newBufferedWriter(saveFile.toPath(), UTF_8));
 
         StringBuilder sb = new StringBuilder();
         for (int i=0; i < logTable.getRowCount(); i++) {
@@ -1670,7 +1670,7 @@ public class BufferListener extends VisPlugin {
       }
       byte[] termString = new byte[i];
       System.arraycopy(ba.mem, 0, termString, 0, i);
-      return new String(termString).replaceAll("[^\\p{Print}]", "");
+      return new String(termString, UTF_8).replaceAll("[^\\p{Print}]", "");
     }
   }
 
@@ -1679,7 +1679,7 @@ public class BufferListener extends VisPlugin {
     @Override
     public String parseString(BufferAccess ba) {
       /* TODO Diff? */
-      return new String(ba.mem).replaceAll("[^\\p{Print}]", "");
+      return new String(ba.mem, UTF_8).replaceAll("[^\\p{Print}]", "");
     }
   }
 

--- a/java/org/contikios/cooja/plugins/LogListener.java
+++ b/java/org/contikios/cooja/plugins/LogListener.java
@@ -30,6 +30,10 @@
 
 package org.contikios.cooja.plugins;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
+
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -49,12 +53,12 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.regex.PatternSyntaxException;
-
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.Box;
@@ -78,11 +82,8 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
-
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
-
+import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.HasQuickHelp;
@@ -96,6 +97,7 @@ import org.contikios.cooja.VisPlugin;
 import org.contikios.cooja.dialogs.TableColumnAdjuster;
 import org.contikios.cooja.dialogs.UpdateAggregator;
 import org.contikios.cooja.util.ArrayQueue;
+import org.jdom.Element;
 
 /**
  * A simple mote log listener.
@@ -804,7 +806,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
       }
 
       try {
-        PrintWriter outStream = new PrintWriter(new FileWriter(saveFile));
+        PrintWriter outStream = new PrintWriter(Files.newBufferedWriter(saveFile.toPath(), UTF_8));
         for(LogData data : logs) {
           outStream.println(
               data.getTime() + "\t" +
@@ -840,7 +842,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
           appendStream.close();
           appendStream = null;
         }
-        appendStream = new PrintWriter(new FileWriter(file,true));
+        appendStream = new PrintWriter(Files.newBufferedWriter(file.toPath(), UTF_8, CREATE, APPEND));
         appendStreamFile = file;
         appendToFileWroteHeader = false;
       } catch (Exception ex) {

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -30,21 +30,24 @@
 
 package org.contikios.cooja.plugins;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
+
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.lang.reflect.UndeclaredThrowableException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Hashtable;
 import java.util.Observer;
 import java.util.concurrent.Semaphore;
-
 import javax.script.Invocable;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
-
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-
+import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.SimEventCentral.LogOutputEvent;
@@ -437,8 +440,7 @@ public class LogScriptEngine {
     @Override
     public void append(String filename, String msg) {
       try{
-        FileWriter fstream = new FileWriter(filename, true);
-        BufferedWriter out = new BufferedWriter(fstream);
+        BufferedWriter out = Files.newBufferedWriter(Paths.get(filename), UTF_8, CREATE, APPEND);
         out.write(msg);
         out.close();
       } catch (Exception e) {
@@ -448,8 +450,7 @@ public class LogScriptEngine {
     @Override
     public void writeFile(String filename, String msg) {
       try{
-        FileWriter fstream = new FileWriter(filename, false);
-        BufferedWriter out = new BufferedWriter(fstream);
+        BufferedWriter out = Files.newBufferedWriter(Paths.get(filename), UTF_8);
         out.write(msg);
         out.close();
       } catch (Exception e) {

--- a/java/org/contikios/cooja/plugins/RadioLogger.java
+++ b/java/org/contikios/cooja/plugins/RadioLogger.java
@@ -29,6 +29,8 @@
  */
 package org.contikios.cooja.plugins;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Font;
@@ -44,6 +46,7 @@ import java.awt.event.MouseEvent;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,7 +55,6 @@ import java.util.Observable;
 import java.util.Observer;
 import java.util.Properties;
 import java.util.regex.PatternSyntaxException;
-
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.ButtonGroup;
@@ -77,11 +79,8 @@ import javax.swing.event.ListSelectionListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
-
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
-
+import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.ConvertedRadioPacket;
 import org.contikios.cooja.Cooja;
@@ -102,6 +101,7 @@ import org.contikios.cooja.plugins.analyzers.IPv6PacketAnalyzer;
 import org.contikios.cooja.plugins.analyzers.PacketAnalyzer;
 import org.contikios.cooja.plugins.analyzers.RadioLoggerAnalyzerSuite;
 import org.contikios.cooja.util.StringUtils;
+import org.jdom.Element;
 
 /**
  * Radio logger listens to the simulation radio medium and lists all transmitted
@@ -1032,7 +1032,7 @@ public class RadioLogger extends VisPlugin {
       }
 
       try {
-        PrintWriter outStream = new PrintWriter(new FileWriter(saveFile));
+        PrintWriter outStream = new PrintWriter(Files.newBufferedWriter(saveFile.toPath(), UTF_8));
         for (int i = 0; i < connections.size(); i++) {
           outStream.print(connections.get(i).toString() + "\n");
         }

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -29,6 +29,11 @@
 
 package org.contikios.cooja.plugins;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import de.sciss.syntaxpane.DefaultSyntaxKit;
+import de.sciss.syntaxpane.actions.DefaultSyntaxAction;
+import de.sciss.syntaxpane.actions.ScriptRunnerAction;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -46,11 +51,11 @@ import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Observable;
 import java.util.Observer;
-
 import javax.script.ScriptException;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -72,14 +77,8 @@ import javax.swing.JTextArea;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 import javax.swing.filechooser.FileFilter;
-
-import de.sciss.syntaxpane.DefaultSyntaxKit;
-import de.sciss.syntaxpane.actions.DefaultSyntaxAction;
-import de.sciss.syntaxpane.actions.ScriptRunnerAction;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
-
+import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.PluginType;
@@ -88,6 +87,7 @@ import org.contikios.cooja.VisPlugin;
 import org.contikios.cooja.dialogs.MessageList;
 import org.contikios.cooja.dialogs.MessageListUI;
 import org.contikios.cooja.util.StringUtils;
+import org.jdom.Element;
 
 @ClassDescription("Simulation script editor")
 @PluginType(PluginType.SIM_CONTROL_PLUGIN)
@@ -356,7 +356,7 @@ public class ScriptRunner extends VisPlugin {
             if (logFile.exists()) {
               logFile.delete();
             }
-            logWriter = new BufferedWriter(new FileWriter(logFile));
+            logWriter = Files.newBufferedWriter(logFile.toPath(), UTF_8);
             logWriter.write("Random seed: " + simulation.getRandomSeed() + "\n");
             logWriter.flush();
           }
@@ -510,8 +510,8 @@ public class ScriptRunner extends VisPlugin {
 
       /* Start process */
       final Process process = Runtime.getRuntime().exec(command, null, coojaBuild);
-      final BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()));
-      final BufferedReader err = new BufferedReader(new InputStreamReader(process.getErrorStream()));
+      final BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream(), UTF_8));
+      final BufferedReader err = new BufferedReader(new InputStreamReader(process.getErrorStream(), UTF_8));
 
       /* GUI components */
       final MessageListUI testOutput = new MessageListUI();

--- a/java/org/contikios/cooja/plugins/TimeLine.java
+++ b/java/org/contikios/cooja/plugins/TimeLine.java
@@ -30,6 +30,8 @@
 
 package org.contikios.cooja.plugins;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
@@ -51,7 +53,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Observable;
 import java.util.Observer;
-
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JCheckBox;
@@ -76,11 +77,8 @@ import javax.swing.SwingUtilities;
 import javax.swing.Timer;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
-
+import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.HasQuickHelp;
@@ -98,6 +96,7 @@ import org.contikios.cooja.interfaces.LED;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.interfaces.Radio.RadioEvent;
 import org.contikios.cooja.motes.AbstractEmulatedMote;
+import org.jdom.Element;
 
 /**
  * Shows events such as mote logs, LEDs, and radio transmissions, in a timeline.
@@ -707,7 +706,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
         BufferedWriter outStream = new BufferedWriter(
             new OutputStreamWriter(
                 new FileOutputStream(
-                    saveFile)));
+                    saveFile), UTF_8));
 
         /* Output all events (sorted per mote) */
         for (MoteEvents moteEvents: allMoteEvents) {

--- a/java/org/contikios/cooja/util/StringUtils.java
+++ b/java/org/contikios/cooja/util/StringUtils.java
@@ -28,6 +28,8 @@
 
 package org.contikios.cooja.util;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
@@ -35,6 +37,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -151,7 +154,7 @@ public class StringUtils {
       return null;
     }
     try {
-      InputStreamReader reader = new InputStreamReader(url.openStream());
+      InputStreamReader reader = new InputStreamReader(url.openStream(), UTF_8);
       StringBuilder sb = new StringBuilder();
       char[] buf = new char[4096];
       int read;
@@ -175,9 +178,9 @@ public class StringUtils {
     
     try {
       if (file.getName().endsWith(".gz")) {
-        reader = new InputStreamReader(new GZIPInputStream(new FileInputStream(file)));
+        reader = new InputStreamReader(new GZIPInputStream(new FileInputStream(file)), UTF_8);
       } else {
-        reader = new InputStreamReader(new FileInputStream(file));
+        reader = new InputStreamReader(new FileInputStream(file), UTF_8);
       }
 
       char[] buf = new char[4096];
@@ -207,7 +210,7 @@ public class StringUtils {
   
   public static boolean saveToFile(File file, String text) {
     try {
-      PrintWriter outStream = new PrintWriter(new FileWriter(file));
+      PrintWriter outStream = new PrintWriter(Files.newBufferedWriter(file.toPath(), UTF_8));
       outStream.print(text);
       outStream.close();
       return true;


### PR DESCRIPTION
Explicitly specify the charset as UTF-8 to
avoid relying on the JVM default charset.

The patch is compilation fixes on top of
an automatically generated patch by ErrorProne,
and ErrorProne shuffles the order of some
import statements.