### PR TITLE
Close log4j logs properly

### DIFF
--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -261,14 +261,13 @@ class Main {
       // Construct the root logger and initialize the configurator
       builder.add(builder.newRootLogger(Level.INFO).add(builder.newAppenderRef("Stdout"))
               .add(builder.newAppenderRef("File")));
-      // FIXME: This should be try (LoggerContext cxt = Configurator.initialize(..)),
-      //        but go immediately returns which causes the log file to be closed
-      //        while the simulation is still running.
-      Configurator.initialize(builder.build());
-      Cooja.go(options);
+      try (var cxt = Configurator.initialize(builder.build())) {
+        Cooja.go(options);
+      }
     } else {
-      Configurator.initialize("ConfigFile", options.logConfigFile);
-      Cooja.go(options);
+      try (var cxt = Configurator.initialize("ConfigFile", options.logConfigFile)) {
+        Cooja.go(options);
+      }
     }
   }
 }


### PR DESCRIPTION
Add a synchronization between Cooja and
go() so the log4j resources in main can
be wrapped in a try-with-resources.