### PR TITLE
Cooja: delay showing of dialog

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2233,9 +2233,6 @@ public class Cooja extends Observable {
           progressDialog.getRootPane().setDefaultButton(button);
           progressDialog.setLocationRelativeTo(Cooja.getTopParentContainer());
           progressDialog.setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
-
-          java.awt.EventQueue.invokeLater(() -> progressDialog.setVisible(true));
-
           return progressDialog;
         }
       }.invokeAndWait();
@@ -2298,7 +2295,10 @@ public class Cooja extends Observable {
     };
 
     if (progressDialog != null) {
-      progressDialog.getRootPane().getDefaultButton().addActionListener(e -> worker.cancel(true));
+      java.awt.EventQueue.invokeLater(() -> {
+        progressDialog.getRootPane().getDefaultButton().addActionListener(e -> worker.cancel(true));
+        progressDialog.setVisible(true);
+      });
     }
 
     worker.execute();


### PR DESCRIPTION
Add the action listener and set the progress
dialog to visible after defining the worker thread, and do both in the AWT thread.