### PR TITLE
AbstractCompileDialog: stop disabling create button

### DIFF
--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -668,8 +668,8 @@ public abstract class AbstractCompileDialog extends JDialog {
     	compileButton.setEnabled(false);
     	createButton.setEnabled(true);
     	commandsArea.setEnabled(false);
-    	setCompileCommands("");
       getRootPane().setDefaultButton(createButton);
+      setCompileCommands("");
       break;
 
     default:
@@ -679,18 +679,25 @@ public abstract class AbstractCompileDialog extends JDialog {
 
   private void addCompileCommandTab(JTabbedPane parent) {
     commandsArea = new JTextArea(10, 1);
+    // Loading firmware sets the create button to default, so do not update dialog state after that.
     commandsArea.getDocument().addDocumentListener(new DocumentListener() {
       @Override
       public void changedUpdate(DocumentEvent e) {
-        setDialogState(DialogState.AWAITING_COMPILATION);
+        if (contikiSource != null || getRootPane().getDefaultButton() != createButton) {
+          setDialogState(DialogState.AWAITING_COMPILATION);
+        }
       }
       @Override
       public void insertUpdate(DocumentEvent e) {
-        setDialogState(DialogState.AWAITING_COMPILATION);
+        if (contikiSource != null || getRootPane().getDefaultButton() != createButton) {
+          setDialogState(DialogState.AWAITING_COMPILATION);
+        }
       }
       @Override
       public void removeUpdate(DocumentEvent e) {
-        setDialogState(DialogState.AWAITING_COMPILATION);
+        if (contikiSource != null || getRootPane().getDefaultButton() != createButton) {
+          setDialogState(DialogState.AWAITING_COMPILATION);
+        }
       }
     });
     parent.addTab("Compile commands", null, new JScrollPane(commandsArea), "Manually alter Contiki compilation commands");


### PR DESCRIPTION
Loading a firmware immediately disables the just enabled
create button when the compile commands are blanked out.
Avoid updating the dialog status in the document listener
for that condition.