### PR TITLE
Enable Cooja to pass core count to make

### DIFF
--- a/java/org/contikios/cooja/dialogs/CompileContiki.java
+++ b/java/org/contikios/cooja/dialogs/CompileContiki.java
@@ -102,7 +102,7 @@ public class CompileContiki {
   }
 
   /**
-   * Executes a Contiki compilation command.
+   * Perform variable expansion and execute a Contiki compilation command.
    *
    * @param command Command
    * @param env (Optional) Environment. May be null.
@@ -116,7 +116,7 @@ public class CompileContiki {
    * @throws Exception If process returns error, or outputFile does not exist
    */
   public static Process compile(
-      final String command[],
+      final String commandIn[],
       final String[] env,
       final File outputFile,
       final File directory,
@@ -132,7 +132,12 @@ public class CompileContiki {
   	} else {
   		messageDialog = compilationOutput;
   	}
-  	
+    String cpus = Integer.toString(Runtime.getRuntime().availableProcessors());
+    // Perform compile command variable expansions.
+    String command[] = new String[commandIn.length];
+    for (int i = 0; i < commandIn.length; i++) {
+      command[i] = commandIn[i].replace("$(CPUS)", cpus);
+    }
     {
       String cmd = "";
       for (String c: command) {


### PR DESCRIPTION
Add a variable $(CPUS) to commands that
is replaced with the number of cores,
so we can avoid spawning 40 compilers with
"make -j" in the Contiki-NG regression tests.

This gives a slight performance improvement
on 07-simulation-tests on my 12 core machine,
time -p make before the change:

real 174.78
user 339.52
sys 27.04

and after the change:

real 169.06
user 330.62
sys 26.70

Machines with fewer cores should see a greater
improvement.