### PR TITLE
Add .gradle_home to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gradle
+.gradle_home
 *~
 build
 /dist


### PR DESCRIPTION
The docker image cannot save content
outside of the Contiki-NG repository.
Add an ignored directory for gradle home
so users can restart their containers
without having to download the dependencies
again.

This directory will also be used by
the Contiki-NG CI.