### PR TITLE
Distinguish make target and library file names

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -367,11 +367,21 @@ public class ContikiMoteType implements MoteType {
     return true;
   }
 
-  public static File getExpectedFirmwareFile(File source) {
+  /**
+   * Returns make target based on source file.
+   *
+   * @param source The source file
+   * @return Make target based on source file
+   */
+  public static File getMakeTargetName(File source) {
     File parentDir = source.getParentFile();
     String sourceNoExtension = source.getName().substring(0, source.getName().length() - 2);
-
     return new File(parentDir, sourceNoExtension + librarySuffix);
+  }
+
+  public static File getExpectedFirmwareFile(String moteId, File source) {
+    return new File(source.getParentFile(),
+            ContikiMoteType.tempOutputDirectory + "/" + moteId + ContikiMoteType.librarySuffix);
   }
 
   /**
@@ -1330,12 +1340,12 @@ public class ContikiMoteType implements MoteType {
       setContikiSourceFile(oldVersionSource);
       logger.info("Guessing Contiki source: " + oldVersionSource.getAbsolutePath());
 
-      setContikiFirmwareFile(getExpectedFirmwareFile(oldVersionSource));
+      setContikiFirmwareFile(getExpectedFirmwareFile(getIdentifier(), oldVersionSource));
       logger.info("Guessing Contiki firmware: " + getContikiFirmwareFile().getAbsolutePath());
 
       /* Guess compile commands */
       String compileCommands
-              = "make " + getExpectedFirmwareFile(oldVersionSource).getName() + " TARGET=cooja";
+              = "make " + getMakeTargetName(oldVersionSource).getName() + " TARGET=cooja";
       logger.info("Guessing compile commands: " + compileCommands);
       setCompileCommands(compileCommands);
     }

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -641,7 +641,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     	createButton.setEnabled(false);
     	commandsArea.setEnabled(true);
       setCompileCommands(getDefaultCompileCommands(sourceFile));
-      contikiFirmware = getExpectedFirmwareFile(sourceFile);
+      contikiFirmware = getExpectedFirmwareFile(moteType.getIdentifier(), sourceFile);
       contikiSource = sourceFile;
       setDialogState(DialogState.AWAITING_COMPILATION);
       break;
@@ -871,6 +871,17 @@ public abstract class AbstractCompileDialog extends JDialog {
    * @return Expected Contiki firmware compiled from source
    */
   public abstract File getExpectedFirmwareFile(File source);
+
+  /**
+   * Returns the Contiki firmware name for moteId and source.
+   *
+   * @param moteId The ID of the mote
+   * @param source Contiki source
+   * @return Expected Contiki firmware compiled from source
+   */
+  public File getExpectedFirmwareFile(String moteId, File source) {
+    return getExpectedFirmwareFile(source);
+  }
 
   private void abortAnyCompilation() {
     if (currentCompilationProcess == null) {

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -213,14 +213,19 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
       defines = " DEFINES=NETSTACK_CONF_H=" + ((ContikiMoteType) moteType).getNetworkStack().getHeaderFile();
     }
 
-    return
-    /*"make clean TARGET=cooja\n" + */
-    Cooja.getExternalToolsSetting("PATH_MAKE") + " " + getExpectedFirmwareFile(source).getName() + " TARGET=cooja" + defines;
+    return Cooja.getExternalToolsSetting("PATH_MAKE") + " " +
+            ContikiMoteType.getMakeTargetName(source).getName() + " TARGET=cooja" + defines;
   }
 
   @Override
   public File getExpectedFirmwareFile(File source) {
-    return ContikiMoteType.getExpectedFirmwareFile(source);
+    logger.fatal("Called getExpectedFirmwareFile(File)");
+    throw new RuntimeException("This method should not be called on ContikiMotes");
+  }
+
+  @Override
+  public File getExpectedFirmwareFile(String moteId, File source) {
+    return ContikiMoteType.getExpectedFirmwareFile(moteId, source);
   }
 
   @Override


### PR DESCRIPTION
The firmware for Contiki motes is called mtypeNNN
where NNN is the mote identifier. The static method
getExpectedFirmwareFile returns something else,
and AbstractCompileDialog checks that this file exists.
The file no longer exists after the latest build system
updates, so make getExpectedFirmwareFile return the right
thing.

The make target name is constructed from the name
of the firmware file so that breaks from this fix.
Add a separate method that works like the old
getExpectedFirmwareFile and use that method for
constructing make target names.