### PR TITLE
More preparations for early return in Cooja constructor

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -359,7 +359,7 @@ public class Cooja extends Observable {
     cooja = this;
     this.logDirectory = logDirectory;
     mySimulation = null;
-    final var desktop = new JDesktopPane() {
+    myDesktopPane = new JDesktopPane() {
       @Override
       public void setBounds(int x, int y, int w, int h) {
         super.setBounds(x, y, w, h);
@@ -377,23 +377,22 @@ public class Cooja extends Observable {
         return c;
       }
     };
-    desktop.setDesktopManager(new DefaultDesktopManager() {
+    myDesktopPane.setDesktopManager(new DefaultDesktopManager() {
       @Override
       public void endResizingFrame(JComponent f) {
         super.endResizingFrame(f);
-        updateDesktopSize(desktop);
+        updateDesktopSize(myDesktopPane);
       }
       @Override
       public void endDraggingFrame(JComponent f) {
         super.endDraggingFrame(f);
-        updateDesktopSize(desktop);
+        updateDesktopSize(myDesktopPane);
       }
     });
-    desktop.setDragMode(JDesktopPane.OUTLINE_DRAG_MODE);
+    myDesktopPane.setDragMode(JDesktopPane.OUTLINE_DRAG_MODE);
     if (vis) {
       frame = new JFrame(WINDOW_TITLE);
     }
-    myDesktopPane = desktop;
 
     /* Help panel */
     quickHelpTextPane = new JTextPane();

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -468,7 +468,7 @@ public class Cooja extends Observable {
 
     /* Parse current extension configuration */
     try {
-      reparseProjectConfig();
+      parseProjectConfig();
     } catch (ParseProjectsException e) {
       logger.fatal("Error when loading extensions: " + e.getMessage(), e);
       if (isVisualized()) {
@@ -1314,7 +1314,10 @@ public class Cooja extends Observable {
     unregisterPositioners();
     unregisterRadioMediums();
     projectDirClassLoader = null;
+    parseProjectConfig();
+  }
 
+  private void parseProjectConfig() throws ParseProjectsException {
     /* Build cooja configuration */
     try {
       projectConfig = new ProjectConfig(true);

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1281,10 +1281,7 @@ public class Cooja extends Observable {
 
   /**
    * Builds new extension configuration using current extension directories settings.
-   * Reregisters mote types, plugins, positioners and radio
-   * mediums. This method may still return true even if all classes could not be
-   * registered, but always returns false if all extension directory configuration
-   * files were not parsed correctly.
+   * Re-registers mote types, plugins, positioners and radio mediums.
    */
   public void reparseProjectConfig() throws ParseProjectsException {
     /* Remove current dependencies */

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -199,7 +199,7 @@ public class Cooja extends Observable {
   /**
    * Default extension configuration filename.
    */
-  public static String PROJECT_DEFAULT_CONFIG_FILENAME = null;
+  public static final String PROJECT_DEFAULT_CONFIG_FILENAME = "/cooja_default.config";
 
   /**
    * User extension configuration filename.
@@ -1308,10 +1308,6 @@ public class Cooja extends Observable {
    * files were not parsed correctly.
    */
   public void reparseProjectConfig() throws ParseProjectsException {
-    if (PROJECT_DEFAULT_CONFIG_FILENAME == null) {
-      PROJECT_DEFAULT_CONFIG_FILENAME = "/cooja_default.config";
-    }
-
     /* Remove current dependencies */
     unregisterMoteTypes();
     unregisterPlugins();

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1214,13 +1214,6 @@ public class Cooja extends Observable {
   }
 
   /**
-   * Unregister all mote type classes.
-   */
-  public void unregisterMoteTypes() {
-    moteTypeClasses.clear();
-  }
-
-  /**
    * @return All registered mote type classes
    */
   public List<Class<? extends MoteType>> getRegisteredMoteTypes() {
@@ -1248,13 +1241,6 @@ public class Cooja extends Observable {
 
     positionerClasses.add(positionerClass);
     return true;
-  }
-
-  /**
-   * Unregister all positioner classes.
-   */
-  public void unregisterPositioners() {
-    positionerClasses.clear();
   }
 
   /**
@@ -1287,13 +1273,6 @@ public class Cooja extends Observable {
   }
 
   /**
-   * Unregister all radio medium classes.
-   */
-  public void unregisterRadioMediums() {
-    radioMediumClasses.clear();
-  }
-
-  /**
    * @return All registered radio medium classes
    */
   public List<Class<? extends RadioMedium>> getRegisteredRadioMediums() {
@@ -1309,10 +1288,11 @@ public class Cooja extends Observable {
    */
   public void reparseProjectConfig() throws ParseProjectsException {
     /* Remove current dependencies */
-    unregisterMoteTypes();
-    unregisterPlugins();
-    unregisterPositioners();
-    unregisterRadioMediums();
+    moteTypeClasses.clear();
+    menuMotePluginClasses.clear();
+    pluginClasses.clear();
+    positionerClasses.clear();
+    radioMediumClasses.clear();
     projectDirClassLoader = null;
     parseProjectConfig();
   }
@@ -1736,14 +1716,6 @@ public class Cooja extends Observable {
       return false;
     }
     return true;
-  }
-
-  /**
-   * Unregister all plugin classes
-   */
-  public void unregisterPlugins() {
-    menuMotePluginClasses.clear();
-    pluginClasses.clear();
   }
 
   /**

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1361,7 +1361,6 @@ public class Cooja extends Observable {
 
         if (moteTypeClass != null) {
           registerMoteType(moteTypeClass);
-          // logger.info("Loaded mote type class: " + moteTypeClassName);
         } else {
           logger.warn("Could not load mote type class: " + moteTypeClassName);
         }
@@ -1381,7 +1380,6 @@ public class Cooja extends Observable {
 
         if (pluginClass != null) {
           registerPlugin(pluginClass);
-          // logger.info("Loaded plugin class: " + pluginClassName);
         } else {
           logger.warn("Could not load plugin class: " + pluginClassName);
         }
@@ -1398,7 +1396,6 @@ public class Cooja extends Observable {
 
         if (positionerClass != null) {
           registerPositioner(positionerClass);
-          // logger.info("Loaded positioner class: " + positionerClassName);
         } else {
           logger
           .warn("Could not load positioner class: " + positionerClassName);
@@ -1416,14 +1413,12 @@ public class Cooja extends Observable {
 
         if (radioMediumClass != null) {
           registerRadioMedium(radioMediumClass);
-          // logger.info("Loaded radio medium class: " + radioMediumClassName);
         } else {
           logger.warn("Could not load radio medium class: "
               + radioMediumClassName);
         }
       }
     }
-
   }
 
   /**


### PR DESCRIPTION
Various changes that prepare for returning early without visualization in the Cooja constructor. The next step would be to move the early return, but ScriptRunner assumes there is a desktop and otherwise crashes.