### PR TITLE
Fail when given a faulty seed

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -3163,6 +3163,7 @@ public class Cooja extends Observable {
           randomSeed =  Long.valueOf(arg);
         } catch (Exception e) {
           logger.error("Failed to convert \"" + arg +"\" to an integer.");
+          System.exit(1);
         }
       }
     }


### PR DESCRIPTION
The path already contains logger.error, add
a System.exit(1) after so the simulation does
not start with a different seed than the user
intended.