### PR TITLE
Remove PATH_CONTIKI_NG_BUILD_DIR

### DIFF
--- a/config/external_tools.config
+++ b/config/external_tools.config
@@ -1,6 +1,5 @@
 PATH_COOJA = ./
 PATH_CONTIKI = ../../
-PATH_CONTIKI_NG_BUILD_DIR = build/cooja
 PATH_MAKE = make
 PATH_SHELL = sh
 PATH_C_COMPILER = gcc

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -265,7 +265,6 @@ public class Cooja extends Observable {
     "PATH_COOJA",
     "PATH_CONTIKI", "PATH_APPS",
     "PATH_APPSEARCH",
-    "PATH_CONTIKI_NG_BUILD_DIR",
 
     "PATH_MAKE",
     "PATH_SHELL",

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -104,12 +104,6 @@ public class ContikiMoteType implements MoteType {
   private static final String librarySuffix = ".cooja";
 
   /**
-   * Temporary output directory
-   */
-  private static final File tempOutputDirectory = new File(
-      Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "build/cooja"));
-
-  /**
    * Random generator for generating a unique mote ID.
    */
   private static final Random rnd = new Random();
@@ -209,8 +203,7 @@ public class ContikiMoteType implements MoteType {
    * @return The mote file for the extension
    */
   private File getMoteFile(String extension) {
-    var dir = Cooja.getExternalToolsSetting("PATH_CONTIKI_NG_BUILD_DIR", "build/cooja");
-    return new File(fileSource.getParentFile(),dir + "/" + identifier + extension);
+    return new File(fileSource.getParentFile(), "build/cooja/" + identifier + extension);
   }
 
   /**
@@ -365,8 +358,7 @@ public class ContikiMoteType implements MoteType {
   }
 
   public static File getExpectedFirmwareFile(String moteId, File source) {
-    return new File(source.getParentFile(),
-            ContikiMoteType.tempOutputDirectory + "/" + moteId + ContikiMoteType.librarySuffix);
+    return new File(source.getParentFile(), "build/cooja/" + moteId + ContikiMoteType.librarySuffix);
   }
 
   /**


### PR DESCRIPTION
This directory is decided by Contiki-NG,
so remove the option to configure it in
Cooja.