### PR TITLE
ScriptRunner: stop needless reload

### DIFF
--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -311,14 +311,6 @@ public class ScriptRunner implements Plugin {
 
   private void activateScript() {
     deactivateScript();
-    if (linkedFile != null) {
-      String script = StringUtils.loadFromFile(linkedFile);
-      if (script == null) {
-        logger.fatal("Failed to load script from: " + linkedFile.getAbsolutePath());
-        return;
-      }
-      updateScript(script);
-    }
 
     /* Create new engine */
     engine = new LogScriptEngine(simulation);


### PR DESCRIPTION
The method is called from two places,
the first is the "Activate" menu item,
and the other is setConfigXML. Both
cases ensure that codeEditor.getText()
will contain the script.