### PR TITLE
Remove one instance of reloadCurrentSimulation

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2384,12 +2384,10 @@ public class Cooja extends Observable {
   /**
    * Reload currently configured simulation.
    * Reloading a simulation may include recompiling Contiki.
-   *
-   * @param autoStart Start executing simulation when loaded
-   * @param randomSeed Simulation's next random seed
    */
-  public void reloadCurrentSimulation(final boolean autoStart, final long randomSeed) {
-    if (getSimulation() == null) {
+  public void reloadCurrentSimulation() {
+    final Simulation sim = getSimulation();
+    if (sim == null) {
       logger.fatal("No simulation to reload");
       return;
     }
@@ -2399,6 +2397,8 @@ public class Cooja extends Observable {
       return;
     }
 
+    final boolean autoStart = sim.isRunning();
+    final long randomSeed = sim.getRandomSeed();
     final JDialog progressDialog = new JDialog(frame, "Reloading", true);
     final Thread loadThread = new Thread(new Runnable() {
       @Override
@@ -2512,18 +2512,6 @@ public class Cooja extends Observable {
     }
 
     return false;
-  }
-
-  /**
-   * Reload currently configured simulation.
-   * Reloading a simulation may include recompiling Contiki.
-   * The same random seed is used.
-   *
-   * @see #reloadCurrentSimulation(boolean, long)
-   * @param autoStart Start executing simulation when loaded
-   */
-  public void reloadCurrentSimulation(boolean autoStart) {
-    reloadCurrentSimulation(autoStart, getSimulation().getRandomSeed());
   }
 
   /**
@@ -4437,10 +4425,7 @@ public class Cooja extends Observable {
         }).start();
         return;
       }
-
-      /* Reload current simulation */
-      long seed = getSimulation().getRandomSeed();
-      reloadCurrentSimulation(getSimulation().isRunning(), seed);
+      reloadCurrentSimulation();
     }
     @Override
     public boolean shouldBeEnabled() {

--- a/java/org/contikios/cooja/plugins/SimControl.java
+++ b/java/org/contikios/cooja/plugins/SimControl.java
@@ -332,7 +332,7 @@ public class SimControl extends VisPlugin implements HasQuickHelp {
   private Action reloadAction = new AbstractAction("Reload") {
     @Override
     public void actionPerformed(ActionEvent e) {
-      simulation.getCooja().reloadCurrentSimulation(simulation.isRunning());
+      simulation.getCooja().reloadCurrentSimulation();
     }
   };
 


### PR DESCRIPTION
The method is only called with the expected
parameters, it uses the same seed as the current
simulation, and it restarts if the simulation
is already running.

Remove the two parameters on the method,
and remove the single-parameter method
with the same name.