### PR TITLE
Stop interfering with thread scheduler

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -348,7 +348,6 @@ public class Simulation extends Observable implements Runnable {
     if (!isRunning()) {
       isRunning = true;
       simulationThread = new Thread(this);
-      simulationThread.setPriority(Thread.MIN_PRIORITY);
       simulationThread.start();
     }
   }

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -334,7 +334,11 @@ public class LogScriptEngine {
     });
     scriptThread.start(); /* Starts by acquiring semaphore (blocks) */
     while (!semaphoreScript.hasQueuedThreads()) {
-      Thread.yield();
+      try {
+        Thread.sleep(50);
+      } catch (InterruptedException e) {
+        // Does not matter, we are waiting.
+      }
     }
 
     /* Setup simulation observers */


### PR DESCRIPTION
The documentation for yield says:

It is rarely appropriate to use this method.
It may be useful for debugging or testing
purposes, where it may help to reproduce
bugs due to race conditions.

Beyond the anti-recommendation from the
documentation, we want to keep the thread
active so replace the yield with a short sleep
instead. Also remove the call to setPriority
and let the simulation thread keep the default
priority.

The net result seems to be a slight performance
improvement, using a precompiled jar and running
time -p make in 07-simulation-base in docker
before the change:

real 181.82
user 356.84
sys 30.90

and after:

real 175.49
user 342.36
sys 28.92