### PR TITLE
Memory: update long size for 64-bit arch

### DIFF
--- a/java/org/contikios/cooja/mote/memory/Memory.java
+++ b/java/org/contikios/cooja/mote/memory/Memory.java
@@ -138,7 +138,7 @@ public abstract class Memory {
    * @return long read from address
    */
   public long getLongValueOf(long addr) {
-    return MemoryBuffer.wrap(memIntf.getLayout(), memIntf.getMemorySegment(addr, 4)).getLong();
+    return MemoryBuffer.wrap(memIntf.getLayout(), memIntf.getMemorySegment(addr, 8)).getLong();
   }
 
   /**
@@ -252,7 +252,7 @@ public abstract class Memory {
    * @param value long to write
    */
   public void setLongValueOf(long addr, long value) {
-    memIntf.setMemorySegment(addr, MemoryBuffer.wrap(memIntf.getLayout(), new byte[4]).putLong(value).getBytes());
+    memIntf.setMemorySegment(addr, MemoryBuffer.wrap(memIntf.getLayout(), new byte[8]).putLong(value).getBytes());
   }
 
   /**


### PR DESCRIPTION
Long is 32 bits on Windows and 64 bits on most other
64-bit platforms. Use the larger size since that
matches Linux/OS X.