### PR TITLE
Revert "Close log4j logs properly"

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -71,7 +71,6 @@ import java.util.MissingResourceException;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import javax.swing.AbstractAction;
@@ -358,9 +357,6 @@ public class Cooja extends Observable {
     }
   }
   private final ArrayList<MoteRelation> moteRelations = new ArrayList<>();
-
-  /** Synchronization for returning from go(). */
-  private static final CountDownLatch completed = new CountDownLatch(1);
 
   /**
    * Creates a new Cooja Simulator GUI and ensures Swing initialization is done in the right thread.
@@ -2680,8 +2676,6 @@ public class Cooja extends Observable {
       }
       saveExternalToolsUserSettings();
     }
-    // Release the thread waiting in go().
-    completed.countDown();
     System.exit(exitCode);
   }
 
@@ -3097,12 +3091,6 @@ public class Cooja extends Observable {
       if (sim == null) {
         System.exit(1);
       }
-    }
-    // Wait for Cooja to exit. This is required so the log4j logs are closed after Cooja is completed.
-    try {
-      completed.await();
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
     }
   }
 
@@ -4174,8 +4162,6 @@ public class Cooja extends Observable {
       if (simulation != null) {
         simulation.stopSimulation(true);
       }
-      // Release the thread waiting in go().
-      completed.countDown();
     }
   }
 

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -261,13 +261,14 @@ class Main {
       // Construct the root logger and initialize the configurator
       builder.add(builder.newRootLogger(Level.INFO).add(builder.newAppenderRef("Stdout"))
               .add(builder.newAppenderRef("File")));
-      try (var cxt = Configurator.initialize(builder.build())) {
-        Cooja.go(options);
-      }
+      // FIXME: This should be try (LoggerContext cxt = Configurator.initialize(..)),
+      //        but go immediately returns which causes the log file to be closed
+      //        while the simulation is still running.
+      Configurator.initialize(builder.build());
+      Cooja.go(options);
     } else {
-      try (var cxt = Configurator.initialize("ConfigFile", options.logConfigFile)) {
-        Cooja.go(options);
-      }
+      Configurator.initialize("ConfigFile", options.logConfigFile);
+      Cooja.go(options);
     }
   }
 }


### PR DESCRIPTION
Cooja sometimes hangs after the latest
changes, so revert the patch that most
likely causes the issue.

This reverts commit 914ca495d47b54a4f317782e6f55aeea4db94f5c.