### PR TITLE
Cooja: check right variable

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2198,9 +2198,7 @@ public class Cooja extends Observable {
   }
 
   private void setSimulation(Simulation sim, boolean startPlugins) {
-    if (sim != null) {
-      doRemoveSimulation(false);
-    }
+    doRemoveSimulation(false);
     mySimulation = sim;
     updateGUIComponentState();
 


### PR DESCRIPTION
There are sanity checks in doRemoveSimulation()
so call it unconditionally. The check removed
by this commit must have been intended to be
mySimulation != null.