### PR TITLE
Execute parse commands under /bin/sh -c

### DIFF
--- a/config/external_tools_win32.config
+++ b/config/external_tools_win32.config
@@ -8,7 +8,7 @@ LINK_COMMAND_2 = -L/usr/lib/mingw
 PARSE_WITH_COMMAND = true
 
 # Hack: nm with arguments -S --size-sort does not display __data_start symbols
-PARSE_COMMAND=sh -c "/bin/nm -aP --size-sort -S $(LIBFILE) && /bin/nm -aP $(LIBFILE)"
+PARSE_COMMAND = /bin/nm -aP --size-sort -S $(LIBFILE) && /bin/nm -aP $(LIBFILE)
 
 COMMAND_VAR_NAME_ADDRESS_SIZE = ^[_](?<symbol>[^.].*?)[ \t]<SECTION>[ \t](?<address>[0-9a-fA-F]+)[ \t](?<size>[0-9a-fA-F]+)
 COMMAND_DATA_START = ^__data_start__[ \t]D[ \t]([0-9A-Fa-f]*)

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -954,26 +954,24 @@ public class ContikiMoteType implements MoteType {
                                 libraryFile.getName().replace(File.separatorChar, '/'));
 
       /* Execute command, read response */
-      String line;
-      Process p = Runtime.getRuntime().exec(
-              command.split(" "),
-              null,
-              libraryFile.getParentFile()
-      );
+      ProcessBuilder pb = new ProcessBuilder("/bin/sh", "-c", command);
+      pb.directory(libraryFile.getParentFile());
+      Process p = pb.start();
       BufferedReader input = new BufferedReader(
               new InputStreamReader(p.getInputStream(), UTF_8)
       );
       p.getErrorStream().close();
+      String line;
       while ((line = input.readLine()) != null) {
         output.add(line);
       }
       input.close();
 
-      if (output == null || output.isEmpty()) {
+      if (p.waitFor() != 0 || output.isEmpty()) {
         return null;
       }
       return output.toArray(new String[0]);
-    } catch (IOException err) {
+    } catch (InterruptedException | IOException err) {
       logger.fatal("Command error: " + err.getMessage(), err);
       return null;
     }


### PR DESCRIPTION
Windows uses && to execute nm twice. Move
the invocation of /bin/sh -c to the command
execution inside the Java code and avoid splitting
the command on space.

Also check the return value of the command.