### PR TITLE
Simulation: fix speedup printout

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -295,6 +295,11 @@ public class Simulation extends Observable implements Runnable {
 
         if (stopSimulation) {
           isRunning = false;
+          var duration = System.currentTimeMillis() - lastStartTime;
+          var curSimTime = getSimulationTimeMillis();
+          logger.info("Runtime: " + duration + " ms. " +
+                  "Simulated time: " + curSimTime + " ms. " +
+                  "Speedup: " + ((double)curSimTime / (double)duration));
         }
       }
     } catch (RuntimeException e) {
@@ -322,13 +327,6 @@ public class Simulation extends Observable implements Runnable {
 
     this.setChanged();
     this.notifyObservers(this);
-    logger.info("Simulation completed, system time: " + System.currentTimeMillis() +
-        "\tDuration: " + (System.currentTimeMillis() - lastStartTime) +
-                " ms" +
-                "\tSimulated time " + getSimulationTimeMillis() +
-                " ms\tRatio " +
-                ((double)getSimulationTimeMillis() /
-                 (double)(System.currentTimeMillis() - lastStartTime)));
   }
 
   /**


### PR DESCRIPTION
Calculate the runtime of the simulation
once, and then use and use the runtime
for calculating the speedup, rather than
calculating a new runtime for the ratio.
Remove the system time in milliseconds part
of the printout, if time should be printed
for informational purposes it should be
a human-readable readable form.

Also move the printout into the part that
leaves the event loop. This makes the runtime
calculation more precise, and avoids printing
the speedup message when exceptions were thrown.