### PR TITLE
Refactor loadSimulationConfig

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -3176,12 +3176,10 @@ public class Cooja extends Observable {
 
       // Parse plugin mote argument (if any)
       Mote mote = null;
-      for (Element pluginSubElement : (List<Element>) pluginElement.getChildren()) {
-        if (pluginSubElement.getName().equals("mote_arg")) {
-          int moteNr = Integer.parseInt(pluginSubElement.getText());
-          if (moteNr >= 0 && moteNr < sim.getMotesCount()) {
-            mote = sim.getMote(moteNr);
-          }
+      for (var pluginSubElement : pluginElement.getChildren("mote_arg")) {
+        int moteNr = Integer.parseInt(((Element)pluginSubElement).getText());
+        if (moteNr >= 0 && moteNr < sim.getMotesCount()) {
+          mote = sim.getMote(moteNr);
         }
       }
 
@@ -3192,10 +3190,8 @@ public class Cooja extends Observable {
       }
 
       /* Apply plugin specific configuration */
-      for (Element pluginSubElement : (List<Element>) pluginElement.getChildren()) {
-        if (pluginSubElement.getName().equals("plugin_config")) {
-          startedPlugin.setConfigXML(pluginSubElement.getChildren(), isVisualized());
-        }
+      for (var pluginSubElement : pluginElement.getChildren("plugin_config")) {
+        startedPlugin.setConfigXML(((Element)pluginSubElement).getChildren(), isVisualized());
       }
 
       /* Activate plugin */

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2873,27 +2873,26 @@ public class Cooja extends Observable {
       root.detach();
 
       /* Locate Contiki mote types in config */
-      var moteTypeIDMappings = new HashMap<String, String>();
+      var readNames = new ArrayList<String>();
       var motetypes = root.getDescendants(new ElementFilter("motetype"));
       while (motetypes.hasNext()) {
         var e = (Element)motetypes.next();
         if (ContikiMoteType.class.getName().equals(e.getContent(0).getValue().trim())) {
-          moteTypeIDMappings.put(e.getChild("identifier").getValue(), "");
+          readNames.add(e.getChild("identifier").getValue());
         }
       }
 
       /* Create old to new identifier mappings */
-      var existingIdentifiers = moteTypeIDMappings.keySet();
-      for (var existingIdentifier : existingIdentifiers) {
+      var moteTypeIDMappings = new HashMap<String, String>();
+      ArrayList<Object> reserved = new ArrayList<>(readNames);
+      for (var existingIdentifier : readNames) {
         MoteType[] existingMoteTypes = null;
         if (mySimulation != null) {
           existingMoteTypes = mySimulation.getMoteTypes();
         }
-        ArrayList<Object> reserved = new ArrayList<>();
-        reserved.addAll(moteTypeIDMappings.keySet());
-        reserved.addAll(moteTypeIDMappings.values());
         String newID = ContikiMoteType.generateUniqueMoteTypeID(existingMoteTypes, reserved);
         moteTypeIDMappings.put(existingIdentifier, newID);
+        reserved.add(newID);
       }
 
       /* Create new config */

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2857,15 +2857,14 @@ public class Cooja extends Observable {
 
   private Simulation loadSimulationConfig(Element root, boolean quick, Long manualRandomSeed)
   throws SimulationCreationException {
+    // Check that config file version is correct
+    if (!root.getName().equals("simconf")) {
+      logger.fatal("Not a valid Cooja simulation config.");
+      return null;
+    }
+
     Simulation newSim = null;
-
     try {
-      // Check that config file version is correct
-      if (!root.getName().equals("simconf")) {
-        logger.fatal("Not a valid Cooja simulation config.");
-        return null;
-      }
-
       /* Verify extension directories */
       boolean projectsOk = verifyProjects(root.getChildren());
 

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2885,11 +2885,8 @@ public class Cooja extends Observable {
       /* Create old to new identifier mappings */
       var moteTypeIDMappings = new HashMap<String, String>();
       ArrayList<Object> reserved = new ArrayList<>(readNames);
+      var existingMoteTypes = mySimulation == null ? null : mySimulation.getMoteTypes();
       for (var existingIdentifier : readNames) {
-        MoteType[] existingMoteTypes = null;
-        if (mySimulation != null) {
-          existingMoteTypes = mySimulation.getMoteTypes();
-        }
         String newID = ContikiMoteType.generateUniqueMoteTypeID(existingMoteTypes, reserved);
         moteTypeIDMappings.put(existingIdentifier, newID);
         reserved.add(newID);

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2916,16 +2916,14 @@ public class Cooja extends Observable {
       }
 
       // Create new simulation from config
-      for (Object element : root.getChildren()) {
-        if (((Element) element).getName().equals("simulation")) {
-          Collection<Element> config = ((Element) element).getChildren();
-          newSim = new Simulation(this);
-          System.gc();
+      for (var element : root.getChildren("simulation")) {
+        Collection<Element> config = ((Element) element).getChildren();
+        newSim = new Simulation(this);
+        System.gc();
 
-          if (!newSim.setConfigXML(config, isVisualized(), quick, manualRandomSeed)) {
-            logger.info("Simulation not loaded");
-            return null;
-          }
+        if (!newSim.setConfigXML(config, isVisualized(), quick, manualRandomSeed)) {
+          logger.info("Simulation not loaded");
+          return null;
         }
       }
 


### PR DESCRIPTION
Manipulate the in-memory XML representation instead of serializing to a string and perform regexp substitutions on that string.

A lot of whitespace changes, easiest to review commit by commit.