### PR TITLE
Cooja: push fields to inner class

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -259,10 +259,6 @@ public class Cooja extends Observable {
 
   private static final int FRAME_NEW_OFFSET = 30;
 
-  private static final int FRAME_STANDARD_WIDTH = 150;
-
-  private static final int FRAME_STANDARD_HEIGHT = 300;
-
   private static final String WINDOW_TITLE = "Cooja: The Contiki Network Simulator";
 
   private final Cooja cooja;
@@ -1667,6 +1663,10 @@ public class Cooja extends Observable {
    */
   public void showPlugin(final Plugin plugin) {
     new RunnableInEDT<Boolean>() {
+      private static final int FRAME_STANDARD_WIDTH = 150;
+
+      private static final int FRAME_STANDARD_HEIGHT = 300;
+
       @Override
       public Boolean work() {
         JInternalFrame pluginFrame = plugin.getCooja();


### PR DESCRIPTION
These fields are only relevant for graphical
Cooja, so put them in the class that needs
them.