### PR TITLE
Disable plugins without simulation

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -983,6 +983,8 @@ public class Cooja extends Observable {
         JMenuItem menuItem = new JMenuItem(description + "...");
         menuItem.putClientProperty("class", newPluginClass);
         menuItem.addActionListener(menuItemListener);
+        // Only enable items when there is a simulation, otherwise the user gets a dialog with a backtrace.
+        menuItem.setEnabled(getSimulation() != null);
         return menuItem;
       }
 


### PR DESCRIPTION
The user gets a dialog with a backtrace
if clicking on these menu items unless
they have a simulation available. Disable
the menu items without a simulation.