### PR TITLE
Log the event instead of Pair@349803493

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -289,7 +289,7 @@ public class Simulation extends Observable implements Runnable {
           throw new RuntimeException("No more events");
         }
         if (nextEvent.time < currentSimulationTime) {
-          throw new RuntimeException("Next event is in the past: " + nextEvent.time + " < " + currentSimulationTime + ": " + nextEvent);
+          throw new RuntimeException("Next event is in the past: " + nextEvent.time + " < " + currentSimulationTime + ": " + nextEvent.event);
         }
         currentSimulationTime = nextEvent.time;
         /*logger.info("Executing event #" + EVENT_COUNTER++ + " @ " + currentSimulationTime + ": " + nextEvent);*/


### PR DESCRIPTION
The event time is already logged and
EventQueue.Pair does not have a toString
method so log the event instead of
the entire pair.