### PR TITLE
Move logic into ContikiMote

### DIFF
--- a/java/org/contikios/cooja/MoteInterfaceHandler.java
+++ b/java/org/contikios/cooja/MoteInterfaceHandler.java
@@ -59,10 +59,6 @@ import org.contikios.cooja.interfaces.Mote2MoteRelations;
 import org.contikios.cooja.interfaces.MoteAttributes;
 import org.contikios.cooja.interfaces.MoteID;
 import org.contikios.cooja.interfaces.PIR;
-import org.contikios.cooja.interfaces.PolledAfterActiveTicks;
-import org.contikios.cooja.interfaces.PolledAfterAllTicks;
-import org.contikios.cooja.interfaces.PolledBeforeActiveTicks;
-import org.contikios.cooja.interfaces.PolledBeforeAllTicks;
 import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.interfaces.RimeAddress;
@@ -111,10 +107,6 @@ public class MoteInterfaceHandler {
   private PIR myPIR;
   private Position myPosition;
   private Radio myRadio;
-  private final ArrayList<PolledBeforeActiveTicks> polledBeforeActive = new ArrayList<>();
-  private final ArrayList<PolledAfterActiveTicks> polledAfterActive = new ArrayList<>();
-  private final ArrayList<PolledBeforeAllTicks> polledBeforeAll = new ArrayList<>();
-  private final ArrayList<PolledAfterAllTicks> polledAfterAll = new ArrayList<>();
 
   /**
    * Creates new mote interface handler. All given interfaces are created.
@@ -125,20 +117,7 @@ public class MoteInterfaceHandler {
   public MoteInterfaceHandler(Mote mote, Class<? extends MoteInterface>[] interfaceClasses) throws MoteType.MoteTypeCreationException {
     for (Class<? extends MoteInterface> interfaceClass : interfaceClasses) {
       try {
-        var intf = interfaceClass.getConstructor(Mote.class).newInstance(mote);
-        moteInterfaces.add(intf);
-        if (intf instanceof PolledBeforeActiveTicks) {
-          polledBeforeActive.add((PolledBeforeActiveTicks) intf);
-        }
-        if (intf instanceof PolledAfterActiveTicks) {
-          polledAfterActive.add((PolledAfterActiveTicks) intf);
-        }
-        if (intf instanceof PolledBeforeAllTicks) {
-          polledBeforeAll.add((PolledBeforeAllTicks) intf);
-        }
-        if (intf instanceof PolledAfterAllTicks) {
-          polledAfterAll.add((PolledAfterAllTicks) intf);
-        }
+        moteInterfaces.add(interfaceClass.getConstructor(Mote.class).newInstance(mote));
       } catch (Exception e) {
         logger.fatal("Exception when calling constructor of " + interfaceClass, e);
         throw new MoteType.MoteTypeCreationException("Exception when calling constructor of " + interfaceClass, e);
@@ -195,26 +174,6 @@ public class MoteInterfaceHandler {
       }
     }
     return null;
-  }
-
-  /** Returns a list of active interfaces before tick. */
-  public ArrayList<PolledBeforeActiveTicks> getActiveActionsBeforeTick() {
-    return polledBeforeActive;
-  }
-
-  /** Returns a list of active interfaces after tick. */
-  public ArrayList<PolledAfterActiveTicks> getActiveActionsAfterTick() {
-    return polledAfterActive;
-  }
-
-  /** Returns a list of passive interfaces before tick. */
-  public ArrayList<PolledBeforeAllTicks> getPassiveActionsBeforeTick() {
-    return polledBeforeAll;
-  }
-
-  /** Returns a list of passive interfaces after tick. */
-  public ArrayList<PolledAfterAllTicks> getPassiveActionsAfterTick() {
-    return polledAfterAll;
   }
 
   /**

--- a/java/org/contikios/cooja/MoteInterfaceHandler.java
+++ b/java/org/contikios/cooja/MoteInterfaceHandler.java
@@ -69,12 +69,6 @@ import org.contikios.cooja.interfaces.RimeAddress;
 
 /**
  * The mote interface handler holds all interfaces for a specific mote.
- * Interfaces should be polled via this class when the mote is ticked.
- *
- * @see #doActiveActionsAfterTick()
- * @see #doActiveActionsBeforeTick()
- * @see #doPassiveActionsAfterTick()
- * @see #doPassiveActionsBeforeTick()
  *
  * @author Fredrik Osterlind
  */
@@ -201,6 +195,26 @@ public class MoteInterfaceHandler {
       }
     }
     return null;
+  }
+
+  /** Returns a list of active interfaces before tick. */
+  public ArrayList<PolledBeforeActiveTicks> getActiveActionsBeforeTick() {
+    return polledBeforeActive;
+  }
+
+  /** Returns a list of active interfaces after tick. */
+  public ArrayList<PolledAfterActiveTicks> getActiveActionsAfterTick() {
+    return polledAfterActive;
+  }
+
+  /** Returns a list of passive interfaces before tick. */
+  public ArrayList<PolledBeforeAllTicks> getPassiveActionsBeforeTick() {
+    return polledBeforeAll;
+  }
+
+  /** Returns a list of passive interfaces after tick. */
+  public ArrayList<PolledAfterAllTicks> getPassiveActionsAfterTick() {
+    return polledAfterAll;
   }
 
   /**
@@ -343,42 +357,6 @@ public class MoteInterfaceHandler {
       myRadio = getInterfaceOfType(Radio.class);
     }
     return myRadio;
-  }
-
-  /**
-   * Polls active interfaces before mote tick.
-   */
-  public void doActiveActionsBeforeTick() {
-    for (PolledBeforeActiveTicks element : polledBeforeActive) {
-      element.doActionsBeforeTick();
-    }
-  }
-
-  /**
-   * Polls active interfaces after mote tick.
-   */
-  public void doActiveActionsAfterTick() {
-    for (PolledAfterActiveTicks element : polledAfterActive) {
-      element.doActionsAfterTick();
-    }
-  }
-
-  /**
-   * Polls passive interfaces before mote tick.
-   */
-  public void doPassiveActionsBeforeTick() {
-    for (PolledBeforeAllTicks element : polledBeforeAll) {
-      element.doActionsBeforeTick();
-    }
-  }
-
-  /**
-   * Polls passive interfaces after mote tick.
-   */
-  public void doPassiveActionsAfterTick() {
-    for (PolledAfterAllTicks element : polledAfterAll) {
-      element.doActionsAfterTick();
-    }
   }
 
   /**

--- a/java/org/contikios/cooja/contikimote/ContikiMote.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMote.java
@@ -35,6 +35,10 @@ import java.util.Collection;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.contikios.cooja.interfaces.PolledAfterActiveTicks;
+import org.contikios.cooja.interfaces.PolledAfterAllTicks;
+import org.contikios.cooja.interfaces.PolledBeforeActiveTicks;
+import org.contikios.cooja.interfaces.PolledBeforeAllTicks;
 import org.jdom.Element;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterface;
@@ -116,10 +120,9 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
    */
   @Override
   public void execute(long simTime) {
-
     /* Poll mote interfaces */
-    myInterfaceHandler.doActiveActionsBeforeTick();
-    myInterfaceHandler.doPassiveActionsBeforeTick();
+    myInterfaceHandler.getActiveActionsBeforeTick().forEach(PolledBeforeActiveTicks::doActionsBeforeTick);
+    myInterfaceHandler.getPassiveActionsBeforeTick().forEach(PolledBeforeAllTicks::doActionsBeforeTick);
 
     /* Check if pre-boot time */
     if (myInterfaceHandler.getClock().getTime() < 0) {
@@ -138,8 +141,8 @@ public class ContikiMote extends AbstractWakeupMote implements Mote {
 
     /* Poll mote interfaces */
     myMemory.pollForMemoryChanges();
-    myInterfaceHandler.doActiveActionsAfterTick();
-    myInterfaceHandler.doPassiveActionsAfterTick();
+    myInterfaceHandler.getActiveActionsAfterTick().forEach(PolledAfterActiveTicks::doActionsAfterTick);
+    myInterfaceHandler.getPassiveActionsAfterTick().forEach(PolledAfterAllTicks::doActionsAfterTick);
   }
 
   /**


### PR DESCRIPTION
Turn the MoteInterfaceHandler into a holder
of information, and put the Polled*Ticks containers
and usage inside ContikiMote instead.