### PR TITLE
Remove powertracker from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 build
 /dist
 /javadoc
-/tools/coffee-manager/coffee.jar


### PR DESCRIPTION
This file is no longer built.