### PR TITLE
Perform calculation as long

### DIFF
--- a/java/org/contikios/cooja/interfaces/IPAddress.java
+++ b/java/org/contikios/cooja/interfaces/IPAddress.java
@@ -114,7 +114,7 @@ public class IPAddress extends MoteInterface {
             for (int i = 0; i < IPv6_MAX_ADDRESSES; i++) {
               long addr_of_ip = moteMem.getVariableAddress("uip_ds6_if") // start address of interface
                       + ipv6_addr_list_offset // offset to ip address region
-                      + i * ipv6_addr_size // offset to ith ip address 
+                      + i * ((long) ipv6_addr_size) // offset to ith ip address
                       + 1 + memory.getLayout().getPaddingBytesFor(
                               MemoryLayout.DataType.INT8,
                               MemoryLayout.DataType.INT16); // skip 'isused'


### PR DESCRIPTION
This should never overflow but the result
is a long so cast the variable before
multiplying.

This fixes a NarrowCalculation warning
in ErrorProne.