### PR TITLE
ContikiMoteType: optimize mapfile parsing further

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -595,18 +595,15 @@ public class ContikiMoteType implements MoteType {
       startAddr = -1;
       size = -1;
       Pattern varPattern = Pattern.compile(startRegExp);
-      Pattern sizePattern = Pattern.compile(sizeRegExp);
       for (var line : getData()) {
         Matcher varMatcher = varPattern.matcher(line);
         if (varMatcher.find()) {
           startAddr = Long.parseUnsignedLong(varMatcher.group(1).trim(), 16);
-        }
-        // TODO: size is on the same line as the section address in the docker image,
-        //       put the size matcher inside the varMatcher.find() block once this has
-        //       had more testing.
-        Matcher sizeMatcher = sizePattern.matcher(line);
-        if (sizeMatcher.find()) {
-          size = (int) Long.parseUnsignedLong(sizeMatcher.group(1).trim(), 16);
+          Pattern sizePattern = Pattern.compile(sizeRegExp);
+          Matcher sizeMatcher = sizePattern.matcher(line);
+          if (sizeMatcher.find()) {
+            size = (int) Long.parseUnsignedLong(sizeMatcher.group(1).trim(), 16);
+          }
           break;
         }
       }


### PR DESCRIPTION
Assume size and start address are on the same line,
and only try to match the size when the start address
has matched. After that, stop the iteration.