### PR TITLE
LogScriptEngine: call stopSimulation directly

### DIFF
--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -426,7 +426,7 @@ public class LogScriptEngine {
       } else {
         quitCooja = true;
       }
-      simulation.invokeSimulationThread(simulation::stopSimulation);
+      simulation.stopSimulation(false);
 
       throw new RuntimeException("test script killed");
     }


### PR DESCRIPTION
Invoking stopSimulation from the simulation
thread just sets stopSimulation = false if
the simulation is running. Call it from
the current thread instead so the variable
gets set without waiting for the simulation
thread to process the poll requests.