### PR TITLE
gradle: use new task API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ jar {
 //  }
 }
 
-task fullJar(type: Jar) {
+tasks.register('fullJar', Jar) {
   archiveClassifier = 'full'
   reproducibleFileOrder = true
   manifest {


### PR DESCRIPTION
The new API works like a function would,
the previous API evaluates things in
the task body even when the task isn't used.