### PR TITLE
Remove superfluous parentheses

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -3031,7 +3031,7 @@ public class Cooja extends Observable {
     for (COOJAProject project: projects) {
     	File projectDir = project.dir;
       try {
-        urls.add((new File(projectDir, "java")).toURI().toURL());
+        urls.add(new File(projectDir, "java").toURI().toURL());
 
         // Read configuration to check if any JAR files should be loaded
         ProjectConfig projectConfig = new ProjectConfig(false);

--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -142,7 +142,7 @@ public abstract class CoreComm {
       String mainTemplate = Cooja
           .getExternalToolsSetting("CORECOMM_TEMPLATE_FILENAME");
 
-      if ((new File(mainTemplate)).exists()) {
+      if (new File(mainTemplate).exists()) {
         reader = Files.newBufferedReader(Paths.get(mainTemplate), UTF_8);
       } else {
         InputStream input = CoreComm.class

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -1104,7 +1104,7 @@ public class ContikiMoteType implements MoteType {
     boolean okID = false;
 
     while (!okID) {
-      testID = ID_PREFIX + (new Random().nextInt(1000));
+      testID = ID_PREFIX + new Random().nextInt(1000);
       okID = true;
 
       // Check if identifier is reserved


### PR DESCRIPTION
These give ErrorProne warnings and
are not hard to read without parentheses.