### PR TITLE
CoreComm cleanups

### DIFF
--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -113,7 +113,7 @@ public abstract class CoreComm {
    * @throws MoteTypeCreationException
    *           If error occurs
    */
-  public static void generateLibSourceFile(Path tempDir, String className)
+  private static void generateLibSourceFile(Path tempDir, String className)
       throws MoteTypeCreationException {
     BufferedWriter sourceFileWriter = null;
     BufferedReader templateFileReader = null;
@@ -194,7 +194,7 @@ public abstract class CoreComm {
    * @throws MoteTypeCreationException
    *           If Java class compilation error occurs
    */
-  public static void compileSourceFile(Path tempDir, String className)
+  private static void compileSourceFile(Path tempDir, String className)
       throws MoteTypeCreationException {
       /* Try to create a message list with support for GUI - will give not UI if headless */
     MessageList compilationOutput = MessageContainer.createMessageList(true);
@@ -249,7 +249,7 @@ public abstract class CoreComm {
    * @return Loaded class
    * @throws MoteTypeCreationException If error occurs
    */
-  public static Class<?> loadClassFile(Path tempDir, String className)
+  private static Class<?> loadClassFile(Path tempDir, String className)
       throws MoteTypeCreationException {
     Class<?> loadedClass = null;
     try {

--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -94,36 +94,6 @@ public abstract class CoreComm {
   private static int fileCounter = 1;
 
   /**
-   * Has any library been loaded? Since libraries can't be unloaded the entire
-   * simulator may have to be restarted.
-   *
-   * @return True if any library has been loaded this session
-   */
-  public static boolean hasLibraryBeenLoaded() {
-    return coreComms.size() > 0;
-  }
-
-  /**
-   * Has given library file already been loaded during this session? A loaded
-   * library can be removed, but not unloaded during one session. And a new
-   * library file, named the same as an earlier loaded and removed file, can't
-   * be loaded either.
-   *
-   * @param libraryFile
-   *          Library file
-   * @return True if a library has already been loaded from the given file's
-   *         filename
-   */
-  public static boolean hasLibraryFileBeenLoaded(File libraryFile) {
-    for (File loadedFile : coreCommFiles) {
-      if (loadedFile.getName().equals(libraryFile.getName())) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
    * Get the class name of next free core communicator class. If null is
    * returned, no classes are available.
    *


### PR DESCRIPTION
Convert methods to use try-with-resources, which simplifies the code flow. Also remove unused methods, make methods private, and inline a short method.