### PR TITLE
Remove upstart crash when headless

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -3276,6 +3276,10 @@ public class Cooja extends Observable {
         }
       }
     } else {
+      if (GraphicsEnvironment.isHeadless()) {
+        logger.fatal("Trying to start GUI in headless environment, aborting");
+        System.exit(1);
+      }
       // Frame start-up
       javax.swing.SwingUtilities.invokeLater(new Runnable() {
         @Override


### PR DESCRIPTION
Exit with error when trying to start the GUI
in a headless environment instead of printing
a long backtrace.

The headless situation occurs when DISPLAY is
missing on Linux.