### PR TITLE
Cooja: name SimInformation properly

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1095,7 +1095,7 @@ public class Cooja extends Observable {
     menuItem.putClientProperty("class", SimControl.class);
     simulationMenu.add(menuItem);
 
-    guiAction = new StartPluginGUIAction("Simulation...");
+    guiAction = new StartPluginGUIAction("Information...");
     menuItem = new JMenuItem(guiAction);
     guiActions.add(guiAction);
     menuItem.setMnemonic(KeyEvent.VK_I);


### PR DESCRIPTION
Having "Simulation" under the "Simulation" menu
seems redundant. Rename the menu item to "Information"
to give a hint that the menu item displays the simulation
information.