### PR TITLE
Add quickhelp to MspCodeWatcher plugin

### DIFF
--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -407,7 +407,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
       }
       if (to == null) {
         if (rulesWithDebuggingOutput) {
-          rulesDebuggingOutput.addMessage(this + " enter substition: " + f.getPath(), MessageList.ERROR);
+          rulesDebuggingOutput.addMessage(this + " enter substitution: " + f.getPath(), MessageList.ERROR);
         }
         return null;
       }

--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -109,7 +109,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
   private final WatchpointMote watchpointMote;
   private WatchpointListener watchpointListener;
 
-  private final JComboBox fileComboBox;
+  private final JComboBox<String> fileComboBox;
   private File[] sourceFiles;
 
   private final JTabbedPane mainPane;
@@ -163,7 +163,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
     getContentPane().setLayout(new BorderLayout());
 
     /* Create source file list */
-    fileComboBox = new JComboBox();
+    fileComboBox = new JComboBox<>();
     fileComboBox.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(ActionEvent e) {

--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -264,7 +264,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
   }
 
   private void updateFileComboBox() {
-    sourceFiles = getSourceFiles(mspMote, rules);
+    sourceFiles = getSourceFiles(rules);
     fileComboBox.removeAllItems();
     fileComboBox.addItem("[view sourcefile]");
     for (File f: sourceFiles) {
@@ -353,7 +353,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
   }
 
   private int getLocatedSourcesCount() {
-    return getSourceFiles(mspMote, rules).length;
+    return getSourceFiles(rules).length;
   }
 
   private void updateRulesUsage() {
@@ -361,7 +361,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
       rule.prefixMatches = 0;
       rule.locatesFile = 0;
     }
-    getSourceFiles(mspMote, rules);
+    getSourceFiles(rules);
     rulesMatched = new int[rules.size()];
     rulesOK = new int[rules.size()];
     for (int i=0; i < rules.size(); i++) {
@@ -674,7 +674,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
     dialog.setVisible(true);
   }
 
-  private File[] getSourceFiles(MspMote mote, ArrayList<Rule> rules) {
+  private File[] getSourceFiles(ArrayList<Rule> rules) {
     /* Verify that files exist */
     ArrayList<File> existing = new ArrayList<>();
     for (String sourceFile: debugSourceFiles) {

--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -64,6 +64,7 @@ import javax.swing.table.AbstractTableModel;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.contikios.cooja.HasQuickHelp;
 import org.jdom.Element;
 
 import org.contikios.cooja.ClassDescription;
@@ -89,7 +90,7 @@ import se.sics.mspsim.util.ELFDebug;
 @ClassDescription("Msp Code Watcher")
 @PluginType(PluginType.MOTE_PLUGIN)
 @SupportedArguments(motes = {MspMote.class})
-public class MspCodeWatcher extends VisPlugin implements MotePlugin {
+public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHelp {
   private static final int SOURCECODE = 0;
   private static final int BREAKPOINTS = 2;
 
@@ -394,6 +395,15 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin {
       rulesMatched[i] = rules.get(i).prefixMatches;
       rulesOK[i] = rules.get(i).locatesFile;
     }
+  }
+
+  @Override
+  public String getQuickHelp() {
+    return "<b>MSPSim's Code Watcher</b><br>" +
+            "<br>This plugin shows the source code for MSP430 based motes and can set or remove breakpoints." +
+            "<br><br>" +
+            "<b>Note:</b> You must compile the code with <i>DEBUG=1</i> to include information about the source code in the build." +
+            "<br><br>Example: make TARGET=sky DEBUG=1 hello-world";
   }
 
   private class Rule {

--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -301,8 +301,8 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
     /* Source */
     updateCurrentSourceCodeFile();
     File file = currentCodeFile;
-    Integer line = currentLineNumber;
-    if (file == null || line == null) {
+    int line = currentLineNumber;
+    if (file == null || line <= 0) {
       currentFileAction.setEnabled(false);
       currentFileAction.putValue(Action.NAME, "[unknown]");
       currentFileAction.putValue(Action.SHORT_DESCRIPTION, null);

--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -34,14 +34,11 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
-import java.util.Observable;
 import java.util.Observer;
 
 import javax.swing.AbstractAction;

--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -148,14 +148,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
     {
       ArrayList<String> newDebugSourceFiles = new ArrayList<>();
       for (String sf: debugSourceFiles) {
-        boolean found = false;
-        for (String nsf: newDebugSourceFiles) {
-          if (sf.equals(nsf)) {
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
+        if (!newDebugSourceFiles.contains(sf)) {
           newDebugSourceFiles.add(sf);
         }
       }

--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -356,11 +356,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
   }
 
   private int getLocatedSourcesCount() {
-    File[] files = getSourceFiles(mspMote, rules);
-    if (files == null) {
-      return 0;
-    }
-    return files.length;
+    return getSourceFiles(mspMote, rules).length;
   }
 
   private void updateRulesUsage() {

--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -675,14 +675,6 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
   }
 
   private File[] getSourceFiles(MspMote mote, ArrayList<Rule> rules) {
-    File contikiSource = mote.getType().getContikiSourceFile();
-    if (contikiSource != null) {
-      try {
-        contikiSource = contikiSource.getCanonicalFile();
-      } catch (IOException e1) {
-      }
-    }
-
     /* Verify that files exist */
     ArrayList<File> existing = new ArrayList<>();
     for (String sourceFile: debugSourceFiles) {

--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -212,7 +212,6 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
     sourceCodeUI = new CodeUI(watchpointMote);
     JPanel sourceCodePanel = new JPanel(new BorderLayout());
     sourceCodePanel.add(BorderLayout.CENTER, sourceCodeUI);
-    sourceCodePanel.add(BorderLayout.SOUTH, sourceCodeControl);
     mainPane.addTab("Source code", null, sourceCodePanel, null); /* SOURCECODE */
 
     assCodeUI = new DebugUI(this.mspMote.getCPU(), true);
@@ -225,6 +224,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
     mainPane.addTab("Breakpoints", null, breakpointsUI, "Right-click source code to add"); /* BREAKPOINTS */
 
     add(BorderLayout.CENTER, mainPane);
+    add(BorderLayout.SOUTH, sourceCodeControl);
 
     /* Listen for breakpoint changes */
     watchpointMote.addWatchpointListener(watchpointListener = new WatchpointListener() {


### PR DESCRIPTION
Add quick help to describe how to build the motes with debug information. MspCodeWatcher requires this information to find the relevant source code files. Also, some code cleanup.