### PR TITLE
Optimize SectionMoteMemory

### DIFF
--- a/java/org/contikios/cooja/mote/memory/SectionMoteMemory.java
+++ b/java/org/contikios/cooja/mote/memory/SectionMoteMemory.java
@@ -141,19 +141,6 @@ public class SectionMoteMemory implements MemoryInterface {
   }
 
   /**
-   * True if given address is part of this memory section.
-   *
-   * @param intf
-   * @param addr
-   * Address
-   * @return True if given address is part of this memory section, false
-   * otherwise
-   */
-  public static boolean includesAddr(MemoryInterface intf, long addr) {
-    return addr >= intf.getStartAddr() && addr < (intf.getStartAddr() + intf.getTotalSize());
-  }
-
-  /**
    * True if the whole address range specified by address and size
    * lies inside this memory section.
    *
@@ -199,7 +186,12 @@ public class SectionMoteMemory implements MemoryInterface {
   public byte[] getMemorySegment(long address, int size) throws MoteMemoryException {
 
     for (MemoryInterface section : sections.values()) {
-      if (includesAddr(section, address) && includesAddr(section, address + size - 1)) {
+      final var secStart = section.getStartAddr();
+      final var secSize = section.getTotalSize();
+      if (address >= secStart &&
+          address < secStart + secSize &&
+          address + size - 1 >= secStart &&
+          address + size - 1 < secStart + secSize) {
         return section.getMemorySegment(address, size);
       }
     }

--- a/java/org/contikios/cooja/mote/memory/SectionMoteMemory.java
+++ b/java/org/contikios/cooja/mote/memory/SectionMoteMemory.java
@@ -191,7 +191,7 @@ public class SectionMoteMemory implements MemoryInterface {
       if (address >= secStart &&
           address < secStart + secSize &&
           address + size - 1 >= secStart &&
-          address + size - 1 < secStart + secSize) {
+          address + size <= secStart + secSize) {
         return section.getMemorySegment(address, size);
       }
     }

--- a/java/org/contikios/cooja/mote/memory/SectionMoteMemory.java
+++ b/java/org/contikios/cooja/mote/memory/SectionMoteMemory.java
@@ -187,8 +187,7 @@ public class SectionMoteMemory implements MemoryInterface {
 
     for (MemoryInterface section : sections.values()) {
       final var secStart = section.getStartAddr();
-      final var secSize = section.getTotalSize();
-      if (address >= secStart && address + size <= secStart + secSize) {
+      if (address >= secStart && address + size <= secStart + section.getTotalSize()) {
         return section.getMemorySegment(address, size);
       }
     }

--- a/java/org/contikios/cooja/mote/memory/SectionMoteMemory.java
+++ b/java/org/contikios/cooja/mote/memory/SectionMoteMemory.java
@@ -188,10 +188,7 @@ public class SectionMoteMemory implements MemoryInterface {
     for (MemoryInterface section : sections.values()) {
       final var secStart = section.getStartAddr();
       final var secSize = section.getTotalSize();
-      if (address >= secStart &&
-          address < secStart + secSize &&
-          address + size - 1 >= secStart &&
-          address + size <= secStart + secSize) {
+      if (address >= secStart && address + size <= secStart + secSize) {
         return section.getMemorySegment(address, size);
       }
     }


### PR DESCRIPTION
The method is quick, but is called
a lot, so inline it at the single
callsite instead. This enables futher
optimization by removing redundant checks.