### PR TITLE
MspMoteType: give informational warning

### DIFF
--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -316,8 +316,8 @@ public abstract class MspMoteType implements MoteType {
       }
 
       /* Backwards compatibility: Generate expected firmware file name from source */
-      logger.warn("Old simulation config detected: no firmware file specified, generating expected");
       fileFirmware = getExpectedFirmwareFile(fileSource);
+      logger.warn("Old simulation config detected: no firmware file specified, using '{}'", fileFirmware);
     }
 
     return configureAndInit(Cooja.getTopParentContainer(), simulation, visAvailable);


### PR DESCRIPTION
Tell the user the name that will be used
for the firmware.