### PR TITLE
Minor tweaks to MoteTypes

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -186,7 +186,7 @@ public class ContikiMoteType implements MoteType {
 
   private final String javaClassName; // Loading Java class name: Lib1.java.
 
-  private ArrayList<Class<? extends MoteInterface>> moteInterfacesClasses = null;
+  private final ArrayList<Class<? extends MoteInterface>> moteInterfacesClasses = new ArrayList<>();
 
   private NetworkStack netStack = NetworkStack.DEFAULT;
 
@@ -1017,7 +1017,7 @@ public class ContikiMoteType implements MoteType {
 
   @Override
   public Class<? extends MoteInterface>[] getMoteInterfaceClasses() {
-    if (moteInterfacesClasses == null) {
+    if (moteInterfacesClasses.isEmpty()) {
       return null;
     }
     Class<? extends MoteInterface>[] arr = new Class[moteInterfacesClasses.size()];
@@ -1027,8 +1027,8 @@ public class ContikiMoteType implements MoteType {
 
   @Override
   public void setMoteInterfaceClasses(Class<? extends MoteInterface>[] moteInterfaces) {
-    this.moteInterfacesClasses = new ArrayList<>();
-    this.moteInterfacesClasses.addAll(Arrays.asList(moteInterfaces));
+    moteInterfacesClasses.clear();
+    moteInterfacesClasses.addAll(Arrays.asList(moteInterfaces));
   }
 
   /**
@@ -1131,8 +1131,6 @@ public class ContikiMoteType implements MoteType {
   public boolean setConfigXML(Simulation simulation,
                               Collection<Element> configXML, boolean visAvailable)
           throws MoteTypeCreationException {
-    moteInterfacesClasses = new ArrayList<>();
-
     for (Element element : configXML) {
       String name = element.getName();
       switch (name) {

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -295,7 +295,8 @@ public class ContikiMoteType implements MoteType {
       if (getIdentifier() == null) {
         throw new MoteTypeCreationException("No identifier specified");
       }
-      if (getContikiSourceFile() == null) {
+      final var source = getContikiSourceFile();
+      if (source == null) {
         throw new MoteTypeCreationException("No Contiki application specified");
       }
       final var commands = getCompileCommands();
@@ -320,7 +321,7 @@ public class ContikiMoteType implements MoteType {
           CompileContiki.compile(
                   cmd,
                   envOneDimension,
-                  getContikiSourceFile().getParentFile(),
+                  source.getParentFile(),
                   null,
                   null,
                   compilationOutput,
@@ -1146,7 +1147,7 @@ public class ContikiMoteType implements MoteType {
           if (!file.exists()) {
             file = simulation.getCooja().restorePortablePath(file);
           }
-          setContikiSourceFile(file);
+          fileSource = file;
           fileFirmware = getMoteFile(librarySuffix);
           break;
         case "commands":

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -392,12 +392,14 @@ public abstract class AbstractCompileDialog extends JDialog {
       }
 
       /* Restore Contiki source or firmware */
-      if (moteType.getContikiSourceFile() != null) {
-        contikiField.setText(moteType.getContikiSourceFile().getAbsolutePath());
+      final var source = moteType.getContikiSourceFile();
+      final var firmware = moteType.getContikiFirmwareFile();
+      if (source != null) {
+        contikiField.setText(source.getAbsolutePath());
         setDialogState(DialogState.SELECTED_SOURCE);
         restoredDialogState = true;
-      } else if (moteType.getContikiFirmwareFile() != null) {
-        contikiField.setText(moteType.getContikiFirmwareFile().getAbsolutePath());
+      } else if (firmware != null) {
+        contikiField.setText(firmware.getAbsolutePath());
         setDialogState(DialogState.SELECTED_FIRMWARE);
         restoredDialogState = true;
       }

--- a/java/org/contikios/cooja/motes/AbstractApplicationMote.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMote.java
@@ -102,10 +102,6 @@ public abstract class AbstractApplicationMote extends AbstractWakeupMote impleme
     return moteInterfaces;
   }
 
-  public void setInterfaces(MoteInterfaceHandler moteInterfaceHandler) {
-    moteInterfaces = moteInterfaceHandler;
-  }
-
   @Override
   public MemoryInterface getMemory() {
     return memory;

--- a/java/org/contikios/cooja/motes/AbstractApplicationMote.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMote.java
@@ -59,9 +59,9 @@ import org.contikios.cooja.mote.memory.MemoryInterface;
 public abstract class AbstractApplicationMote extends AbstractWakeupMote implements Mote {
   private static final Logger logger = LogManager.getLogger(AbstractApplicationMote.class);
 
-  private MoteType moteType = null;
+  private final MoteType moteType;
 
-  private SectionMoteMemory memory = null;
+  private SectionMoteMemory memory;
 
   protected MoteInterfaceHandler moteInterfaces;
 

--- a/java/org/contikios/cooja/mspmote/Exp5438Mote.java
+++ b/java/org/contikios/cooja/mspmote/Exp5438Mote.java
@@ -29,11 +29,10 @@
 
 package org.contikios.cooja.mspmote;
 
-import java.io.File;
-
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
+import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import se.sics.mspsim.platform.GenericNode;
 import se.sics.mspsim.platform.ti.Exp1101Node;
@@ -48,47 +47,43 @@ import se.sics.mspsim.platform.ti.Trxeb2520Node;
 public class Exp5438Mote extends MspMote {
   private static final Logger logger = LogManager.getLogger(Exp5438Mote.class);
 
-  public GenericNode exp5438Node = null;
+  public final GenericNode exp5438Node;
   private String desc = "";
   
-  public Exp5438Mote(MspMoteType moteType, Simulation sim) {
+  public Exp5438Mote(MspMoteType moteType, Simulation sim) throws MoteType.MoteTypeCreationException {
     super(moteType, sim);
-  }
+    final var fileELF = moteType.getContikiFirmwareFile();
+    // Hack: Try to figure out what type of MSPSim-node we should be used by checking file extension.
+    String filename = fileELF.getName();
+    if (filename.endsWith(".exp1101")) {
+      exp5438Node = new Exp1101Node();
+      desc = "Exp5438+CC1101";
+    } else if (filename.endsWith(".exp1120")) {
+      exp5438Node = new Exp1120Node();
+      desc = "Exp5438+CC1120";
+    } else if (filename.endsWith(".trxeb2520")) {
+      exp5438Node = new Trxeb2520Node();
+      desc = "Trxeb2520";
+    } else if (filename.endsWith(".trxeb1120")) {
+      exp5438Node = new Trxeb1120Node(false);
+      desc = "Trxeb1120";
+    } else if (filename.endsWith(".eth1120")) {
+      exp5438Node = new Trxeb1120Node(true);
+      desc = "Eth1120";
+    } else if (filename.endsWith(".exp2420") || filename.endsWith(".exp5438")) {
+      exp5438Node = new Exp5438Node();
+      desc = "Exp5438+CC2420";
+    } else {
+      throw new IllegalStateException("unknown file extension, cannot figure out what MSPSim node type to use: " + filename);
+    }
 
-  @Override
-  protected boolean initEmulator(File fileELF) {
-	  /* Hack: Try to figure out what type of Mspsim-node we should be used by checking file extension */
-	  String filename = fileELF.getName();
-	  if (filename.endsWith(".exp1101")) {
-		  exp5438Node = new Exp1101Node();
-		  desc = "Exp5438+CC1101";
-	  } else if (filename.endsWith(".exp1120")) {
-		  exp5438Node = new Exp1120Node();
-		  desc = "Exp5438+CC1120";
-	  } else if (filename.endsWith(".trxeb2520")) {
-		  exp5438Node = new Trxeb2520Node();
-		  desc = "Trxeb2520";
-	  } else if (filename.endsWith(".trxeb1120")) {
-		  exp5438Node = new Trxeb1120Node(false);
-		  desc = "Trxeb1120";
-	  } else if (filename.endsWith(".eth1120")) {
-		  exp5438Node = new Trxeb1120Node(true);
-		  desc = "Eth1120";
-	  } else if (filename.endsWith(".exp2420") || filename.endsWith(".exp5438")) {
-		  exp5438Node = new Exp5438Node();
-		  desc = "Exp5438+CC2420";
-	  } else {
-		  throw new IllegalStateException("unknown file extension, cannot figure out what Mspsim node type to use: " + filename);
-	  }
-	  
     try {
       registry = exp5438Node.getRegistry();
       prepareMote(fileELF, exp5438Node);
     } catch (Exception e) {
       logger.fatal("Error when creating Exp5438 mote: ", e);
-      return false;
+      throw new MoteType.MoteTypeCreationException("Error creating Exp5438 mote: " + e.getMessage());
     }
-    return true;
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/Exp5438Mote.java
+++ b/java/org/contikios/cooja/mspmote/Exp5438Mote.java
@@ -32,6 +32,7 @@ package org.contikios.cooja.mspmote;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
+import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import se.sics.mspsim.platform.GenericNode;
@@ -84,6 +85,7 @@ public class Exp5438Mote extends MspMote {
       logger.fatal("Error when creating Exp5438 mote: ", e);
       throw new MoteType.MoteTypeCreationException("Error creating Exp5438 mote: " + e.getMessage());
     }
+    myMoteInterfaceHandler = new MoteInterfaceHandler(this, moteType.getMoteInterfaceClasses());
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/Exp5438MoteType.java
+++ b/java/org/contikios/cooja/mspmote/Exp5438MoteType.java
@@ -52,7 +52,7 @@ import org.contikios.cooja.mspmote.interfaces.UsciA1Serial;
 public class Exp5438MoteType extends MspMoteType {
 
   @Override
-  protected MspMote createMote(Simulation simulation) {
+  protected MspMote createMote(Simulation simulation) throws MoteTypeCreationException {
     return new Exp5438Mote(this, simulation);
   }
 

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -108,13 +108,11 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
   public MspMote(MspMoteType moteType, Simulation simulation) {
     super(simulation);
     myMoteType = moteType;
-
     /* Schedule us immediately */
     requestImmediateWakeup();
   }
 
   protected void initMote() throws MoteType.MoteTypeCreationException {
-    initEmulator(myMoteType.getContikiFirmwareFile());
     myMoteInterfaceHandler = createMoteInterfaceHandler();
 
     /* TODO Create COOJA-specific window manager */
@@ -281,14 +279,6 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
   public void setInterfaces(MoteInterfaceHandler moteInterfaceHandler) {
     myMoteInterfaceHandler = moteInterfaceHandler;
   }
-
-  /**
-   * Initializes emulator by creating CPU, memory and node object.
-   *
-   * @param ELFFile ELF file
-   * @return True if successful
-   */
-  protected abstract boolean initEmulator(File ELFFile);
 
   private boolean booted = false;
 

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -97,7 +97,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
   private MSP430 myCpu = null;
   private final MspMoteType myMoteType;
   private MspMoteMemory myMemory = null;
-  private MoteInterfaceHandler myMoteInterfaceHandler = null;
+  protected MoteInterfaceHandler myMoteInterfaceHandler;
   public ComponentRegistry registry = null;
 
   /* Stack monitoring variables */
@@ -112,9 +112,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     requestImmediateWakeup();
   }
 
-  protected void initMote() throws MoteType.MoteTypeCreationException {
-    myMoteInterfaceHandler = createMoteInterfaceHandler();
-
+  protected void initMote() {
     /* TODO Create COOJA-specific window manager */
     registry.removeComponent("windowManager");
     registry.registerComponent("windowManager", new WindowManager() {
@@ -185,10 +183,6 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
   public void stopNextInstruction() {
     stopNextInstruction = true;
     getCPU().stop();
-  }
-
-  protected MoteInterfaceHandler createMoteInterfaceHandler() throws MoteType.MoteTypeCreationException {
-    return new MoteInterfaceHandler(this, getType().getMoteInterfaceClasses());
   }
 
   /**
@@ -462,10 +456,6 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
 
   @Override
   public boolean setConfigXML(Simulation simulation, Collection<Element> configXML, boolean visAvailable) throws MoteType.MoteTypeCreationException {
-    if (myMoteInterfaceHandler == null) {
-      myMoteInterfaceHandler = createMoteInterfaceHandler();
-    }
-
     try {
       debuggingInfo = ((MspMoteType)getType()).getFirmwareDebugInfo();
     } catch (IOException e) {

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -276,10 +276,6 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     return myMoteInterfaceHandler;
   }
 
-  public void setInterfaces(MoteInterfaceHandler moteInterfaceHandler) {
-    myMoteInterfaceHandler = moteInterfaceHandler;
-  }
-
   private boolean booted = false;
 
   public void simTimeChanged(long diff) {

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -158,7 +158,7 @@ public abstract class MspMoteType implements MoteType {
     return mote;
   }
 
-  protected abstract MspMote createMote(Simulation simulation);
+  protected abstract MspMote createMote(Simulation simulation) throws MoteTypeCreationException;
 
   @Override
   public boolean configureAndInit(Container parentContainer, Simulation simulation, boolean visAvailable)

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -198,10 +198,10 @@ public abstract class MspMoteType implements MoteType {
 
     // Not visualized: Compile Contiki immediately.
     final MessageList compilationOutput = MessageContainer.createMessageList(visAvailable);
-    if (getCompileCommands() != null) {
+    final var commands = getCompileCommands();
+    if (commands != null) {
       // Handle multiple compilation commands one by one.
-      String[] arr = getCompileCommands().split("\n");
-      for (String cmd: arr) {
+      for (String cmd: commands.split("\n")) {
         cmd = cmd.trim();
         if (cmd.isEmpty()) {
           continue;
@@ -242,8 +242,9 @@ public abstract class MspMoteType implements MoteType {
 
     /* Contiki source */
     sb.append("<tr><td>Contiki source</td><td>");
-    if (getContikiSourceFile() != null) {
-      sb.append(getContikiSourceFile().getAbsolutePath());
+    final var source = getContikiSourceFile();
+    if (source != null) {
+      sb.append(source.getAbsolutePath());
     } else {
       sb.append("[not specified]");
     }

--- a/java/org/contikios/cooja/mspmote/SkyMote.java
+++ b/java/org/contikios/cooja/mspmote/SkyMote.java
@@ -30,11 +30,10 @@
 
 package org.contikios.cooja.mspmote;
 
-import java.io.File;
-
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
+import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.mspmote.interfaces.CoojaM25P80;
 import org.contikios.cooja.mspmote.interfaces.SkyCoffeeFilesystem;
@@ -46,25 +45,19 @@ import se.sics.mspsim.platform.sky.SkyNode;
 public class SkyMote extends MspMote {
   private static final Logger logger = LogManager.getLogger(SkyMote.class);
 
-  public SkyNode skyNode = null;
+  public final SkyNode skyNode;
 
-  public SkyMote(MspMoteType moteType, Simulation sim) {
+  public SkyMote(MspMoteType moteType, Simulation sim) throws MoteType.MoteTypeCreationException {
     super(moteType, sim);
-  }
-
-  @Override
-  protected boolean initEmulator(File fileELF) {
+    skyNode = new SkyNode();
+    registry = skyNode.getRegistry();
+    skyNode.setFlash(new CoojaM25P80(skyNode.getCPU()));
     try {
-      skyNode = new SkyNode();
-      registry = skyNode.getRegistry();
-      skyNode.setFlash(new CoojaM25P80(skyNode.getCPU()));
-
-      prepareMote(fileELF, skyNode);
+      prepareMote(moteType.getContikiFirmwareFile(), skyNode);
     } catch (Exception e) {
       logger.fatal("Error when creating Sky mote: ", e);
-      return false;
+      throw new MoteType.MoteTypeCreationException("Error when creating Sky mote: " + e.getMessage());
     }
-    return true;
   }
 
   /*private void configureWithMacAddressesTxt(int id) {

--- a/java/org/contikios/cooja/mspmote/SkyMote.java
+++ b/java/org/contikios/cooja/mspmote/SkyMote.java
@@ -33,6 +33,7 @@ package org.contikios.cooja.mspmote;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
+import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.mspmote.interfaces.CoojaM25P80;
@@ -58,6 +59,7 @@ public class SkyMote extends MspMote {
       logger.fatal("Error when creating Sky mote: ", e);
       throw new MoteType.MoteTypeCreationException("Error when creating Sky mote: " + e.getMessage());
     }
+    myMoteInterfaceHandler = new MoteInterfaceHandler(this, moteType.getMoteInterfaceClasses());
   }
 
   /*private void configureWithMacAddressesTxt(int id) {

--- a/java/org/contikios/cooja/mspmote/SkyMoteType.java
+++ b/java/org/contikios/cooja/mspmote/SkyMoteType.java
@@ -56,7 +56,7 @@ import org.contikios.cooja.mspmote.interfaces.SkyTemperature;
 public class SkyMoteType extends MspMoteType {
 
   @Override
-  protected MspMote createMote(Simulation simulation) {
+  protected MspMote createMote(Simulation simulation) throws MoteTypeCreationException {
     return new SkyMote(this, simulation);
   }
 

--- a/java/org/contikios/cooja/mspmote/Z1Mote.java
+++ b/java/org/contikios/cooja/mspmote/Z1Mote.java
@@ -31,6 +31,7 @@
 package org.contikios.cooja.mspmote;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.mspmote.interfaces.CoojaM25P80;
@@ -54,6 +55,7 @@ public class Z1Mote extends MspMote {
             logger.fatal("Error when creating Z1 mote: ", e);
             throw new MoteType.MoteTypeCreationException("Error when creating Z1 mote: " + e.getMessage());
         }
+        myMoteInterfaceHandler = new MoteInterfaceHandler(this, moteType.getMoteInterfaceClasses());
     }
 
     @Override

--- a/java/org/contikios/cooja/mspmote/Z1Mote.java
+++ b/java/org/contikios/cooja/mspmote/Z1Mote.java
@@ -29,9 +29,9 @@
  */
 
 package org.contikios.cooja.mspmote;
-import java.io.File;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.mspmote.interfaces.CoojaM25P80;
 import se.sics.mspsim.platform.z1.Z1Node;
@@ -43,23 +43,17 @@ public class Z1Mote extends MspMote {
 
     private static final Logger logger = LogManager.getLogger(Z1Mote.class);
 
-    public Z1Mote(MspMoteType moteType, Simulation sim) {
+    public Z1Mote(MspMoteType moteType, Simulation sim) throws MoteType.MoteTypeCreationException {
         super(moteType, sim);
-    }
-
-    @Override
-    protected boolean initEmulator(File fileELF) {
+        Z1Node z1Node = new Z1Node();
+        registry = z1Node.getRegistry();
+        z1Node.setFlash(new CoojaM25P80(z1Node.getCPU()));
         try {
-            Z1Node z1Node = new Z1Node();
-            registry = z1Node.getRegistry();
-            z1Node.setFlash(new CoojaM25P80(z1Node.getCPU()));
-
-            prepareMote(fileELF, z1Node);
+            prepareMote(moteType.getContikiFirmwareFile(), z1Node);
         } catch (Exception e) {
             logger.fatal("Error when creating Z1 mote: ", e);
-            return false;
+            throw new MoteType.MoteTypeCreationException("Error when creating Z1 mote: " + e.getMessage());
         }
-        return true;
     }
 
     @Override

--- a/java/org/contikios/cooja/mspmote/Z1MoteType.java
+++ b/java/org/contikios/cooja/mspmote/Z1MoteType.java
@@ -67,7 +67,7 @@ public class Z1MoteType extends MspMoteType {
     }
 
     @Override
-    protected MspMote createMote(Simulation simulation) {
+    protected MspMote createMote(Simulation simulation) throws MoteTypeCreationException {
         return new Z1Mote(this, simulation);
     }
 


### PR DESCRIPTION
Move code around so the MoteInterfaceHandler can be allocated in the constructor of the MSP430 motes.