### PR TITLE
build.xml: make run targets fail on error

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -63,7 +63,8 @@ The COOJA Simulator
   </target>
 
   <target name="export-jar" depends="init, jar">
-    <java fork="yes" dir="${build}" classname="org.contikios.cooja.util.ExecuteJAR" maxmemory="512m">
+    <java fork="yes" dir="${build}" classname="org.contikios.cooja.util.ExecuteJAR"
+          failonerror="true" maxmemory="512m">
         <sysproperty key="user.language" value="en"/>
         <arg file="${CSC}"/>
         <arg file="exported.jar"/>
@@ -108,7 +109,8 @@ The COOJA Simulator
   </target>
 
   <target name="run" depends="init, compile, jar, copy configs">
-    <java fork="yes" dir="${build}" classname="org.contikios.cooja.Cooja" maxmemory="512m">
+    <java fork="yes" dir="${build}" classname="org.contikios.cooja.Cooja"
+          failonerror="true" maxmemory="512m">
       <sysproperty key="user.language" value="en"/>
       <arg line="${args}"/>
       <env key="LD_LIBRARY_PATH" value="."/>
@@ -117,7 +119,8 @@ The COOJA Simulator
   </target>
 
   <target name="run_errorbox" depends="init, compile, jar, copy configs">
-    <java fork="yes" dir="${build}" classname="org.contikios.cooja.Cooja" maxmemory="512m">
+    <java fork="yes" dir="${build}" classname="org.contikios.cooja.Cooja"
+          failonerror="true" maxmemory="512m">
       <sysproperty key="user.language" value="en"/>
       <jvmarg value="-XX:+ShowMessageBoxOnError"/>
       <env key="LD_LIBRARY_PATH" value="."/>
@@ -126,7 +129,8 @@ The COOJA Simulator
   </target>
 
   <target name="runprof" depends="init, compile, jar, copy configs">
-    <java fork="yes" dir="${build}" classname="org.contikios.cooja.Cooja">
+    <java fork="yes" dir="${build}" classname="org.contikios.cooja.Cooja"
+          failonerror="true">
       <arg line="${args}"/>
       <env key="LD_LIBRARY_PATH" value="."/>
       <jvmarg line="-agentlib:yjpagent"/>
@@ -135,7 +139,8 @@ The COOJA Simulator
   </target>
 
   <target name="runfree" depends="init, compile, jar, copy configs">
-    <java fork="yes" dir="${build}" classname="org.contikios.cooja.Cooja" maxmemory="1536m">
+    <java fork="yes" dir="${build}" classname="org.contikios.cooja.Cooja"
+          failonerror="true" maxmemory="1536m">
       <arg line="${args}"/>
       <env key="LD_LIBRARY_PATH" value="."/>
       <classpath refid="cooja.classpath"/>
@@ -147,7 +152,8 @@ The COOJA Simulator
   </target>
 
   <target name="run_bigmem" depends="init, compile, jar, copy configs">
-    <java fork="yes" dir="${build}" classname="org.contikios.cooja.Cooja" maxmemory="1536m">
+    <java fork="yes" dir="${build}" classname="org.contikios.cooja.Cooja"
+          failonerror="true" maxmemory="1536m">
       <arg line="${args}"/>
       <env key="LD_LIBRARY_PATH" value="."/>
       <classpath refid="cooja.classpath"/>
@@ -163,7 +169,8 @@ The COOJA Simulator
   </target>
 
   <target name="run_nogui" depends="init, compile, jar, copy configs">
-    <java fork="yes" dir="${build}" classname="org.contikios.cooja.Cooja" maxmemory="512m">
+    <java fork="yes" dir="${build}" classname="org.contikios.cooja.Cooja"
+          failonerror="true" maxmemory="512m">
       <arg line="-nogui=${args}"/>
       <env key="LD_LIBRARY_PATH" value="."/>
       <classpath refid="cooja.nogui.classpath"/>


### PR DESCRIPTION
Ant currently exits with 0 when the run
target fails which makes it hard to detect
errors from the Contiki-NG build system.
Make ant fail when the run targets fail
instead.