### PR TITLE
Add build system info to cooja --version

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -152,6 +152,13 @@ public class Cooja extends Observable {
    * Version of Cooja.
    */
   public static final String VERSION = "4.8";
+
+  /**
+   *  Version used to detect incompatibility with the Contiki-NG
+   *  build system. The format is <YYYY><MM><DD><2 digit sequence number>.
+   */
+  public static final String CONTIKI_NG_BUILD_VERSION = "2022052601";
+
   private static JFrame frame = null;
   private static final Logger logger = LogManager.getLogger(Cooja.class);
 

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -52,7 +52,7 @@ import java.nio.file.Paths;
  * Contains the command line parameters and is the main entry point for Cooja.
  */
 @Command(version = {
-        "Cooja " + Cooja.VERSION,
+        "Cooja " + Cooja.VERSION + ", Contiki-NG build interface version " + Cooja.CONTIKI_NG_BUILD_VERSION,
         "JVM: ${java.version} (${java.vendor} ${java.vm.name} ${java.vm.version})",
         "OS: ${os.name} ${os.version} ${os.arch}"})
 class Main {

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -248,9 +248,7 @@ public class ContikiMoteType implements MoteType {
     String ccFlags = Cooja.getExternalToolsSetting("COMPILER_ARGS", "");
     ArrayList<String[]> env = new ArrayList<>();
     env.add(new String[] { "LIBNAME", "$(BUILD_DIR_BOARD)/" + getIdentifier() + ".cooja" });
-    // COOJA_VERSION is used to detect incompatibility with the Contiki-NG
-    // build system. The format is <YYYY><MM><DD><2 digit sequence number>.
-    env.add(new String[] { "COOJA_VERSION", "2022052601" });
+    env.add(new String[] { "COOJA_VERSION",  Cooja.CONTIKI_NG_BUILD_VERSION });
     env.add(new String[] { "CLASSNAME", javaClassName});
     env.add(new String[] { "COOJA_SOURCEDIRS", dirs.toString().replace("\\", "/") });
     env.add(new String[] { "COOJA_SOURCEFILES", sources.toString() });


### PR DESCRIPTION
This makes it possible for the end-user to query
Cooja for what Contiki-NG build interface version
it is expecting.