### PR TITLE
Fix broken javadoc references

### DIFF
--- a/java/org/contikios/cooja/Mote.java
+++ b/java/org/contikios/cooja/Mote.java
@@ -69,7 +69,6 @@ public interface Mote {
   /**
    * Returns mote type.
    *
-   * @see org.contikios.cooja.contikimote.ContikiMote#setType(MoteType)
    * @return Mote type
    */
   MoteType getType();

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -201,7 +201,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
    * Prepares CPU, memory and ELF module.
    *
    * @param fileELF ELF file
-   * @param cpu MSP430 cpu
+   * @param node MSP430 cpu
    * @throws IOException Preparing mote failed
    */
   protected void prepareMote(File fileELF, GenericNode node) throws IOException {


### PR DESCRIPTION
The setType method was removed in b1efc97ba7cdf8e25afa6df130d7f365d2fe5701, so just remove the reference.