### PR TITLE
Move code around in LogScriptRunner

### DIFF
--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -153,13 +153,13 @@ public class LogScriptEngine {
     /* Check if test script requested us to stop */
     if (stopSimulation) {
       simulation.stopSimulation();
-      stopSimulation = false;
     }
     if (quitCooja) {
       simulation.stopSimulation();
       quitRunnable.run();
-      quitCooja = false;
     }
+    stopSimulation = false;
+    quitCooja = false;
   }
 
   public void setScriptLogObserver(Observer observer) {

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -152,7 +152,7 @@ public class LogScriptEngine {
 
     /* Check if test script requested us to stop */
     if (stopSimulation) {
-      stopSimulationRunnable.run();
+      simulation.stopSimulation();
       stopSimulation = false;
     }
     if (quitCooja) {
@@ -370,12 +370,6 @@ public class LogScriptEngine {
     }
   };
 
-  private final Runnable stopSimulationRunnable = new Runnable() {
-    @Override
-    public void run() {
-      simulation.stopSimulation();
-    }
-  };
   private final Runnable quitRunnable = new Runnable() {
     @Override
     public void run() {
@@ -436,7 +430,12 @@ public class LogScriptEngine {
       if (Cooja.isVisualized()) {
         log("[if test was run without visualization, Cooja would now have been terminated]\n");
         stopSimulation = true;
-        simulation.invokeSimulationThread(stopSimulationRunnable);
+        simulation.invokeSimulationThread(new Runnable() {
+          @Override
+          public void run() {
+            simulation.stopSimulation();
+          }
+        });
       } else {
         quitCooja = true;
         simulation.invokeSimulationThread(quitRunnable);

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -430,12 +430,7 @@ public class LogScriptEngine {
       if (Cooja.isVisualized()) {
         log("[if test was run without visualization, Cooja would now have been terminated]\n");
         stopSimulation = true;
-        simulation.invokeSimulationThread(new Runnable() {
-          @Override
-          public void run() {
-            simulation.stopSimulation();
-          }
-        });
+        simulation.invokeSimulationThread(simulation::stopSimulation);
       } else {
         quitCooja = true;
         simulation.invokeSimulationThread(quitRunnable);

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -146,6 +146,7 @@ public class LogScriptEngine {
       semSim.acquire();
     } catch (InterruptedException e1) {
       e1.printStackTrace();
+      // FIXME: Something called interrupt() on this thread, computation should stop.
     }
 
     /* ... script is now again waiting for script semaphore ... */
@@ -205,6 +206,7 @@ public class LogScriptEngine {
         scriptThread.join();
       } catch (InterruptedException e) {
         e.printStackTrace();
+        // FIXME: Something called interrupt() on this thread, computation needs to stop.
       }
     }
     scriptThread = null;
@@ -254,6 +256,7 @@ public class LogScriptEngine {
       semaphoreScript.acquire();
     } catch (InterruptedException e) {
       logger.fatal("Error when creating engine: " + e.getMessage(), e);
+      // FIXME: should not proceed after this.
     }
     ThreadGroup group = new ThreadGroup("script") {
       @Override
@@ -306,7 +309,7 @@ public class LogScriptEngine {
       try {
         Thread.sleep(50);
       } catch (InterruptedException e) {
-        // Does not matter, we are waiting.
+        // FIXME: Something called interrupt() on this thread, stop the computation.
       }
     }
 

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -156,6 +156,7 @@ public class LogScriptEngine {
       stopSimulation = false;
     }
     if (quitCooja) {
+      simulation.stopSimulation();
       quitRunnable.run();
       quitCooja = false;
     }
@@ -373,7 +374,6 @@ public class LogScriptEngine {
   private final Runnable quitRunnable = new Runnable() {
     @Override
     public void run() {
-      simulation.stopSimulation();
       new Thread(() -> {
         try { Thread.sleep(500); } catch (InterruptedException e) { }
         simulation.getCooja().doQuit(false, exitCode);
@@ -433,6 +433,7 @@ public class LogScriptEngine {
         simulation.invokeSimulationThread(simulation::stopSimulation);
       } else {
         quitCooja = true;
+        simulation.invokeSimulationThread(simulation::stopSimulation);
         simulation.invokeSimulationThread(quitRunnable);
       }
 


### PR DESCRIPTION
Move some code around in preparation for untangling interactions between threads.