### PR TITLE
AbstractCompileDialog: provide default compile commands

### DIFF
--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -833,7 +833,10 @@ public abstract class AbstractCompileDialog extends JDialog {
    * @param source Contiki source
    * @return Suggested compile commands for compiling source
    */
-  public abstract String getDefaultCompileCommands(File source);
+  public String getDefaultCompileCommands(File source) {
+    return Cooja.getExternalToolsSetting("PATH_MAKE") + " -j$(CPUS) " +
+           getExpectedFirmwareFile(source).getName() + " TARGET=" + getTargetName();
+  }
 
   /**
    * @param source Contiki source

--- a/java/org/contikios/cooja/mspmote/MspCompileDialog.java
+++ b/java/org/contikios/cooja/mspmote/MspCompileDialog.java
@@ -94,14 +94,6 @@ public class MspCompileDialog extends AbstractCompileDialog {
   }
 
   @Override
-  public String getDefaultCompileCommands(File source) {
-    /* TODO Split into String[] */
-    return
-    Cooja.getExternalToolsSetting("PATH_MAKE") + " -j$(CPUS) " +
-    getExpectedFirmwareFile(source).getName() + " TARGET=" + target;
-  }
-
-  @Override
   public File getExpectedFirmwareFile(File source) {
     return ((MspMoteType)moteType).getExpectedFirmwareFile(source);
   }


### PR DESCRIPTION
The MspMote compile commands are platform neutral,
so move them into AbstractCompileDialog.