### PR TITLE
Make visualization logger info into debug

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1749,7 +1749,7 @@ public class Cooja extends Observable {
         Throwable cause = ex;
         do {
           if (cause instanceof PluginRequiresVisualizationException) {
-            logger.info("Visualized plugin was not started: " + pluginClass);
+            logger.debug("Visualized plugin was not started: " + pluginClass);
             return null;
           }
         } while (cause != null && (cause=cause.getCause()) != null);


### PR DESCRIPTION
The Contiki-NG regression tests are run with
-nogui and they all print out 5 lines of
"Visualized plugin was not started: ..".
This is not an error condition, so put this
message as a debug message to reduce the unimportant
output in the regression tests.