### PR TITLE
Simplify firmware name handling

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -898,13 +898,6 @@ public class ContikiMoteType implements MoteType {
     fileFirmware = file;
   }
 
-  /**
-   * Set the Contiki firmware file according to the source file.
-   */
-  public void setContikiFirmwareFile() {
-    fileFirmware = getMoteFile(librarySuffix);
-  }
-
   @Override
   public String getCompileCommands() {
     return compileCommands;
@@ -1157,7 +1150,7 @@ public class ContikiMoteType implements MoteType {
             file = simulation.getCooja().restorePortablePath(file);
           }
           setContikiSourceFile(file);
-          setContikiFirmwareFile();
+          fileFirmware = getMoteFile(librarySuffix);
           break;
         case "commands":
           compileCommands = element.getText();

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -270,7 +270,6 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
 
   @Override
   public void writeSettingsToMoteType() {
-    ((ContikiMoteType)moteType).setContikiFirmwareFile();
   }
 
   @Override


### PR DESCRIPTION
Remove some dead code and inline the method at the single call site.