### PR TITLE
Cooja: replace call to deprecated method

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2032,7 +2032,7 @@ public class Cooja extends Observable {
     // Create mote type
     MoteType newMoteType = null;
     try {
-      newMoteType = moteTypeClass.newInstance();
+      newMoteType = moteTypeClass.getDeclaredConstructor().newInstance();
       if (!newMoteType.configureAndInit(Cooja.getTopParentContainer(), mySimulation, isVisualized())) {
         return;
       }


### PR DESCRIPTION
This way of calling newInstance() apparently
gives better compiler checking, and is not
deprecated.