### PR TITLE
ContikiMoteType: remove coreinterfaces + follow-on simplifications

### DIFF
--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -111,14 +111,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
 
   @Override
   public boolean canLoadFirmware(File file) {
-    /* Disallow loading firmwares without compilation */
-    /*
-    if (file.getName().endsWith(ContikiMoteType.librarySuffix)) {
-      return true;
-    }
-    */
-
-    return false;
+    return false; // Always recompile, CoreComm needs fresh names.
   }
 
   @Override

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -116,14 +116,8 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
 
   @Override
   public String getDefaultCompileCommands(final File source) {
-    if (moteType == null) {
-      /* Not ready to compile yet */
-      return "";
-    }
-
-    if (source == null || !source.exists()) {
-      /* Not ready to compile yet */
-      return "";
+    if (moteType == null || source == null || !source.exists()) {
+      return ""; // Not ready to compile yet.
     }
 
     if (moteType.getIdentifier() == null) {

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -338,23 +338,6 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
   }
 
   @Override
-  public void compileContiki()
-  throws Exception {
-    if (((ContikiMoteType)moteType).mapFile == null ||
-        ((ContikiMoteType)moteType).javaClassName == null) {
-      throw new Exception("Library variables not defined");
-    }
-
-    /* Extract Contiki dependencies from currently selected mote interfaces */
-    String[] coreInterfaces =
-      ContikiMoteType.getRequiredCoreInterfaces(getSelectedMoteInterfaceClasses());
-    ((ContikiMoteType)moteType).setCoreInterfaces(coreInterfaces);
-
-    /* Start compiling */
-    super.compileContiki();
-  }
-
-  @Override
   protected String getTargetName() {
   	return "cooja";
   }


### PR DESCRIPTION
The coreInterfaces field is only used to provide some visualization
for the end user about interfaces. Remove the field
and the methods for it. This removes the need for
reflection in ContikiMoteType.

This allows ContikiMoteCompileDialog to use
the default compileContiki() implementation.