### PR TITLE
Represent addresses as long

### DIFF
--- a/java/org/contikios/cooja/dialogs/ConfigurationWizard.java
+++ b/java/org/contikios/cooja/dialogs/ConfigurationWizard.java
@@ -974,7 +974,7 @@ public class ConfigurationWizard extends JDialog {
       testOutput.addMessage("Could not find address of referenceVar", MessageList.ERROR);
       return false;
     }
-    int relRefAddress = (int) addresses.get("referenceVar").addr;
+    long relRefAddress = addresses.get("referenceVar").addr;
     javaLibrary.setReferenceAddress(relRefAddress);
 
     testOutput.addMessage("### Creating data and BSS memory sections");

--- a/java/org/contikios/cooja/plugins/VariableWatcher.java
+++ b/java/org/contikios/cooja/plugins/VariableWatcher.java
@@ -144,7 +144,7 @@ public class VariableWatcher extends VisPlugin implements MotePlugin, HasQuickHe
     SHORT("short", 2),
     INT("int", 2),
     LONG("long", 4),
-    ADDR("address", 4);
+    ADDR("address", 8);
 
     String mRep;
     int mSize;
@@ -770,7 +770,6 @@ public class VariableWatcher extends VisPlugin implements MotePlugin, HasQuickHe
     long address = (varAddressField.getValue() == null) ? 0 : (long) varAddressField.getValue();
     int bytes;
     try {
-      //address = Integer.parseInt(varAddressField.getText());
       bytes = Integer.parseInt(varSizeField.getText());
     } catch (NumberFormatException ex) {
       bytes = 0;


### PR DESCRIPTION
This converts the remaining internal addresses
to be represented as long.

There are still int addresses in some interfaces
that are shared with MSPSim, those will be updated
in a separate commit.