### PR TITLE
Remove quickstart option for C files

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1242,50 +1242,6 @@ public class Cooja extends Observable {
     }
   }
 
-  /**
-   * Allows user to create a simulation with a single mote type.
-   *
-   * @param source       Contiki application file name
-   * @param vis          True if GUI mode
-   * @param logDirectory Directory for log files
-   * @return True if simulation was created
-   */
-  private static Simulation quickStartSimulation(String source, boolean vis, String logDirectory) {
-    Cooja gui = new Cooja(logDirectory, createDesktopPane(vis));
-    configureFrame(gui);
-
-    logger.info("> Creating simulation");
-    Simulation sim = new Simulation(gui);
-    sim.setTitle("Quickstarted simulation: " + source);
-    boolean simOK = CreateSimDialog.showDialog(Cooja.getTopParentContainer(), sim);
-    if (!simOK) {
-      logger.fatal("No simulation, aborting quickstart");
-      System.exit(1);
-    }
-    gui.setSimulation(sim, true);
-
-    logger.info("> Creating mote type");
-    ContikiMoteType moteType = new ContikiMoteType();
-    moteType.setContikiSourceFile(new File(source));
-    moteType.setDescription("Cooja mote type (" + source + ")");
-
-    try {
-      boolean compileOK = moteType.configureAndInit(Cooja.getTopParentContainer(), sim, vis);
-      if (!compileOK) {
-        logger.fatal("Mote type initialization failed, aborting quickstart");
-        return null;
-      }
-    } catch (MoteTypeCreationException e1) {
-      logger.fatal("Mote type initialization failed, aborting quickstart");
-      return null;
-    }
-    sim.addMoteType(moteType);
-
-    logger.info("> Adding motes");
-    gui.doAddMotes(moteType);
-    return sim;
-  }
-
   //// PROJECT CONFIG AND EXTENDABLE PARTS METHODS ////
 
   /**
@@ -2997,21 +2953,7 @@ public class Cooja extends Observable {
       });
     } else if (options.action.quickstart != null) {
       String contikiApp = options.action.quickstart;
-      Simulation sim = null;
-      if (contikiApp.endsWith(".csc")) {
-        sim = quickStartSimulationConfig(new File(contikiApp), true, options.randomSeed, logDirectory);
-      } else {
-        if (contikiApp.endsWith(".cooja")) {
-          contikiApp = contikiApp.substring(0, contikiApp.length() - ".cooja".length());
-        }
-        if (!contikiApp.endsWith(".c")) {
-          contikiApp += ".c";
-        }
-
-        sim = quickStartSimulation(contikiApp, true, logDirectory);
-      }
-
-      if (sim == null) {
+      if (quickStartSimulationConfig(new File(contikiApp), true, options.randomSeed, logDirectory) == null) {
         System.exit(1);
       }
     } else if (options.action.nogui != null) {

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -158,6 +158,20 @@ class Main {
       System.setProperty("java.awt.headless", "true");
     }
 
+    // Verify soundness of -nogui/-quickstart argument.
+    if (options.action != null) {
+      String file = options.action.nogui == null ? options.action.quickstart : options.action.nogui;
+      if (!file.endsWith(".csc")) {
+        String option = options.action.nogui == null ? "-quickstart" : "-nogui";
+        System.err.println("Cooja " + option + " expects a filename extension of '.csc'");
+        System.exit(1);
+      }
+      if (!Files.exists(Path.of(file))) {
+        System.err.println("File '" + file + "' does not exist");
+        System.exit(1);
+      }
+    }
+
     if (options.logConfigFile != null && !Files.exists(Path.of(options.logConfigFile))) {
       System.err.println("Configuration file '" + options.logConfigFile + "' does not exist");
       System.exit(1);


### PR DESCRIPTION
Remove the option to quickstart with anything other
than a Cooja simulation file, and provide a clear
error message when -nogui/-quickstart get the wrong
kind of file as argument.

This removes a number of special cases in the Cooja
startup code.