### PR TITLE
build.xml: compile as Java 11

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0"?>
 
 <project name="COOJA Simulator" default="run" basedir=".">
+  <fail message="Ant 1.10+ required">
+    <condition>
+      <not><antversion atleast="1.10" /></not>
+    </condition>
+  </fail>
+
   <property name="java" location="java"/>
   <property name="build" location="build"/>
   <property name="javadoc" location="javadoc"/>
@@ -77,7 +83,7 @@ The COOJA Simulator
 
   <target name="compile" depends="init">
     <mkdir dir="${build}"/>
-    <javac srcdir="${java}" destdir="${build}" debug="on"
+    <javac srcdir="${java}" destdir="${build}" debug="on" release="11"
            includeantruntime="false"
            encoding="utf-8">
       <classpath refid="cooja.classpath"/>


### PR DESCRIPTION
Use release tag on javac to compile as Java 11.
If the JDK does not support Java 11, ant will
give a human readable error message and stop:

[javac] error: release version 11 not supported

The release tag is not present in "old" releases
of ant, so add a requirement on ant 1.10 that
was released in 2017.