### PR TITLE
ContikiMoteType: remove display-only field

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -171,8 +171,6 @@ public class ContikiMoteType implements MoteType {
     }
   }
 
-  private final String[] sensors = {"button_sensor", "pir_sensor", "vib_sensor"};
-
   private String identifier = null;
   private String description = null;
   private File fileSource = null;
@@ -1065,13 +1063,6 @@ public class ContikiMoteType implements MoteType {
     /* JNI class */
     sb.append("<tr><td>JNI library</td><td>")
             .append(this.javaClassName).append("</td></tr>");
-
-    /* Contiki sensors */
-    sb.append("<tr><td valign=\"top\">Contiki sensors</td><td>");
-    for (String sensor : sensors) {
-      sb.append(sensor).append("<br>");
-    }
-    sb.append("</td></tr>");
 
     /* Mote interfaces */
     sb.append("<tr><td valign=\"top\">Mote interface</td><td>");


### PR DESCRIPTION
The only use for this field is to output some
HTML for visualization purposes. Remove the
field since there is no code that updates
the content.