### PR TITLE
Stop synchronizing on non-final fields

### DIFF
--- a/java/se/sics/mspsim/cli/CommandHandler.java
+++ b/java/se/sics/mspsim/cli/CommandHandler.java
@@ -19,7 +19,7 @@ public class CommandHandler implements ActiveComponent, LineListener {
   protected final PrintStream err;
   private MapTable mapTable;
   private ComponentRegistry registry;
-  private ArrayList<CommandContext[]> currentAsyncCommands = new ArrayList<CommandContext[]>();
+  private final ArrayList<CommandContext[]> currentAsyncCommands = new ArrayList<>();
   private int pidCounter = 0;
 
   public CommandHandler(PrintStream out, PrintStream err) {

--- a/java/se/sics/mspsim/ui/ConsoleUI.java
+++ b/java/se/sics/mspsim/ui/ConsoleUI.java
@@ -96,7 +96,7 @@ public class ConsoleUI extends JComponent {
   /* size of lines */
   int lineWidth = 40;
 
-  private ArrayDeque<String> commands = new ArrayDeque<String>();
+  private final ArrayDeque<String> commands = new ArrayDeque<>();
 
   private int len = 0;
   private int back = 0;

--- a/java/se/sics/mspsim/ui/SerialMon.java
+++ b/java/se/sics/mspsim/ui/SerialMon.java
@@ -75,7 +75,7 @@ public class SerialMon implements USARTListener, StateChangeListener, ServiceCom
   private int historyCount = 0;
   private String text = "*** Serial mon for MSPsim ***\n";
 
-  private ArrayDeque<String> sendQueue = new ArrayDeque<String>(8);
+  private final ArrayDeque<String> sendQueue = new ArrayDeque<>(8);
   private int sendIndex;
 
   private int lines = 1;


### PR DESCRIPTION
Make the fields that are synchronized on final
to ensure that all threads synchronize on the same
container.