### PR TITLE
MspMoteTypes: localize array creation

### DIFF
--- a/java/org/contikios/cooja/mspmote/AbstractMspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/AbstractMspMoteType.java
@@ -35,14 +35,8 @@
 
 package org.contikios.cooja.mspmote;
 
-import org.contikios.cooja.MoteInterface;
-
 /**
  *
  */
 public abstract class AbstractMspMoteType extends MspMoteType {
-    protected Class<? extends MoteInterface>[] createMoteInterfaceList(Class<? extends MoteInterface>... interfaceList) {
-        return interfaceList;
-    }
-
 }

--- a/java/org/contikios/cooja/mspmote/Exp5438MoteType.java
+++ b/java/org/contikios/cooja/mspmote/Exp5438MoteType.java
@@ -28,6 +28,7 @@
  */
 
 package org.contikios.cooja.mspmote;
+import java.util.List;
 import org.contikios.cooja.AbstractionLevelDescription;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.MoteInterface;
@@ -72,8 +73,7 @@ public class Exp5438MoteType extends AbstractMspMoteType {
 
   @Override
   public Class<? extends MoteInterface>[] getDefaultMoteInterfaceClasses() {
-    @SuppressWarnings("unchecked")
-    Class<? extends MoteInterface>[] list = createMoteInterfaceList(
+    var classes = List.of(
             Position.class,
             RimeAddress.class,
             IPAddress.class,
@@ -84,15 +84,13 @@ public class Exp5438MoteType extends AbstractMspMoteType {
             Msp802154Radio.class,
             UsciA1Serial.class,
             Exp5438LED.class,
-            /*Exp5438LCD.class,*/ /* TODO */
             MspDebugOutput.class);
-    return list;
+    return classes.toArray(new Class[0]);
   }
 
   @Override
   public Class<? extends MoteInterface>[] getAllMoteInterfaceClasses() {
-    @SuppressWarnings("unchecked")
-    Class<? extends MoteInterface>[] list = createMoteInterfaceList(
+    var classes = List.of(
         Position.class,
         RimeAddress.class,
         IPAddress.class,
@@ -105,8 +103,7 @@ public class Exp5438MoteType extends AbstractMspMoteType {
         CC1120Radio.class,
         UsciA1Serial.class,
         Exp5438LED.class,
-        /*Exp5438LCD.class,*/ /* TODO */
         MspDebugOutput.class);
-    return list;
+    return classes.toArray(new Class[0]);
   }
 }

--- a/java/org/contikios/cooja/mspmote/SkyMoteType.java
+++ b/java/org/contikios/cooja/mspmote/SkyMoteType.java
@@ -30,6 +30,7 @@
 
 package org.contikios.cooja.mspmote;
 
+import java.util.List;
 import org.contikios.cooja.AbstractionLevelDescription;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.MoteInterface;
@@ -80,8 +81,7 @@ public class SkyMoteType extends AbstractMspMoteType {
   }
   @Override
   public Class<? extends MoteInterface>[] getAllMoteInterfaceClasses() {
-    @SuppressWarnings("unchecked")
-    Class<? extends MoteInterface>[] list =  createMoteInterfaceList(
+    var classes = List.of(
         Position.class,
         RimeAddress.class,
         IPAddress.class,
@@ -95,8 +95,8 @@ public class SkyMoteType extends AbstractMspMoteType {
         Msp802154Radio.class,
         MspSerial.class,
         SkyLED.class,
-        MspDebugOutput.class, /* EXPERIMENTAL: Enable me for COOJA_DEBUG(..) */
+        MspDebugOutput.class,
         SkyTemperature.class);
-    return list;
+    return classes.toArray(new Class[0]);
   }
 }

--- a/java/org/contikios/cooja/mspmote/Z1MoteType.java
+++ b/java/org/contikios/cooja/mspmote/Z1MoteType.java
@@ -29,6 +29,7 @@
  */
 
 package org.contikios.cooja.mspmote;
+import java.util.List;
 import org.contikios.cooja.AbstractionLevelDescription;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.MoteInterface;
@@ -77,8 +78,7 @@ public class Z1MoteType extends AbstractMspMoteType {
 
     @Override
     public Class<? extends MoteInterface>[] getAllMoteInterfaceClasses() {
-        @SuppressWarnings("unchecked")
-        Class<? extends MoteInterface>[] list = createMoteInterfaceList(
+        var classes = List.of(
                 Position.class,
                 RimeAddress.class,
                 IPAddress.class,
@@ -91,9 +91,8 @@ public class Z1MoteType extends AbstractMspMoteType {
                 Msp802154Radio.class,
                 MspDefaultSerial.class,
                 MspLED.class,
-                MspDebugOutput.class /* EXPERIMENTAL: Enable me for COOJA_DEBUG(..) */
-        );
-        return list;
+                MspDebugOutput.class);
+        return classes.toArray(new Class[0]);
     }
 
 }


### PR DESCRIPTION
This removes an IntelliJ warning about possible
heap pollution from parameterized vararg type.