### PR TITLE
ContikiMoteCompileDialog: remove spurious null check

### DIFF
--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -116,7 +116,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
 
   @Override
   public String getDefaultCompileCommands(final File source) {
-    if (moteType == null || source == null || !source.exists()) {
+    if (source == null || !source.exists()) {
       return ""; // Not ready to compile yet.
     }
 


### PR DESCRIPTION
The dialog is called from ContikiMoteType, so moteType
can never be null.