### PR TITLE
gradle: remove workingDir workaround

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,8 +86,6 @@ tasks.register('fullJar', Jar) {
 }
 
 run {
-  // Workaround for make call in CompileContiki.java.
-  workingDir = file('build')
   // Bad Cooja location detected with gradle run, explicitly pass -cooja.
   doFirst {
     args += ['-cooja', "$projectDir"]

--- a/config/external_tools.config
+++ b/config/external_tools.config
@@ -1,5 +1,5 @@
-PATH_COOJA = ../
-PATH_CONTIKI = ../../../
+PATH_COOJA = ./
+PATH_CONTIKI = ../../
 PATH_CONTIKI_NG_BUILD_DIR = build/cooja
 PATH_MAKE = make
 PATH_SHELL = sh


### PR DESCRIPTION
Ant and Gradle needed to be in agreement
about the working directory during the migration
phase. Remove the workaround now since ant
is no longer a concern.