### PR TITLE
Cooja: fix creation of ContikiMoteType

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2209,7 +2209,8 @@ public class Cooja extends Observable {
     // Create mote type
     MoteType newMoteType;
     try {
-      newMoteType = moteTypeClass.getDeclaredConstructor().newInstance();
+      newMoteType = moteTypeClass == ContikiMoteType.class
+              ? new ContikiMoteType(this) : moteTypeClass.getDeclaredConstructor().newInstance();
       if (!newMoteType.configureAndInit(Cooja.getTopParentContainer(), mySimulation, isVisualized())) {
         return;
       }


### PR DESCRIPTION
Cooja allocates mote types in multiple places,
update this caller for the additional constructor argument introduced in commit 69f6287d0891.