### PR TITLE
AbstractCompileDialog: clean disables create button

### DIFF
--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -279,6 +279,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     cleanButton.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(ActionEvent e) {
+        createButton.setEnabled(false);
 				try {
 					currentCompilationProcess = CompileContiki.compile(
 							"make clean TARGET=" + getTargetName(),


### PR DESCRIPTION
Disable the create button when running clean
since there is no firmware to load after that.