### PR TITLE
Cooja: do not dereference null

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -3435,6 +3435,10 @@ public class Cooja extends Observable {
       }.invokeAndWait();
     }
 
+    if (!isVisualized()) {
+      return true;
+    }
+
     /* Z order visualized plugins */
     try {
     	for (int z=0; z < getDesktopPane().getAllFrames().length; z++) {


### PR DESCRIPTION
Return early in headless mode instead of
dereferencing null and catching the exception.