### PR TITLE
Return error when mote creation fails

### DIFF
--- a/java/org/contikios/cooja/Mote.java
+++ b/java/org/contikios/cooja/Mote.java
@@ -105,7 +105,7 @@ public interface Mote {
    * @see #getConfigXML()
    */
   boolean setConfigXML(Simulation simulation,
-      Collection<Element> configXML, boolean visAvailable);
+      Collection<Element> configXML, boolean visAvailable) throws MoteType.MoteTypeCreationException;
 
   /**
    * Called when mote is removed from simulation

--- a/java/org/contikios/cooja/MoteInterface.java
+++ b/java/org/contikios/cooja/MoteInterface.java
@@ -77,12 +77,12 @@ public abstract class MoteInterface extends Observable {
    * @return Mote interface instance
    */
   public static MoteInterface generateInterface(
-      Class<? extends MoteInterface> interfaceClass, Mote mote) {
+      Class<? extends MoteInterface> interfaceClass, Mote mote) throws MoteType.MoteTypeCreationException {
     try {
       return interfaceClass.getConstructor(new Class[] { Mote.class }).newInstance(mote);
     } catch (Exception e) {
       logger.fatal("Exception when calling constructor of " + interfaceClass, e);
-      return null;
+      throw new MoteType.MoteTypeCreationException("Exception when calling constructor of " + interfaceClass, e);
     }
   }
 

--- a/java/org/contikios/cooja/MoteInterfaceHandler.java
+++ b/java/org/contikios/cooja/MoteInterfaceHandler.java
@@ -97,15 +97,9 @@ public class MoteInterfaceHandler {
    * @param mote Mote
    * @param interfaceClasses Mote interface classes
    */
-  public MoteInterfaceHandler(Mote mote, Class<? extends MoteInterface>[] interfaceClasses) {
+  public MoteInterfaceHandler(Mote mote, Class<? extends MoteInterface>[] interfaceClasses) throws MoteType.MoteTypeCreationException {
     for (Class<? extends MoteInterface> interfaceClass : interfaceClasses) {
-      MoteInterface intf = MoteInterface.generateInterface(interfaceClass, mote);
-
-      if (intf != null) {
-        addInterface(intf);
-      } else {
-        logger.fatal("Could not load interface: " + interfaceClass);
-      }
+      addInterface(MoteInterface.generateInterface(interfaceClass, mote));
     }
   }
 

--- a/java/org/contikios/cooja/MoteType.java
+++ b/java/org/contikios/cooja/MoteType.java
@@ -164,7 +164,7 @@ public interface MoteType {
    *          Simulation that will contain mote
    * @return New mote
    */
-  Mote generateMote(Simulation simulation);
+  Mote generateMote(Simulation simulation) throws MoteTypeCreationException;
 
   /**
    * This method configures and initializes a mote type ready to be used. It is

--- a/java/org/contikios/cooja/contikimote/ContikiMote.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMote.java
@@ -75,7 +75,7 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
    * @param moteType Mote type
    * @param sim Mote's simulation
    */
-  public ContikiMote(ContikiMoteType moteType, Simulation sim) {
+  public ContikiMote(ContikiMoteType moteType, Simulation sim) throws MoteType.MoteTypeCreationException {
     setSimulation(sim);
     this.myType = moteType;
     this.myMemory = moteType.createInitialMemory();
@@ -179,7 +179,12 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
   public boolean setConfigXML(Simulation simulation, Collection<Element> configXML, boolean visAvailable) {
     setSimulation(simulation);
     myMemory = myType.createInitialMemory();
-    myInterfaceHandler = new MoteInterfaceHandler(this, myType.getMoteInterfaceClasses());
+    try {
+      myInterfaceHandler = new MoteInterfaceHandler(this, myType.getMoteInterfaceClasses());
+    } catch (Exception e) {
+      logger.fatal("Failed to create mote: " + e);
+      return false;
+    }
 
     for (Element element: configXML) {
       String name = element.getName();

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -202,7 +202,7 @@ public class ContikiMoteType implements MoteType {
   }
 
   @Override
-  public Mote generateMote(Simulation simulation) {
+  public Mote generateMote(Simulation simulation) throws MoteTypeCreationException {
     return new ContikiMote(this, simulation);
   }
 

--- a/java/org/contikios/cooja/dialogs/AddMoteDialog.java
+++ b/java/org/contikios/cooja/dialogs/AddMoteDialog.java
@@ -493,6 +493,13 @@ public class AddMoteDialog extends JDialog {
               "Reduce number of nodes or start Cooja with more memory (\">ant run_bigmem\").",
               "Not enough heap memory.", JOptionPane.ERROR_MESSAGE
           );
+        } catch (MoteType.MoteTypeCreationException e2) {
+          newMotes.clear();
+          JOptionPane.showMessageDialog(
+                  AddMoteDialog.this,
+                  "Could not create mote.\nException message: \"" + e2.getMessage() + "\"\n\n",
+                  "Mote creation failed", JOptionPane.ERROR_MESSAGE
+          );
         }
       }
     }

--- a/java/org/contikios/cooja/motes/AbstractApplicationMote.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMote.java
@@ -85,11 +85,11 @@ public abstract class AbstractApplicationMote extends AbstractWakeupMote impleme
   public abstract void receivedPacket(RadioPacket p);
   public abstract void sentPacket(RadioPacket p);
   
-  public AbstractApplicationMote() {
+  public AbstractApplicationMote() throws MoteType.MoteTypeCreationException {
     moteInterfaces = new MoteInterfaceHandler(this, moteType.getMoteInterfaceClasses());
   }
 
-  public AbstractApplicationMote(MoteType moteType, Simulation sim) {
+  public AbstractApplicationMote(MoteType moteType, Simulation sim) throws MoteType.MoteTypeCreationException {
     setSimulation(sim);
     this.moteType = moteType;
     MemoryLayout.getNative();

--- a/java/org/contikios/cooja/motes/DisturberMoteType.java
+++ b/java/org/contikios/cooja/motes/DisturberMoteType.java
@@ -83,7 +83,7 @@ public class DisturberMoteType extends AbstractApplicationMoteType {
   }
   
   @Override
-  public Mote generateMote(Simulation simulation) {
+  public Mote generateMote(Simulation simulation) throws MoteTypeCreationException {
     return new DisturberMote(this, simulation);
   }
 
@@ -96,10 +96,10 @@ public class DisturberMoteType extends AbstractApplicationMoteType {
     private final static long DELAY = Simulation.MILLISECOND/5;
     private final static long DURATION = 10*Simulation.MILLISECOND;
     
-    public DisturberMote() {
+    public DisturberMote() throws MoteTypeCreationException {
       super();
     }
-    public DisturberMote(MoteType moteType, Simulation simulation) {
+    public DisturberMote(MoteType moteType, Simulation simulation) throws MoteTypeCreationException {
       super(moteType, simulation);
     }
     

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -113,7 +113,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     requestImmediateWakeup();
   }
 
-  protected void initMote() {
+  protected void initMote() throws MoteType.MoteTypeCreationException {
     if (myMoteType != null) {
       initEmulator(myMoteType.getContikiFirmwareFile());
       myMoteInterfaceHandler = createMoteInterfaceHandler();
@@ -173,7 +173,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     getCPU().stop();
   }
 
-  protected MoteInterfaceHandler createMoteInterfaceHandler() {
+  protected MoteInterfaceHandler createMoteInterfaceHandler() throws MoteType.MoteTypeCreationException {
     return new MoteInterfaceHandler(this, getType().getMoteInterfaceClasses());
   }
 
@@ -459,7 +459,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     return getInterfaces().getMoteID().getMoteID();
   }
 
-  public boolean setConfigXML(Simulation simulation, Collection<Element> configXML, boolean visAvailable) {
+  public boolean setConfigXML(Simulation simulation, Collection<Element> configXML, boolean visAvailable) throws MoteType.MoteTypeCreationException {
     setSimulation(simulation);
     if (myMoteInterfaceHandler == null) {
       myMoteInterfaceHandler = createMoteInterfaceHandler();

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -126,7 +126,7 @@ public abstract class MspMoteType implements MoteType {
     moteInterfaceClasses = classes;
   }
 
-  public final Mote generateMote(Simulation simulation) {
+  public final Mote generateMote(Simulation simulation) throws MoteTypeCreationException {
     MspMote mote = createMote(simulation);
     mote.initMote();
     return mote;


### PR DESCRIPTION
The entirety of 07-simulation-base passes on Ubuntu 22.04
despite all the non-sky/z1 tests throwing an exception.
Let the error propagate to the top so the CI tests can
detect failures.