### PR TITLE
Simulation: synchronized access on hasPollRequests

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -1121,7 +1121,12 @@ public class Simulation extends Observable implements Runnable {
    * @return True if simulation is runnable
    */
   public boolean isRunnable() {
-    return isRunning || hasPollRequests || !eventQueue.isEmpty();
+    if (isRunning || !eventQueue.isEmpty()) {
+      return true;
+    }
+    synchronized (pollRequests) {
+      return hasPollRequests;
+    }
   }
 
   /**


### PR DESCRIPTION
The variable is synchronized on pollRequests, so
add that in the remaining place where it is missing.