### PR TITLE
Cooja: avoid VisPlugin early when headless

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -3358,6 +3358,10 @@ public class Cooja extends Observable {
         logger.fatal("Could not load plugin class: " + pluginClassName);
         return false;
       }
+      // Skip plugins that require visualization in headless mode.
+      if (!isVisualized() && VisPlugin.class.isAssignableFrom(pluginClass)) {
+        continue;
+      }
 
       // Parse plugin mote argument (if any)
       Mote mote = null;


### PR DESCRIPTION
Subclasses of VisPlugin are never loaded in
headless mode, so detect these classes early
and continue to the next class.