### PR TITLE
Disable reload menu without simulation

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -4439,7 +4439,7 @@ public class Cooja extends Observable {
     }
     @Override
     public boolean shouldBeEnabled() {
-      return true;
+      return getSimulation() != null;
     }
   };
   GUIAction reloadRandomSimulationAction = new GUIAction("Reload with new random seed", KeyEvent.VK_N, KeyStroke.getKeyStroke(KeyEvent.VK_R, ActionEvent.CTRL_MASK | ActionEvent.SHIFT_MASK)) {


### PR DESCRIPTION
Disable the reload menu item unless
there is an active simulation.