### PR TITLE
Stop printing the compile command twice

### DIFF
--- a/java/org/contikios/cooja/dialogs/CompileContiki.java
+++ b/java/org/contikios/cooja/dialogs/CompileContiki.java
@@ -143,7 +143,6 @@ public class CompileContiki {
       for (String c: command) {
       	cmd += c + " ";
       }
-      logger.info("> " + cmd);
       messageDialog.addMessage("", MessageList.NORMAL);
       messageDialog.addMessage("> " + cmd, MessageList.NORMAL);
     }


### PR DESCRIPTION
The compile command is echoed twice for
headless users, one time to the messageDialog
and one time to the logger.

The log does not contain enough information
to troubleshoot compilation failures so logging
the command is not helpful, remove the line
sent to the logger.