### PR TITLE
CoreComm: use current classpath

### DIFF
--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -169,9 +169,7 @@ public abstract class CoreComm {
       int b;
       String[] cmd = new String[] {
           Cooja.getExternalToolsSetting("PATH_JAVAC"),
-          "-cp",
-          "." + File.pathSeparator +
-          Cooja.getExternalToolsSetting("PATH_COOJA") + "dist/cooja.jar",
+          "-cp", System.getProperty("java.class.path"),
           tempDir + "/org/contikios/cooja/corecomm/" + className + ".java" };
 
       ProcessBuilder pb = new ProcessBuilder(cmd);


### PR DESCRIPTION
Use the classpath for the current invocation
instead of trying to construct something from
the configuration.

This guarantees that the java file will compile
against the same classes that it will be loaded
with.