### PR TITLE
Cooja: add option for using FlatLaf

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ dependencies {
   implementation 'ch.qos.logback:logback-classic:1.4.11'
   // https://mvnrepository.com/artifact/com.github.cliftonlabs/json-simple
   implementation 'com.github.cliftonlabs:json-simple:4.0.1'
+  // https://mvnrepository.com/artifact/com.formdev/flatlaf
+  implementation 'com.formdev:flatlaf:3.2.1'
   // https://mvnrepository.com/artifact/de.sciss/syntaxpane
   implementation 'de.sciss:syntaxpane:1.3.0'
   // https://mvnrepository.com/artifact/info.picocli/picocli

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -161,7 +161,7 @@ public class Cooja {
       return new RunnableInEDT<Cooja>() {
         @Override
         public Cooja work() {
-          GUI.setLookAndFeel();
+          GUI.setLookAndFeel(configuration.lookAndFeel);
           try {
             return new Cooja();
           } catch (ParseProjectsException e) {
@@ -1680,8 +1680,8 @@ public class Cooja {
    * When SimConfig contains an identical field, these values are the default
    * values when creating a new simulation in the File menu.
    */
-  public record Config(LogbackColors logColors, boolean vis, String externalToolsConfig,
-                       String nashornArgs, String logDir,
+  public record Config(LogbackColors logColors, boolean vis, GUI.LookAndFeel lookAndFeel,
+                       String externalToolsConfig, String nashornArgs, String logDir,
                        String contikiPath, String coojaPath) {}
 
   public record LogbackColors(String error, String warn, String info, String fallback) {}

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -60,6 +60,12 @@ import se.sics.mspsim.util.ArgumentManager;
         "OS: ${os.name} ${os.version} ${os.arch}"}, sortOptions = false, sortSynopsis = false)
 class Main {
   /**
+   * Option for specifying look and feel.
+   */
+  @Option(names = "--look-and-feel", paramLabel = "LookAndFeel", description = "one of: ${COMPLETION-CANDIDATES}")
+  GUI.LookAndFeel lookAndFeel = GUI.LookAndFeel.Nimbus;
+
+  /**
    * Option for specifying if a GUI should be used.
    */
   @Option(names = "--gui", description = "use graphical mode", negatable = true)
@@ -154,6 +160,7 @@ class Main {
   public static void main(String[] args) {
     Main options = new Main();
     CommandLine commandLine = new CommandLine(options);
+    commandLine.setCaseInsensitiveEnumValuesAllowed(true);
     try {
       commandLine.parseArgs(args);
     } catch (CommandLine.ParameterException e) {
@@ -299,7 +306,7 @@ class Main {
       // Use colors that are good on a dark background and readable on a white background.
       var colors = new LogbackColors(ANSIConstants.BOLD + "91", "96",
               ANSIConstants.GREEN_FG, ANSIConstants.DEFAULT_FG);
-      var cfg = new Config(colors, options.gui, options.externalUserConfig,
+      var cfg = new Config(colors, options.gui, options.lookAndFeel, options.externalUserConfig,
                 options.nashornArgs,
                 options.logDir, options.contikiPath, options.coojaPath);
       Cooja.go(cfg, simConfigs);


### PR DESCRIPTION
Add a command-line option to select look and
feel, but continue to use Nimbus as default.
    
This allows us to remove the fallback code
for setting look and feel, so the user either
gets what they requested, or a failure.

Setting dragMode leaves residue from the borders
when moving windows on OS X, so use the default
dragMode.