### PR TITLE
Use FileFilter in dialogs

### DIFF
--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -224,7 +224,7 @@ public abstract class AbstractCompileDialog extends JDialog {
         }
 
         fc.setFileSelectionMode(JFileChooser.FILES_ONLY);
-        fc.addChoosableFileFilter(new FileFilter() {
+        fc.setFileFilter(new FileFilter() {
           @Override
           public boolean accept(File f) {
             if (f.isDirectory()) {

--- a/java/org/contikios/cooja/dialogs/ImportAppMoteDialog.java
+++ b/java/org/contikios/cooja/dialogs/ImportAppMoteDialog.java
@@ -135,14 +135,13 @@ public class ImportAppMoteDialog extends JDialog {
         }
 
         fc.setFileSelectionMode(JFileChooser.FILES_ONLY);
-        fc.addChoosableFileFilter(new FileFilter() {
+        fc.setFileFilter(new FileFilter() {
           @Override
           public boolean accept(File f) {
             if (f.isDirectory()) {
               return true;
             }
-            String filename = f.getName();
-            return filename != null && filename.endsWith(".class");
+            return f.getName().endsWith(".class");
           }
 
           @Override

--- a/java/org/contikios/mrm/AreaViewer.java
+++ b/java/org/contikios/mrm/AreaViewer.java
@@ -1120,7 +1120,7 @@ public class AreaViewer extends VisPlugin {
       /* Select image file */
       JFileChooser fileChooser = new JFileChooser();
       ImageFilter filter = new ImageFilter();
-      fileChooser.addChoosableFileFilter(filter);
+      fileChooser.setFileFilter(filter);
 
       int returnVal = fileChooser.showOpenDialog(canvas);
       if (returnVal != JFileChooser.APPROVE_OPTION) {


### PR DESCRIPTION
Calling setFileFilter makes the filter active
so the interesting files are selectable, instead
of giving the option to enable the filter in
a drop-down.