### PR TITLE
Shorten thread names

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -678,7 +678,7 @@ public class Cooja extends Observable {
   }
 
   private void doLoadConfigAsync(final boolean quick, final File file) {
-    new Thread(() -> cooja.doLoadConfig(file, quick, false, null), "doLoadConfigAsync").start();
+    new Thread(() -> cooja.doLoadConfig(file, quick, false, null), "asyncld").start();
   }
   private void updateOpenHistoryMenuItems(File[] openFilesHistory) {
   	menuOpenSimulation.removeAll();

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -345,7 +345,7 @@ public class Simulation extends Observable implements Runnable {
   public void startSimulation() {
     if (!isRunning()) {
       isRunning = true;
-      simulationThread = new Thread(this, "simulationThread");
+      simulationThread = new Thread(this, "sim");
       simulationThread.start();
     }
   }

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -310,7 +310,7 @@ public class LogScriptEngine {
           }
         }
       }
-    }, "scriptThread");
+    }, "script");
     scriptThread.start(); /* Starts by acquiring semaphore (blocks) */
     while (!semaphoreScript.hasQueuedThreads()) {
       try {


### PR DESCRIPTION
The more descriptive threadd names improved
readability for profiling, but chatty threads
disturb the log4j output. Shorten the names
of the threads that typically appear in
the output.