### PR TITLE
AbstractApplicationMote: remove unused object

### DIFF
--- a/java/org/contikios/cooja/motes/AbstractApplicationMote.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMote.java
@@ -48,7 +48,6 @@ import org.contikios.cooja.interfaces.ApplicationRadio;
 import org.contikios.cooja.interfaces.ApplicationSerialPort;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.mote.memory.MemoryInterface;
-import org.contikios.cooja.mote.memory.MemoryLayout;
 
 /**
  * Abstract application mote.
@@ -92,7 +91,6 @@ public abstract class AbstractApplicationMote extends AbstractWakeupMote impleme
   public AbstractApplicationMote(MoteType moteType, Simulation sim) throws MoteType.MoteTypeCreationException {
     setSimulation(sim);
     this.moteType = moteType;
-    MemoryLayout.getNative();
     this.memory = new SectionMoteMemory(new HashMap<>());
     this.moteInterfaces = new MoteInterfaceHandler(this, moteType.getMoteInterfaceClasses());
     this.moteInterfaces.getRadio().addObserver(radioDataObserver);


### PR DESCRIPTION
The commit that added this line also added
a similar line to the MspMote constructor.
The line in the MspMote constructor has
already been removed by someone else.