### PR TITLE
LogScriptEngine: speedup newLogOutput

### DIFF
--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -78,9 +78,10 @@ public class LogScriptEngine {
     }
     @Override
     public void newLogOutput(LogOutputEvent ev) {
+      final var mote = ev.getMote();
       handleNewMoteOutput(
-          ev.getMote(),
-          ev.getMote().getID(),
+          mote,
+          mote.getID(),
           ev.getTime(),
           ev.msg
       );

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -78,14 +78,14 @@ public class LogScriptEngine {
     }
     @Override
     public void newLogOutput(LogOutputEvent ev) {
+      if (scriptThread == null || !scriptThread.isAlive()) {
+        logger.warn("No script thread, deactivate script.");
+        return;
+      }
+
       // Only called from the simulation loop.
       final var mote = ev.getMote();
       try {
-        if (scriptThread == null || !scriptThread.isAlive()) {
-          logger.warn("No script thread, deactivate script.");
-          return;
-        }
-
         // Update script variables.
         engine.put("mote", mote);
         engine.put("id", mote.getID());

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -78,13 +78,30 @@ public class LogScriptEngine {
     }
     @Override
     public void newLogOutput(LogOutputEvent ev) {
+      // Only called from the simulation loop.
       final var mote = ev.getMote();
-      handleNewMoteOutput(
-          mote,
-          mote.getID(),
-          ev.getTime(),
-          ev.msg
-      );
+      try {
+        if (scriptThread == null || !scriptThread.isAlive()) {
+          logger.warn("No script thread, deactivate script.");
+          return;
+        }
+
+        // Update script variables.
+        engine.put("mote", mote);
+        engine.put("id", mote.getID());
+        engine.put("time", ev.getTime());
+        engine.put("msg", ev.msg);
+
+        stepScript();
+      } catch (UndeclaredThrowableException e) {
+        logger.fatal("Exception: " + e.getMessage(), e);
+        if (Cooja.isVisualized()) {
+          Cooja.showErrorDialog(Cooja.getTopParentContainer(),
+              e.getMessage(),
+              e, false);
+        }
+        simulation.stopSimulation();
+      }
     }
     @Override
     public void removedLogOutput(LogOutputEvent ev) {
@@ -141,34 +158,6 @@ public class LogScriptEngine {
     if (quitCooja) {
       quitRunnable.run();
       quitCooja = false;
-    }
-  }
-
-  /* Only called from the simulation loop */
-  private void handleNewMoteOutput(Mote mote, int id, long time, String msg) {
-    try {
-      if (scriptThread == null ||
-          !scriptThread.isAlive()) {
-        logger.warn("No script thread, deactivate script.");
-        /*scriptThread.isInterrupted()*/
-        return;
-      }
-
-      /* Update script variables */
-      engine.put("mote", mote);
-      engine.put("id", id);
-      engine.put("time", time);
-      engine.put("msg", msg);
-
-      stepScript();
-    } catch (UndeclaredThrowableException e) {
-      logger.fatal("Exception: " + e.getMessage(), e);
-      if (Cooja.isVisualized()) {
-        Cooja.showErrorDialog(Cooja.getTopParentContainer(),
-            e.getMessage(),
-            e, false);
-      }
-      simulation.stopSimulation();
     }
   }
 


### PR DESCRIPTION
This method shows up in the profiling data, so make it a bit faster by avoiding some recomputations and inlining the called method.