### PR TITLE
Run GUI things in Swing thread

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1350,40 +1350,40 @@ public class Cooja extends Observable {
     return myDesktopPane;
   }
 
-  private static void setLookAndFeel() {
+  private static void setLookAndFeel() throws InterruptedException, InvocationTargetException {
+    javax.swing.SwingUtilities.invokeAndWait(() -> {
+      JFrame.setDefaultLookAndFeelDecorated(true);
+      JDialog.setDefaultLookAndFeelDecorated(true);
 
-    JFrame.setDefaultLookAndFeelDecorated(true);
-    JDialog.setDefaultLookAndFeelDecorated(true);
+      ToolTipManager.sharedInstance().setDismissDelay(60000);
 
-    ToolTipManager.sharedInstance().setDismissDelay(60000);
-
-    /* Nimbus */
-    try {
-      String osName = System.getProperty("os.name").toLowerCase();
-      if (osName.startsWith("linux")) {
-        try {
-          for (LookAndFeelInfo info : UIManager.getInstalledLookAndFeels()) {
-            if ("Nimbus".equals(info.getName())) {
+      /* Nimbus */
+      try {
+        String osName = System.getProperty("os.name").toLowerCase();
+        if (osName.startsWith("linux")) {
+          try {
+            for (LookAndFeelInfo info : UIManager.getInstalledLookAndFeels()) {
+              if ("Nimbus".equals(info.getName())) {
                 UIManager.setLookAndFeel(info.getClassName());
                 break;
+              }
             }
+          } catch (UnsupportedLookAndFeelException e) {
+            UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
           }
-
-        } catch (UnsupportedLookAndFeelException e) {
-          UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
+        } else {
+          UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
         }
-      } else {
-        UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+        return;
+      } catch (Exception e) {
       }
-      return;
-    } catch (Exception e) {
-    }
 
-    /* System */
-    try {
-      UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-    } catch (Exception e) {
-    }
+      /* System */
+      try {
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+      } catch (Exception e) {
+      }
+    });
   }
 
   private static void updateDesktopSize(final JDesktopPane desktop) {
@@ -3041,7 +3041,14 @@ public class Cooja extends Observable {
     var vis = options.action == null || options.action.quickstart != null;
 
     if (vis) {
-      setLookAndFeel();
+      try {
+        setLookAndFeel();
+      } catch (InterruptedException e) {
+        logger.fatal("Thread interrupted: " + e.getMessage());
+        return;
+      } catch (InvocationTargetException e) {
+        throw new RuntimeException(e);
+      }
     }
 
     Cooja gui = null;


### PR DESCRIPTION
Ensure GUI things run in the Swing thread.

Error handling can still be improved, but this hopefully stops the:

Unknown error: javax.swing.plaf.BorderUIResource cannot be cast to java.awt.Font

exceptions from happening in the first place.