### PR TITLE
Use validated information

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -678,9 +678,14 @@ public class Simulation extends Observable implements Runnable {
         	moteTypeClassName = moteTypeClassName.replaceFirst("se\\.sics", "org.contikios");
         }
 
+        var availableMoteTypesObjs = getCooja().getRegisteredMoteTypes();
+        String[] availableMoteTypes = new String[availableMoteTypesObjs.size()];
+        for (int i = 0; i < availableMoteTypes.length; i++) {
+          availableMoteTypes[i] = availableMoteTypesObjs.get(i).getName();
+        }
+
         /* Try to recreate simulation using a different mote type */
         if (visAvailable && !quick) {
-          String[] availableMoteTypes = getCooja().getProjectConfig().getStringArrayValue("org.contikios.cooja.Cooja.MOTETYPES");
           String newClass = (String) JOptionPane.showInputDialog(
               Cooja.getTopParentContainer(),
               "The simulation is about to load '" + moteTypeClassName + "'\n" +
@@ -700,23 +705,23 @@ public class Simulation extends Observable implements Runnable {
           }
         }
 
-        Class<? extends MoteType> moteTypeClass = cooja.tryLoadClass(this,
-            MoteType.class, moteTypeClassName);
-
-        if (moteTypeClass == null) {
-          logger.fatal("Could not load mote type class: " + moteTypeClassName);
-          throw new MoteType.MoteTypeCreationException("Could not load mote type class: " + moteTypeClassName);
+        Class<? extends MoteType> moteTypeClass = null;
+        for (int i = 0; i < availableMoteTypes.length; i++) {
+          if (moteTypeClassName.equals(availableMoteTypes[i])) {
+            moteTypeClass = availableMoteTypesObjs.get(i);
+            break;
+          }
         }
 
-        MoteType moteType = moteTypeClass.getConstructor((Class[]) null).newInstance();
+        assert moteTypeClass != null : "Selected MoteType class is null";
+        MoteType moteType = moteTypeClass.getConstructor((Class<? extends MoteType>[]) null).newInstance();
 
         boolean createdOK = moteType.setConfigXML(this, element.getChildren(),
             visAvailable);
         if (createdOK) {
           addMoteType(moteType);
         } else {
-          logger
-              .fatal("Mote type was not created: " + element.getText().trim());
+          logger.fatal("Mote type was not created: " + element.getText().trim());
           return false;
         }
       }

--- a/java/org/contikios/cooja/dialogs/ProjectDirectoriesDialog.java
+++ b/java/org/contikios/cooja/dialogs/ProjectDirectoriesDialog.java
@@ -429,12 +429,27 @@ public class ProjectDirectoriesDialog extends JDialog {
 				}
 			}
 		}
-		if (project.getConfigMoteTypes() != null) {
-			projectInfo.append("Mote types: " + Arrays.toString(project.getConfigMoteTypes()) + "\n");
-		}
-		if (project.getConfigRadioMediums() != null) {
-			projectInfo.append("Radio mediums: " + Arrays.toString(project.getConfigRadioMediums()) + "\n");
-		}
+    var sb = new StringBuilder();
+    var moteTypes = gui.getRegisteredMoteTypes();
+    if (moteTypes != null) {
+      sb.append("Mote types:");
+      for (var moteType : moteTypes) {
+        sb.append(' ').append(moteType.toString());
+      }
+      sb.append("\n");
+      projectInfo.append(sb.toString());
+      sb.setLength(0);
+    }
+    var radioMediums = gui.getRegisteredRadioMediums();
+    if (radioMediums != null) {
+      sb.append("Radio mediums:");
+      for (var medium : radioMediums) {
+        sb.append(' ').append(medium.toString());
+      }
+      sb.append("\n");
+      projectInfo.append(sb.toString());
+      sb.setLength(0);
+    }
 		if (project.getConfigMoteInterfaces() != null) {
 			projectInfo.append("Cooja mote interfaces: " + Arrays.toString(project.getConfigMoteInterfaces()) + "\n");
 		}


### PR DESCRIPTION
The Cooja constructor will parse `cooja_default.config` and keep track of the mote types/radio mediums/etc that passed tryLoadClass(). Use this validated information instead of parsing the text file again and potentially get an immediate failure if the configuration is faulty.