### PR TITLE
Only store EEPROM data in simulation file if changed from default

### DIFF
--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiEEPROM.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiEEPROM.java
@@ -32,6 +32,7 @@ package org.contikios.cooja.contikimote.interfaces;
 
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.EventQueue;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -252,18 +253,17 @@ public class ContikiEEPROM extends MoteInterface implements ContikiMoteInterface
       }
     });
     
-    Observer observer;
-    this.addObserver(observer = new Observer() {
-      @Override
-      public void update(Observable obs, Object obj) {
-        long currentTime = mote.getSimulation().getSimulationTime();
+    Observer observer = (obs, obj) -> {
+      final long currentTime = mote.getSimulation().getSimulationTime();
+      EventQueue.invokeLater(() -> {
         lastTimeLabel.setText("Last change at time: " + currentTime);
         lastReadLabel.setText("Last change read bytes: " + getLastReadCount());
         lastWrittenLabel.setText("Last change wrote bytes: " + getLastWrittenCount());
-        
-        redrawDataView(dataViewArea);        
-      }
-    });
+
+        redrawDataView(dataViewArea);
+      });
+    };
+    this.addObserver(observer);
 
     // Saving observer reference for releaseInterfaceVisualizer
     panel.putClientProperty("intf_obs", observer);

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiEEPROM.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiEEPROM.java
@@ -296,11 +296,13 @@ public class ContikiEEPROM extends MoteInterface implements ContikiMoteInterface
   @Override
   public Collection<Element> getConfigXML() {
       var config = new ArrayList<Element>();
+      var data = getEEPROMData();
 
-      // Infinite boolean
-      var element = new Element("eeprom");
-      element.setText(Base64.getEncoder().encodeToString(getEEPROMData()));
-      config.add(element);
+      if (!isEmpty(data)) {
+        var element = new Element("eeprom");
+        element.setText(Base64.getEncoder().encodeToString(data));
+        config.add(element);
+      }
 
       return config;
   }
@@ -358,6 +360,15 @@ public class ContikiEEPROM extends MoteInterface implements ContikiMoteInterface
     }
 
     return fileData;
+  }
+
+  private static boolean isEmpty(byte[] data) {
+    for (byte b : data) {
+      if (b != 0) {
+        return false;
+      }
+    }
+    return true;
   }
 
 }


### PR DESCRIPTION
This reduces the size of saved simulation files somewhat as most simulations do not have modified EEPROM data.