### PR TITLE
Cooja: remove quickHelpProperties field

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -308,7 +308,6 @@ public class Cooja extends Observable {
   private final JTextPane quickHelpTextPane;
   private final GUIAction showQuickHelpAction;
   private final JScrollPane quickHelpScroll;
-  private final Properties quickHelpProperties;
 
   /**
    * Mote relation (directed).
@@ -387,7 +386,6 @@ public class Cooja extends Observable {
     }
 
     if (!vis) {
-      quickHelpProperties = null;
       SAVED_SIMULATIONS_FILES = null;
       myDesktopPane = null;
       showQuickHelpAction = null;
@@ -484,19 +482,6 @@ public class Cooja extends Observable {
         return true;
       }
     };
-    quickHelpProperties = new Properties();
-    quickHelpProperties.put("KEYBOARD_SHORTCUTS",
-      "<b>Keyboard shortcuts</b><br>" +
-      "<br><i>Ctrl+N:</i> New simulation" +
-      "<br><i>Ctrl+S:</i> Start/pause simulation" +
-      "<br><i>Ctrl+R:</i> Reload current simulation. If no simulation exists, the last used simulation config is loaded" +
-      "<br><i>Ctrl+Shift+R:</i> Reload current simulation with another random seed" +
-      "<br>" +
-      "<br><i>F1:</i> Toggle quick help");
-    quickHelpProperties.put("GETTING_STARTED",
-      "<b>Getting started</b><br>" +
-      "<br>" +
-      "<br><i>F1:</i> Toggle quick help</i>");
     quickHelpTextPane = new JTextPane();
     quickHelpTextPane.setContentType("text/html");
     quickHelpTextPane.setEditable(false);
@@ -4077,7 +4062,25 @@ public class Cooja extends Observable {
       } else {
         key = obj.getClass().getName();
       }
-      help = quickHelpProperties.getProperty(key);
+      switch (key) {
+        case "KEYBOARD_SHORTCUTS":
+          help = "<b>Keyboard shortcuts</b><br>" +
+                  "<br><i>Ctrl+N:</i> New simulation" +
+                  "<br><i>Ctrl+S:</i> Start/pause simulation" +
+                  "<br><i>Ctrl+R:</i> Reload current simulation. If no simulation exists, the last used simulation config is loaded" +
+                  "<br><i>Ctrl+Shift+R:</i> Reload current simulation with another random seed" +
+                  "<br>" +
+                  "<br><i>F1:</i> Toggle quick help";
+          break;
+        case "GETTING_STARTED":
+          help = "<b>Getting started</b><br>" +
+                  "<br>" +
+                  "<br><i>F1:</i> Toggle quick help</i>";
+          break;
+        default:
+          help = null;
+          break;
+      }
     }
 
     if (help != null) {


### PR DESCRIPTION
Nothing external can update this container
so replace it with a switch statement
where the information is required.