### PR TITLE
Simplify generateUniqueMoteTypeID

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -70,6 +70,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Observable;
 import java.util.Observer;
@@ -2814,10 +2815,15 @@ public class Cooja extends Observable {
 
       /* Create old to new identifier mappings */
       var moteTypeIDMappings = new HashMap<String, String>();
-      ArrayList<Object> reserved = new ArrayList<>(readNames);
+      var reserved = new HashSet<>(readNames);
       var existingMoteTypes = mySimulation == null ? null : mySimulation.getMoteTypes();
+      if (existingMoteTypes != null) {
+        for (var mote : existingMoteTypes) {
+          reserved.add(mote.getIdentifier());
+        }
+      }
       for (var existingIdentifier : readNames) {
-        String newID = ContikiMoteType.generateUniqueMoteTypeID(existingMoteTypes, reserved);
+        String newID = ContikiMoteType.generateUniqueMoteTypeID(reserved);
         moteTypeIDMappings.put(existingIdentifier, newID);
         reserved.add(newID);
       }

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -45,6 +45,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.swing.JComponent;
@@ -1024,31 +1025,16 @@ public class ContikiMoteType implements MoteType {
   /**
    * Generates a unique Cooja mote type ID.
    *
-   * @param existingTypes Already existing mote types, may be null
-   * @param reservedIdentifiers Already reserved identifiers, may be null
+   * @param reservedIdentifiers Already reserved identifiers
    * @return Unique mote type ID.
    */
-  public static String generateUniqueMoteTypeID(MoteType[] existingTypes, Collection reservedIdentifiers) {
+  public static String generateUniqueMoteTypeID(Set<String> reservedIdentifiers) {
     String testID = "";
     boolean available = false;
 
     while (!available) {
       testID = "mtype" + new Random().nextInt(1000000000);
-      available = reservedIdentifiers == null || !reservedIdentifiers.contains(testID);
-
-      if (!available) {
-        continue;
-      }
-
-      // Check if identifier is used
-      if (existingTypes != null) {
-        for (MoteType existingMoteType : existingTypes) {
-          if (existingMoteType.getIdentifier().equals(testID)) {
-            available = false;
-            break;
-          }
-        }
-      }
+      available = !reservedIdentifiers.contains(testID);
       // FIXME: add check that the library name is not already used.
     }
 

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -39,6 +39,7 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 
+import java.util.HashSet;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.JButton;
@@ -58,6 +59,7 @@ import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.MoteInterface;
+import org.contikios.cooja.MoteType;
 import org.contikios.cooja.ProjectConfig;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.contikimote.ContikiMoteType;
@@ -116,8 +118,11 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
     }
 
     if (moteType.getIdentifier() == null) {
-      moteType.setIdentifier(
-          ContikiMoteType.generateUniqueMoteTypeID(simulation.getMoteTypes(), null));
+      var usedNames = new HashSet<String>();
+      for (var mote : simulation.getMoteTypes()) {
+        usedNames.add(mote.getIdentifier());
+      }
+      moteType.setIdentifier(ContikiMoteType.generateUniqueMoteTypeID(usedNames));
     }
 
     moteType.setContikiSourceFile(source);


### PR DESCRIPTION
Pass in a single parameter that contains
all the names that are reserved. This
avoids iterating over the already
active motes for each new name generated.