### PR TITLE
Remove setMemory method

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -856,8 +856,7 @@ public class ContikiMoteType implements MoteType {
   }
 
   /**
-   * Copy given memory to the Contiki system. This should not be used directly,
-   * but instead via ContikiMote.setMemory().
+   * Copy given memory to the Contiki system.
    *
    * @param mem
    * New memory

--- a/java/org/contikios/cooja/motes/AbstractApplicationMote.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMote.java
@@ -115,10 +115,6 @@ public abstract class AbstractApplicationMote extends AbstractWakeupMote impleme
     return memory;
   }
 
-  public void setMemory(SectionMoteMemory memory) {
-    this.memory = memory;
-  }
-
   @Override
   public MoteType getType() {
     return moteType;

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -203,10 +203,6 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     return myMemory;
   }
 
-  public void setMemory(MspMoteMemory memory) {
-    myMemory = memory;
-  }
-
   /**
    * Prepares CPU, memory and ELF module.
    *


### PR DESCRIPTION
Motes can have the content of their
memory changed in runtime (that is what
tick() does), but not the memory itself.
Remove the unused methods.