### PR TITLE
AES128: stop using toString() on array

### DIFF
--- a/java/se/sics/mspsim/core/AES128.java
+++ b/java/se/sics/mspsim/core/AES128.java
@@ -32,6 +32,7 @@
  */
 package se.sics.mspsim.core;
 
+import java.util.Arrays;
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -304,7 +305,7 @@ public class AES128 extends IOUnit {
                         outData.put(bytes);
                         outData.resetPos();
                 } catch (Exception e) {
-                        log(e.getStackTrace().toString());
+                        log(Arrays.toString(e.getStackTrace()));
                 }
         }
 
@@ -326,7 +327,7 @@ public class AES128 extends IOUnit {
                         outData.put(bytes);
                         outData.resetPos();
                 } catch (Exception e) {
-                        log(e.getStackTrace().toString());
+                        log(Arrays.toString(e.getStackTrace()));
                 }
         }
 


### PR DESCRIPTION
Calling .toString() on an array will print
the object identity, not a human readable
form of its content. Replace with Arrays.toString()
instead.