### PR TITLE
Optimize getCompressedIPv6AddressString

### DIFF
--- a/java/org/contikios/cooja/util/IPUtils.java
+++ b/java/org/contikios/cooja/util/IPUtils.java
@@ -95,7 +95,7 @@ public class IPUtils {
         else if (i > 0) {
           builder.append(':');
         }
-        builder.append(String.format("%x", a));
+        builder.append(Integer.toHexString(a & 0xFFFF));
       }
     }
   }


### PR DESCRIPTION
String.format is used for hex conversion of a short
and shows up in a profile. Use Integer.toHexString
instead.