### PR TITLE
Use Cooja location for javac

### DIFF
--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -170,8 +170,7 @@ public abstract class CoreComm {
           Cooja.getExternalToolsSetting("PATH_JAVAC"),
           "-cp",
           "." + File.pathSeparator +
-          Cooja.getExternalToolsSetting("PATH_CONTIKI")
-          + "/tools/cooja/dist/cooja.jar",
+          Cooja.getExternalToolsSetting("PATH_COOJA") + "dist/cooja.jar",
           tempDir + "/org/contikios/cooja/corecomm/" + className + ".java" };
 
       ProcessBuilder pb = new ProcessBuilder(cmd);


### PR DESCRIPTION
This might be the cause for setting the working
directory on the run targets in build.xml.

Gradle will be easier to integrate with this
change in the tree.