### PR TITLE
AbstractCompileDialog: keep ID and Position enabled

### DIFF
--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -802,8 +802,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     });
 
     /* Always select position and ID interface */
-    if (intfClass == Position.class ||
-        intfClass == MoteID.class) {
+    if (Position.class.isAssignableFrom(intfClass) || MoteID.class.isAssignableFrom(intfClass)) {
       intfCheckBox.setEnabled(false);
       intfCheckBox.setSelected(true);
     }


### PR DESCRIPTION
ContikiMoteType extends MoteID so include classes
that are derived in the check for what interfaces
that can be disabled.

Issue identified by Niclas Finne.