### PR TITLE
Start simulator in go()

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -3122,6 +3122,10 @@ public class Cooja extends Observable {
       if (sim == null) {
         System.exit(1);
       }
+      if (!vis) {
+        sim.setSpeedLimit(null);
+        sim.startSimulation();
+      }
     }
   }
 

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -255,11 +255,6 @@ public class ScriptRunner implements Plugin {
 
   @Override
   public void startPlugin() {
-	/* start simulation */
-	if (!Cooja.isVisualized()) {
-	  simulation.setSpeedLimit(null);
-	  simulation.startSimulation();
-	}
   }
 
   public void setLinkFile(File source) {


### PR DESCRIPTION
The simulator is allocated in go() so also
start the simulator there.

There are no strong guarantees for ordering
of plugins so starting the simulator in startPlugin()
is most likely wrong on a fundamental level.