### PR TITLE
ContikiMoteType: remove file existence check

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -323,12 +323,6 @@ public class ContikiMoteType implements MoteType {
           throw newException;
         }
       }
-
-      /* Make sure compiled firmware exists */
-      if (getContikiFirmwareFile() == null
-              || !getContikiFirmwareFile().exists()) {
-        throw new MoteTypeCreationException("Contiki firmware file does not exist: " + getContikiFirmwareFile());
-      }
     }
 
     Path tmpDir;


### PR DESCRIPTION
CompileContiki.compile() will throw exceptions
when make fails, so this check can only detect
that the Contiki-NG build system is broken.
Remove the check since the Contiki-NG build
system is unlikely to be broken in this
particular way.