### PR TITLE
mrm: fix clean rule in build.xml

### DIFF
--- a/apps/mrm/build.xml
+++ b/apps/mrm/build.xml
@@ -23,7 +23,7 @@
 
   <target name="clean" depends="init">
     <delete dir="${build}"/>
-    <delete file="${jarfile}"/>
+    <delete file="${mrm_jar}"/>
   </target>
 
   <target name="jar" depends="init, compile">


### PR DESCRIPTION
There is no ${jarfile}, replace it with
${mrm_jar} that exists.