### PR TITLE
Cooja: avoid starting AWT thread

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -368,8 +368,8 @@ public class Cooja extends Observable {
    * @param vis          True if running in visual mode
    */
   public static Cooja makeCooja(final String logDirectory, final boolean vis) {
-    assert !java.awt.EventQueue.isDispatchThread() : "Call from regular context";
     if (vis) {
+      assert !java.awt.EventQueue.isDispatchThread() : "Call from regular context";
       return new RunnableInEDT<Cooja>() {
         @Override
         public Cooja work() {


### PR DESCRIPTION
Push the assertion into the code that deals
with visual mode to avoid starting the AWT
thread in headless mode with assertions.