### PR TITLE
mspsim: ignore untracked changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "mspsim"]
 	path = mspsim
 	url = https://github.com/contiki-ng/mspsim.git
+	ignore = untracked


### PR DESCRIPTION
This enables having untracked files
in mspsim without "git status" in Cooja
showing the submodule as modified.