### PR TITLE
Respect speed limit in csc file when headless

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -67,6 +67,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.Observable;
 import java.util.Observer;
@@ -3075,8 +3076,9 @@ public class Cooja extends Observable {
    * Load configurations and create a GUI.
    *
    * @param options Parsed command line options
+   * @param cfg Map of key-value pairs of configuration
    */
-  public static void go(Main options) {
+  public static void go(Main options, Map<String, String> cfg) {
     externalToolsUserSettingsFileReadOnly = options.externalToolsConfig != null;
     if (options.externalToolsConfig == null) {
       externalToolsUserSettingsFile = new File(System.getProperty("user.home"), EXTERNAL_TOOLS_USER_SETTINGS_FILENAME);
@@ -3123,7 +3125,9 @@ public class Cooja extends Observable {
         System.exit(1);
       }
       if (!vis) {
-        sim.setSpeedLimit(null);
+        if (Boolean.parseBoolean(cfg.get("ignore-speed-limit"))) {
+          sim.setSpeedLimit(null);
+        }
         sim.startSimulation();
       }
     }


### PR DESCRIPTION
Switch the default behavior of Cooja to respect
the specified speed limit in headless mode.
The previous behavior is still available by
passing the ignore-speed-limit key-value pair
to -nogui:

-nogui=file.csc,ignore-speed-limit=true