### PR TITLE
Fix headless startup check logic

### DIFF
--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -41,7 +41,7 @@ import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
-import java.awt.*;
+import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Files;
@@ -143,8 +143,8 @@ class Main {
       return;
     }
 
-    if (options.action != null && options.action.quickstart == null &&
-        options.action.nogui == null && GraphicsEnvironment.isHeadless()) {
+    if ((options.action == null || options.action.nogui == null) &&
+        GraphicsEnvironment.isHeadless()) {
       System.err.println("Trying to start GUI in headless environment, aborting");
       System.exit(1);
     }


### PR DESCRIPTION
The picocli introduction transferred the test
from a deep nesting level in the old main method
and got the overall logic wrong, fix the condition.