### PR TITLE
Include simulation name when logging seed

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -435,7 +435,10 @@ public class Simulation extends Observable implements Runnable {
   public void setRandomSeed(long randomSeed) {
     this.randomSeed = randomSeed;
     randomGenerator.setSeed(randomSeed);
-    logger.info("Simulation random seed: " + randomSeed);
+    String name =
+      cooja.currentConfigFile == null ? "(unnamed)"
+                                      : cooja.currentConfigFile.toString();
+    logger.info("Simulation " + name + " random seed: " + randomSeed);
   }
 
   /**


### PR DESCRIPTION
Cooja logs the seed so add the simulation
name to that line of output. This allows us
to remove the corresponding echo from the
Contiki-NG test scripts.