### PR TITLE
ScriptRunner: initialize SyntaxKit in constructor

### DIFF
--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -37,7 +37,6 @@ import de.sciss.syntaxpane.actions.ScriptRunnerAction;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.GraphicsEnvironment;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -85,13 +84,6 @@ public class ScriptRunner implements Plugin {
   private static final Logger logger = LogManager.getLogger(ScriptRunner.class);
 
   private final Cooja gui;
-  static boolean headless;
-  {
-    headless = GraphicsEnvironment.isHeadless();
-    if (!headless) {
-      DefaultSyntaxKit.initKit();
-    }
-  }
 
   final String[] EXAMPLE_SCRIPTS = new String[] {
       "basic.js", "Various commands",
@@ -127,6 +119,7 @@ public class ScriptRunner implements Plugin {
       return;
     }
 
+    DefaultSyntaxKit.initKit();
     frame = new VisPlugin("Simulation script editor", gui, this);
 
     /* Menus */
@@ -411,7 +404,7 @@ public class ScriptRunner implements Plugin {
         logWriter = null;
       }
 
-      if (!headless) {
+      if (Cooja.isVisualized()) {
         if (actionLinkFile != null) {
           actionLinkFile.setEnabled(true);
         }


### PR DESCRIPTION
The constructor knows if Cooja is visualized, so
put the SyntaxKit initialization in the code
that is only run when Cooja is visualized.