### PR TITLE
Only save settings upon changes

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2330,9 +2330,8 @@ public class Cooja extends Observable {
         setExternalToolsSetting("FRAME_WIDTH", String.valueOf(frame.getWidth()));
         setExternalToolsSetting("FRAME_HEIGHT", String.valueOf(frame.getHeight()));
       }
+      saveExternalToolsUserSettings();
     }
-    saveExternalToolsUserSettings();
-
     System.exit(exitCode);
   }
 


### PR DESCRIPTION
The external tools user settings can not
be changed in headless mode, so move
the call inside the isVisualized() if-statement.