### PR TITLE
Add log4j messages for test fail/ok

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -265,7 +265,7 @@ public class Simulation extends Observable implements Runnable {
   @Override
   public void run() {
     lastStartTime = System.currentTimeMillis();
-    logger.info("Simulation started, system time: " + lastStartTime);
+    logger.debug("Simulation started, system time: " + lastStartTime);
     isRunning = true;
     speedLimitLastRealtime = System.currentTimeMillis();
     speedLimitLastSimtime = getSimulationTime();

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -460,12 +460,14 @@ public class LogScriptEngine {
     @Override
     public void testOK() {
       exitCode = 0;
+      logger.info("TEST OK\n");
       log("TEST OK\n");
       deactive();
     }
     @Override
     public void testFailed() {
       exitCode = 1;
+      logger.warn("TEST FAILED\n");
       log("TEST FAILED\n");
       deactive();
     }


### PR DESCRIPTION
This makes it clear whether a test fails
or not by adding a "TEST FAILED" or "TEST OK"
message to the console log.

Also move the start simulation message to
debug level, the progress message from
LogScriptEngine is sufficient to understand
that the simulation has started.