### PR TITLE
AbstractCompileDialog: validate name before existence

### DIFF
--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -591,12 +591,12 @@ public abstract class AbstractCompileDialog extends JDialog {
       break;
 
     case SELECTED_SOURCE:
-      if (!sourceFile.exists()) {
-        logger.warn("Could not find Contiki source: " + sourceFile.getAbsolutePath());
+      if (!sourceFile.getName().endsWith(".c")) {
         setDialogState(DialogState.NO_SELECTION);
         return;
       }
-      if (!sourceFile.getName().endsWith(".c")) {
+      if (!sourceFile.exists()) {
+        logger.warn("Could not find Contiki source: " + sourceFile.getAbsolutePath());
         setDialogState(DialogState.NO_SELECTION);
         return;
       }
@@ -612,12 +612,12 @@ public abstract class AbstractCompileDialog extends JDialog {
       break;
 
     case AWAITING_COMPILATION:
-      if (!sourceFile.exists()) {
-        logger.warn("Could not find Contiki source: " + sourceFile.getAbsolutePath());
+      if (!sourceFile.getName().endsWith(".c")) {
         setDialogState(DialogState.NO_SELECTION);
         return;
       }
-      if (!sourceFile.getName().endsWith(".c")) {
+      if (!sourceFile.exists()) {
+        logger.warn("Could not find Contiki source: " + sourceFile.getAbsolutePath());
         setDialogState(DialogState.NO_SELECTION);
         return;
       }


### PR DESCRIPTION
Check that the selected file is of the right type
before checking that the file exists. This avoids
spurious printouts on the console when no file
is selected.