### PR TITLE
Have exactly one SimControl

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1123,14 +1123,7 @@ public class Cooja extends Observable {
     reloadSimulationMenuItem.add(new JMenuItem(reloadRandomSimulationAction));
     simulationMenu.add(reloadSimulationMenuItem);
 
-    GUIAction guiAction = new StartPluginGUIAction("Control panel...");
-    menuItem = new JMenuItem(guiAction);
-    guiActions.add(guiAction);
-    menuItem.setMnemonic(KeyEvent.VK_C);
-    menuItem.putClientProperty("class", SimControl.class);
-    simulationMenu.add(menuItem);
-
-    guiAction = new StartPluginGUIAction("Simulation...");
+    var guiAction = new StartPluginGUIAction("Simulation...");
     menuItem = new JMenuItem(guiAction);
     guiActions.add(guiAction);
     menuItem.setMnemonic(KeyEvent.VK_I);

--- a/java/org/contikios/cooja/plugins/SimControl.java
+++ b/java/org/contikios/cooja/plugins/SimControl.java
@@ -94,6 +94,9 @@ public class SimControl extends VisPlugin implements HasQuickHelp {
       updateLabelTimer.start();
     }
 
+    // There should only be one SimControl, so start automatically and prevent closing the window.
+    setClosable(false);
+
     /* Menus */
     JMenuBar menuBar = new JMenuBar();
     JMenu runMenu = new JMenu("Run");


### PR DESCRIPTION
Remove the possibility for the user to open
and close the SimControl window. This ensures
existence of a single SimControl.