### PR TITLE
Catch undefined syms in object files

### DIFF
--- a/config/external_tools.config
+++ b/config/external_tools.config
@@ -17,7 +17,7 @@ REGEXP_PARSE_INTERFACES = ([^/]*.c):SIM_INTERFACE\\(([^,]*),
 CMD_GREP_SENSORS = grep "^SENSORS_SENSOR([^,]*," -o -d skip -D skip -H -r
 REGEXP_PARSE_SENSORS = ([^/]*.c):SENSORS_SENSOR\\(([^,]*),
 COMPILER_ARGS = -fno-builtin-printf
-LINK_COMMAND_1 = gcc -shared -Wl,-Map=$(MAPFILE) -o $(LIBFILE)
+LINK_COMMAND_1 = gcc -shared -Wl,-zdefs -Wl,-Map=$(MAPFILE) -o $(LIBFILE)
 LINK_COMMAND_2 =
 AR_COMMAND_1 = ar rcf $(ARFILE)
 AR_COMMAND_2 =


### PR DESCRIPTION
Add -Wl,-zdefs to the linker flags.