### PR TITLE
CI: enable gradle cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 7.4.2
+          cache-read-only: false
           arguments: jar
       - name: Test MSPSim
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
The Gradle module provides all functionality
concerning caching, but by default, only jobs
on master will update the cache.

Allow pull requests to master to update the cache
so Gradle doesn't have to be downloaded in each CI
job.