### PR TITLE
Reduce risk of name collision for ContikiMoteType

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -1009,7 +1009,7 @@ public class ContikiMoteType implements MoteType {
     boolean available = false;
 
     while (!available) {
-      testID = "mtype" + new Random().nextInt(1000);
+      testID = "mtype" + new Random().nextInt(1000000000);
       available = reservedIdentifiers == null || !reservedIdentifiers.contains(testID);
 
       if (!available) {


### PR DESCRIPTION
Make the space for mote names larger to reduce the risk
of collisions when reloading simulations. Before this,
reloading a simulation with 200 motes 5 times will
fill the available name space, and the next reload
will fail.