### PR TITLE
Stop reinitializing motes in setConfigXML

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMote.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMote.java
@@ -64,7 +64,7 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
   private static final Logger logger = LogManager.getLogger(ContikiMote.class);
 
   private final ContikiMoteType myType;
-  private SectionMoteMemory myMemory;
+  private final SectionMoteMemory myMemory;
   private MoteInterfaceHandler myInterfaceHandler;
 
   /**
@@ -170,7 +170,6 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
   @Override
   public boolean setConfigXML(Simulation simulation, Collection<Element> configXML, boolean visAvailable) {
     setSimulation(simulation);
-    myMemory = myType.createInitialMemory();
     try {
       myInterfaceHandler = new MoteInterfaceHandler(this, myType.getMoteInterfaceClasses());
     } catch (Exception e) {

--- a/java/org/contikios/cooja/contikimote/ContikiMote.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMote.java
@@ -65,7 +65,7 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
 
   private final ContikiMoteType myType;
   private final SectionMoteMemory myMemory;
-  private MoteInterfaceHandler myInterfaceHandler;
+  private final MoteInterfaceHandler myInterfaceHandler;
 
   /**
    * Creates a new mote of given type.
@@ -170,13 +170,6 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
   @Override
   public boolean setConfigXML(Simulation simulation, Collection<Element> configXML, boolean visAvailable) {
     setSimulation(simulation);
-    try {
-      myInterfaceHandler = new MoteInterfaceHandler(this, myType.getMoteInterfaceClasses());
-    } catch (Exception e) {
-      logger.fatal("Failed to create mote: " + e);
-      return false;
-    }
-
     for (Element element: configXML) {
       String name = element.getName();
 

--- a/java/org/contikios/cooja/contikimote/ContikiMote.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMote.java
@@ -169,7 +169,6 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
 
   @Override
   public boolean setConfigXML(Simulation simulation, Collection<Element> configXML, boolean visAvailable) {
-    setSimulation(simulation);
     for (Element element: configXML) {
       String name = element.getName();
 

--- a/java/org/contikios/cooja/motes/AbstractApplicationMote.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMote.java
@@ -146,7 +146,6 @@ public abstract class AbstractApplicationMote extends AbstractWakeupMote impleme
   @Override
   public boolean setConfigXML(Simulation simulation,
       Collection<Element> configXML, boolean visAvailable) {
-    setSimulation(simulation);
     this.memory = new SectionMoteMemory(new HashMap<>());
     moteInterfaces.getRadio().addObserver(radioDataObserver);
 

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -106,7 +106,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
   public GenericNode mspNode = null;
 
   public MspMote(MspMoteType moteType, Simulation simulation) {
-    this.simulation = simulation;
+    setSimulation(simulation);
     myMoteType = moteType;
 
     /* Schedule us immediately */
@@ -474,7 +474,6 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
 
   @Override
   public boolean setConfigXML(Simulation simulation, Collection<Element> configXML, boolean visAvailable) throws MoteType.MoteTypeCreationException {
-    setSimulation(simulation);
     if (myMoteInterfaceHandler == null) {
       myMoteInterfaceHandler = createMoteInterfaceHandler();
     }


### PR DESCRIPTION
Motes are created with respect to a simulation, so use the assignments in the constructor instead of reassigning values again.