### PR TITLE
CoreComm: compile as java 11

### DIFF
--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -164,7 +164,7 @@ public abstract class CoreComm {
       int b;
       String[] cmd = new String[] {
           Cooja.getExternalToolsSetting("PATH_JAVAC"),
-          "-cp", System.getProperty("java.class.path"),
+          "-cp", System.getProperty("java.class.path"), "--release", "11",
           tempDir + "/org/contikios/cooja/corecomm/" + className + ".java" };
 
       ProcessBuilder pb = new ProcessBuilder(cmd);


### PR DESCRIPTION
Cooja is compiled as Java 11 and javac on
LibN.java needs to produce a classfile of
the same version.