### PR TITLE
Single-pass section start/address mapfile parsing on Linux

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -594,17 +594,16 @@ public class ContikiMoteType implements MoteType {
     protected boolean parseStartAddrAndSize() {
       startAddr = -1;
       size = -1;
-      var mapData = getData();
       Pattern varPattern = Pattern.compile(startRegExp);
-      for (var line : mapData) {
+      Pattern sizePattern = Pattern.compile(sizeRegExp);
+      for (var line : getData()) {
         Matcher varMatcher = varPattern.matcher(line);
         if (varMatcher.find()) {
           startAddr = Long.parseUnsignedLong(varMatcher.group(1).trim(), 16);
-          break;
         }
-      }
-      Pattern sizePattern = Pattern.compile(sizeRegExp);
-      for (var line : mapData) {
+        // TODO: size is on the same line as the section address in the docker image,
+        //       put the size matcher inside the varMatcher.find() block once this has
+        //       had more testing.
         Matcher sizeMatcher = sizePattern.matcher(line);
         if (sizeMatcher.find()) {
           size = (int) Long.parseUnsignedLong(sizeMatcher.group(1).trim(), 16);

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -413,7 +413,7 @@ public class ContikiMoteType implements MoteType {
 
     SectionParser dataSecParser;
     SectionParser bssSecParser;
-    SectionParser commonSecParser;
+    SectionParser commonSecParser = null;
 
     if (useCommand) {
       /* Parse command output */
@@ -463,10 +463,6 @@ public class ContikiMoteType implements MoteType {
               mapData,
               Cooja.getExternalToolsSetting("MAPFILE_BSS_START"),
               Cooja.getExternalToolsSetting("MAPFILE_BSS_SIZE"));
-      commonSecParser = new MapSectionParser(
-              mapData,
-              Cooja.getExternalToolsSetting("MAPFILE_COMMON_START"),
-              Cooja.getExternalToolsSetting("MAPFILE_COMMON_SIZE"));
     }
 
     /* We first need the value of Contiki's referenceVar, which tells us the
@@ -481,7 +477,9 @@ public class ContikiMoteType implements MoteType {
       VarMemory varMem = new VarMemory(tmp);
       tmp.addMemorySection("tmp.data", dataSecParser.parse(0));
       tmp.addMemorySection("tmp.bss", bssSecParser.parse(0));
-      tmp.addMemorySection("tmp.common", commonSecParser.parse(0));
+      if (commonSecParser != null) {
+        tmp.addMemorySection("tmp.common", commonSecParser.parse(0));
+      }
 
       try {
         long referenceVar = varMem.getVariable("referenceVar").addr;
@@ -504,7 +502,9 @@ public class ContikiMoteType implements MoteType {
 
     initialMemory.addMemorySection("bss", bssSecParser.parse(offset));
 
-    initialMemory.addMemorySection("common", commonSecParser.parse(offset));
+    if (commonSecParser != null) {
+      initialMemory.addMemorySection("common", commonSecParser.parse(offset));
+    }
 
     getCoreMemory(initialMemory);
   }

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -582,6 +582,10 @@ public class ContikiMoteType implements MoteType {
 
     public MapSectionParser(String[] mapFileData, String startRegExp, String sizeRegExp) {
       super(mapFileData);
+      assert startRegExp != null : "Section start regexp must be specified";
+      assert !startRegExp.isEmpty() : "Section start regexp must contain characters";
+      assert sizeRegExp != null : "Section size regexp must be specified";
+      assert !sizeRegExp.isEmpty() : "Section size regexp must contain characters";
       this.startRegExp = startRegExp;
       this.sizeRegExp = sizeRegExp;
     }
@@ -591,24 +595,20 @@ public class ContikiMoteType implements MoteType {
       startAddr = -1;
       size = -1;
       var mapData = getData();
-      if (startRegExp != null && !startRegExp.equals("")) {
-        Pattern varPattern = Pattern.compile(startRegExp);
-        for (var line : mapData) {
-          Matcher varMatcher = varPattern.matcher(line);
-          if (varMatcher.find()) {
-            startAddr = Long.parseUnsignedLong(varMatcher.group(1).trim(), 16);
-            break;
-          }
+      Pattern varPattern = Pattern.compile(startRegExp);
+      for (var line : mapData) {
+        Matcher varMatcher = varPattern.matcher(line);
+        if (varMatcher.find()) {
+          startAddr = Long.parseUnsignedLong(varMatcher.group(1).trim(), 16);
+          break;
         }
       }
-      if (sizeRegExp != null && !sizeRegExp.equals("")) {
-        Pattern sizePattern = Pattern.compile(sizeRegExp);
-        for (var line : mapData) {
-          Matcher sizeMatcher = sizePattern.matcher(line);
-          if (sizeMatcher.find()) {
-            size = (int) Long.parseUnsignedLong(sizeMatcher.group(1).trim(), 16);
-            break;
-          }
+      Pattern sizePattern = Pattern.compile(sizeRegExp);
+      for (var line : mapData) {
+        Matcher sizeMatcher = sizePattern.matcher(line);
+        if (sizeMatcher.find()) {
+          size = (int) Long.parseUnsignedLong(sizeMatcher.group(1).trim(), 16);
+          break;
         }
       }
       return startAddr >= 0 && size > 0;


### PR DESCRIPTION
This makes `parseStartAddrAndSize()` in MapSectionParser a single-pass operation. There are further optimization opportunities that are low hanging fruit, but start with this conservative optimization.

The OS X function is left with a FIXME so it can be updated after this has had some more testing.