### PR TITLE
Cooja: reorganize new simulation code

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2070,7 +2070,6 @@ public class Cooja extends Observable {
   }
 
   private void setSimulation(Simulation sim, boolean startPlugins) {
-    doRemoveSimulation(false);
     mySimulation = sim;
     updateGUIComponentState();
 
@@ -2260,7 +2259,6 @@ public class Cooja extends Observable {
         do {
           try {
             shouldRetry = false;
-            cooja.doRemoveSimulation(false);
             PROGRESS_WARNINGS.clear();
             newSim = loadSimulationConfig(cfgFile, quick, rewriteCsc, manualRandomSeed);
           } catch (SimulationCreationException e) {
@@ -3049,7 +3047,7 @@ public class Cooja extends Observable {
         logger.fatal("Not a valid Cooja simulation config.");
         return null;
       }
-
+      doRemoveSimulation(false);
       sim = loadSimulationConfig(root, quick, rewriteCsc, manualRandomSeed);
     } catch (JDOMException e) {
       throw new SimulationCreationException("Config not well-formed", e);

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2355,7 +2355,7 @@ public class Cooja extends Observable {
             shouldRetry = false;
             cooja.doRemoveSimulation(false);
             PROGRESS_WARNINGS.clear();
-            Simulation newSim = loadSimulationConfig(root, true, false, randomSeed);
+            Simulation newSim = createSimulation(root, true, false, randomSeed);
 
             if (autoStart) {
               newSim.startSimulation();
@@ -3025,6 +3025,7 @@ public class Cooja extends Observable {
    *
    * @param file       File to read
    * @param rewriteCsc Should Cooja update the .csc file.
+   * @param manualRandomSeed The random seed.
    * @return New simulation or null if recompiling failed or aborted
    * @throws SimulationCreationException If loading fails.
    * @see #saveSimulationConfig(File)
@@ -3048,7 +3049,7 @@ public class Cooja extends Observable {
         return null;
       }
       doRemoveSimulation(false);
-      sim = loadSimulationConfig(root, quick, rewriteCsc, manualRandomSeed);
+      sim = createSimulation(root, quick, rewriteCsc, manualRandomSeed);
     } catch (JDOMException e) {
       throw new SimulationCreationException("Config not well-formed", e);
     } catch (IOException e) {
@@ -3062,7 +3063,15 @@ public class Cooja extends Observable {
     return sim;
   }
 
-  private Simulation loadSimulationConfig(Element root, boolean quick, boolean rewriteCsc, Long manualRandomSeed)
+  /** Create a new simulation object.
+   * @param root The XML config.
+   * @param quick Do a quickstart.
+   * @param rewriteCsc Should Cooja update the .csc file.
+   * @param manualRandomSeed The random seed.
+   * @throws SimulationCreationException If creation fails.
+   * @return Simulation object.
+   * */
+  private Simulation createSimulation(Element root, boolean quick, boolean rewriteCsc, Long manualRandomSeed)
   throws SimulationCreationException {
     boolean projectsOk = verifyProjects(root);
 

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -696,7 +696,14 @@ public class Cooja extends Observable {
 
         var sim = new Simulation(cooja);
         if (CreateSimDialog.showDialog(Cooja.getTopParentContainer(), sim)) {
-          cooja.setSimulation(sim, true);
+          // Start GUI plugins.
+          for (var pluginClass : pluginClasses) {
+            int type = pluginClass.getAnnotation(PluginType.class).value();
+            if (type == PluginType.SIM_STANDARD_PLUGIN) {
+              tryStartPlugin(pluginClass, cooja, sim, null);
+            }
+          }
+          cooja.setSimulation(sim);
         }
       }
       @Override
@@ -2069,23 +2076,13 @@ public class Cooja extends Observable {
     return mySimulation;
   }
 
-  private void setSimulation(Simulation sim, boolean startPlugins) {
+  private void setSimulation(Simulation sim) {
     mySimulation = sim;
     updateGUIComponentState();
 
     // Set frame title
     if (frame != null) {
       frame.setTitle(sim.getTitle() + " - " + WINDOW_TITLE);
-    }
-
-    // Open standard plugins (if none opened already)
-    if (startPlugins) {
-      for (Class<? extends Plugin> pluginClass : pluginClasses) {
-        int pluginType = pluginClass.getAnnotation(PluginType.class).value();
-        if (pluginType == PluginType.SIM_STANDARD_PLUGIN) {
-          tryStartPlugin(pluginClass, this, sim, null);
-        }
-      }
     }
 
     setChanged();
@@ -3050,7 +3047,7 @@ public class Cooja extends Observable {
       }
       doRemoveSimulation(false);
       sim = createSimulation(root, quick, rewriteCsc, manualRandomSeed);
-      setSimulation(sim, false);
+      setSimulation(sim);
     } catch (JDOMException e) {
       throw new SimulationCreationException("Config not well-formed", e);
     } catch (IOException e) {

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -3050,6 +3050,7 @@ public class Cooja extends Observable {
       }
       doRemoveSimulation(false);
       sim = createSimulation(root, quick, rewriteCsc, manualRandomSeed);
+      setSimulation(sim, false);
     } catch (JDOMException e) {
       throw new SimulationCreationException("Config not well-formed", e);
     } catch (IOException e) {
@@ -3167,7 +3168,6 @@ public class Cooja extends Observable {
         return null;
       }
     }
-    setSimulation(newSim, false);
     return newSim;
   }
 


### PR DESCRIPTION
Move code around so methods are only called once and code is as close as possible to where it is used.