### PR TITLE
Tweak default logging behavior

### DIFF
--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -28,6 +28,7 @@
 
 package org.contikios.cooja;
 
+import java.io.IOException;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
@@ -167,6 +168,15 @@ class Main {
     if (options.action != null && options.action.nogui != null) {
       // Ensure no UI is used by Java
       System.setProperty("java.awt.headless", "true");
+      Path logDirPath = Path.of(options.logDir);
+      if (!Files.exists(logDirPath)) {
+        try {
+          Files.createDirectory(logDirPath);
+        } catch (IOException e) {
+          System.err.println("Could not create log directory '" + options.logDir + "'");
+          System.exit(1);
+        }
+      }
     }
 
     // Verify soundness of -nogui/-quickstart argument.

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -46,7 +46,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -369,10 +368,6 @@ public class ScriptRunner implements Plugin {
         /* Continuously write test output to file */
         if (logWriter == null) {
           /* Warning: static variable, used by all active test editor plugins */
-          Path logDirPath = Path.of(gui.logDirectory);
-          if (!Files.exists(logDirPath)) {
-            Files.createDirectory(logDirPath);
-          }
           var logFile = Paths.get(gui.logDirectory, "COOJA.testlog");
           logWriter = Files.newBufferedWriter(logFile, UTF_8, WRITE, CREATE, TRUNCATE_EXISTING);
           logWriter.write("Random seed: " + simulation.getRandomSeed() + "\n");


### PR DESCRIPTION
Stop generating COOJA.log unless the user specifies `-logname` when starting Cooja. Also refuse to start Cooja if the log directory cannot be created, instead of getting a fatal error after starting the simulation.