### PR TITLE
Always register default skins

### DIFF
--- a/config/external_tools.config
+++ b/config/external_tools.config
@@ -40,12 +40,3 @@ COMMAND_BSS_START = ^__bss_start[ \t]B[ \t]([0-9A-Fa-f]*)[ \t]*$
 COMMAND_BSS_END = ^_end[ \t]B[ \t]([0-9A-Fa-f]*)[ \t]*$
 COMMAND_READONLY_START = ^.rodata[ \t]r[ \t]([0-9A-Fa-f]*)[ \t]*$
 COMMAND_READONLY_END = ^.eh_frame_hdr[ \t]r[ \t]([0-9A-Fa-f]*)[ \t]*$
-
-VISUALIZER_DEFAULT_SKINS=\
-org.contikios.cooja.plugins.skins.IDVisualizerSkin;\
-org.contikios.cooja.plugins.skins.GridVisualizerSkin;\
-org.contikios.cooja.plugins.skins.DGRMVisualizerSkin;\
-org.contikios.cooja.plugins.skins.TrafficVisualizerSkin;\
-org.contikios.cooja.plugins.skins.UDGMVisualizerSkin;\
-org.contikios.cooja.plugins.skins.LogisticLossVisualizerSkin;\
-org.contikios.mrm.MRMVisualizerSkin

--- a/java/org/contikios/cooja/plugins/Visualizer.java
+++ b/java/org/contikios/cooja/plugins/Visualizer.java
@@ -95,6 +95,9 @@ import javax.swing.plaf.basic.BasicInternalFrameUI;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.contikios.cooja.plugins.skins.DGRMVisualizerSkin;
+import org.contikios.cooja.plugins.skins.LogisticLossVisualizerSkin;
+import org.contikios.mrm.MRMVisualizerSkin;
 import org.jdom.Element;
 
 import org.contikios.cooja.ClassDescription;
@@ -712,7 +715,14 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
       return;
     }
 
-    /* Activate default skins */
+    // Activate default skins.
+    generateAndActivateSkin(IDVisualizerSkin.class);
+    generateAndActivateSkin(GridVisualizerSkin.class);
+    generateAndActivateSkin(DGRMVisualizerSkin.class);
+    generateAndActivateSkin(TrafficVisualizerSkin.class);
+    generateAndActivateSkin(UDGMVisualizerSkin.class);
+    generateAndActivateSkin(LogisticLossVisualizerSkin.class);
+    generateAndActivateSkin(MRMVisualizerSkin.class);
     String[] defaultSkins = Cooja.getExternalToolsSetting("VISUALIZER_DEFAULT_SKINS", "").split(";");
     for (String skin : defaultSkins) {
       if (skin.isEmpty()) {


### PR DESCRIPTION
Always register the skins that are
a part of Cooja. This makes the code
less dynamic which helps compilers
and code analysis tools to do a better
job.