### PR TITLE
AbstractCompileDialog simplifications

### DIFF
--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -450,8 +450,7 @@ public abstract class AbstractCompileDialog extends JDialog {
 
     /* Handle multiple compilation commands one by one */
     final ArrayList<String> commands = new ArrayList<>();
-    String[] arr = getCompileCommands().split("\n");
-    for (String cmd: arr) {
+    for (String cmd: getCompileCommands().split("\n")) {
       if (cmd.trim().isEmpty()) {
         continue;
       }

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -382,9 +382,8 @@ public abstract class AbstractCompileDialog extends JDialog {
     tryRestoreMoteType();
   }
 
-  private void tryRestoreMoteType() { 
-    /* Restore old configuration if mote type is already configured */
-    boolean restoredDialogState = false;
+  private void tryRestoreMoteType() {
+    var dialogState = DialogState.NO_SELECTION;
     /* Restore description */
     if (moteType.getDescription() != null) {
       descriptionField.setText(moteType.getDescription());
@@ -395,12 +394,10 @@ public abstract class AbstractCompileDialog extends JDialog {
     final var firmware = moteType.getContikiFirmwareFile();
     if (source != null) {
       contikiField.setText(source.getAbsolutePath());
-      setDialogState(DialogState.SELECTED_SOURCE);
-      restoredDialogState = true;
+      dialogState = DialogState.SELECTED_SOURCE;
     } else if (firmware != null) {
       contikiField.setText(firmware.getAbsolutePath());
-      setDialogState(DialogState.SELECTED_FIRMWARE);
-      restoredDialogState = true;
+      dialogState = DialogState.SELECTED_FIRMWARE;
     }
 
     /* Restore mote interface classes */
@@ -422,12 +419,9 @@ public abstract class AbstractCompileDialog extends JDialog {
     final var commands = moteType.getCompileCommands();
     if (commands != null) {
       setCompileCommands(commands);
-      setDialogState(DialogState.AWAITING_COMPILATION);
-      restoredDialogState = true;
+      dialogState = DialogState.AWAITING_COMPILATION;
     }
-    if (!restoredDialogState) {
-      setDialogState(DialogState.NO_SELECTION);
-    }
+    setDialogState(dialogState);
   }
 
   /**

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -503,20 +503,13 @@ public abstract class AbstractCompileDialog extends JDialog {
     final Action nextCommandAction = new AbstractAction() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-        Action nextSuccessAction;
-        if (commands.size() == 1) {
-          nextSuccessAction = compilationSuccessAction;
-        } else {
-          nextSuccessAction = this;
-        }
-
         String command = commands.remove(0);
         try {
           currentCompilationProcess = CompileContiki.compile(
               command,
               compilationEnvironment,
               new File(contikiField.getText()).getParentFile(),
-              nextSuccessAction,
+              commands.isEmpty() ? compilationSuccessAction : this,
               compilationFailureAction,
               taskOutput,
               false

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -365,7 +365,6 @@ public abstract class AbstractCompileDialog extends JDialog {
       Dimension newSize = new Dimension();
       newSize.height = Math.min((int) maxSize.getHeight(), (int) getSize().getHeight());
       newSize.width = Math.min((int) maxSize.getWidth(), (int) getSize().getWidth());
-      /*logger.info("Resizing dialog: " + myDialog.getSize() + " -> " + newSize);*/
       setSize(newSize);
     }
 
@@ -812,7 +811,6 @@ public abstract class AbstractCompileDialog extends JDialog {
    * @param commands User configured compile commands
    */
   public void setCompileCommands(String commands) {
-    /* TODO Merge from String[] */
     commandsArea.setText(commands);
   }
 
@@ -820,7 +818,6 @@ public abstract class AbstractCompileDialog extends JDialog {
    * @return User configured compile commands
    */
   public String getCompileCommands() {
-    /* TODO Split into String[] */
     return commandsArea.getText();
   }
 

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -385,47 +385,45 @@ public abstract class AbstractCompileDialog extends JDialog {
   private void tryRestoreMoteType() { 
     /* Restore old configuration if mote type is already configured */
     boolean restoredDialogState = false;
-    if (moteType != null) {
-      /* Restore description */
-      if (moteType.getDescription() != null) {
-        descriptionField.setText(moteType.getDescription());
-      }
+    /* Restore description */
+    if (moteType.getDescription() != null) {
+      descriptionField.setText(moteType.getDescription());
+    }
 
-      /* Restore Contiki source or firmware */
-      final var source = moteType.getContikiSourceFile();
-      final var firmware = moteType.getContikiFirmwareFile();
-      if (source != null) {
-        contikiField.setText(source.getAbsolutePath());
-        setDialogState(DialogState.SELECTED_SOURCE);
-        restoredDialogState = true;
-      } else if (firmware != null) {
-        contikiField.setText(firmware.getAbsolutePath());
-        setDialogState(DialogState.SELECTED_FIRMWARE);
-        restoredDialogState = true;
-      }
+    /* Restore Contiki source or firmware */
+    final var source = moteType.getContikiSourceFile();
+    final var firmware = moteType.getContikiFirmwareFile();
+    if (source != null) {
+      contikiField.setText(source.getAbsolutePath());
+      setDialogState(DialogState.SELECTED_SOURCE);
+      restoredDialogState = true;
+    } else if (firmware != null) {
+      contikiField.setText(firmware.getAbsolutePath());
+      setDialogState(DialogState.SELECTED_FIRMWARE);
+      restoredDialogState = true;
+    }
 
-      /* Restore mote interface classes */
-      for (Component c : moteIntfBox.getComponents()) {
-        if (!(c instanceof JCheckBox)) {
-          continue;
-        }
-        ((JCheckBox) c).setSelected(false);
+    /* Restore mote interface classes */
+    for (Component c : moteIntfBox.getComponents()) {
+      if (!(c instanceof JCheckBox)) {
+        continue;
       }
-      for (var intf : getAllMoteInterfaces()) {
-        addMoteInterface(intf, false);
-      }
-      var moteClasses = moteType.getMoteInterfaceClasses();
-      for (var intf : moteClasses == null ? getDefaultMoteInterfaces() : moteClasses) {
-        addMoteInterface(intf, true);
-      }
+      ((JCheckBox) c).setSelected(false);
+    }
+    for (var intf : getAllMoteInterfaces()) {
+      addMoteInterface(intf, false);
+    }
+    var moteClasses = moteType.getMoteInterfaceClasses();
+    for (var intf : moteClasses == null ? getDefaultMoteInterfaces() : moteClasses) {
+      addMoteInterface(intf, true);
+    }
 
-      /* Restore compile commands */
-      final var commands = moteType.getCompileCommands();
-      if (commands != null) {
-        setCompileCommands(commands);
-        setDialogState(DialogState.AWAITING_COMPILATION);
-        restoredDialogState = true;
-      }
+    /* Restore compile commands */
+    final var commands = moteType.getCompileCommands();
+    if (commands != null) {
+      setCompileCommands(commands);
+      setDialogState(DialogState.AWAITING_COMPILATION);
+      restoredDialogState = true;
     }
     if (!restoredDialogState) {
       setDialogState(DialogState.NO_SELECTION);

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -855,7 +855,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     currentCompilationProcess = null;
   }
 
-  private boolean createNewCompilationTab(MessageListUI output) {
+  private void createNewCompilationTab(MessageListUI output) {
     abortAnyCompilation();
     tabbedPane.remove(currentCompilationOutput);
 
@@ -864,7 +864,6 @@ public abstract class AbstractCompileDialog extends JDialog {
 
     tabbedPane.setSelectedComponent(scrollOutput);
     currentCompilationOutput = scrollOutput;
-    return true;
   }
 
   protected abstract String getTargetName();

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -402,10 +402,9 @@ public abstract class AbstractCompileDialog extends JDialog {
 
     /* Restore mote interface classes */
     for (Component c : moteIntfBox.getComponents()) {
-      if (!(c instanceof JCheckBox)) {
-        continue;
+      if (c instanceof JCheckBox box) {
+        box.setSelected(false);
       }
-      ((JCheckBox) c).setSelected(false);
     }
     for (var intf : getAllMoteInterfaces()) {
       addMoteInterface(intf, false);

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -66,7 +66,6 @@ import javax.swing.JTabbedPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
-import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.filechooser.FileFilter;
@@ -461,16 +460,7 @@ public abstract class AbstractCompileDialog extends JDialog {
       throw new Exception("No compile commands specified");
     }
 
-    if (SwingUtilities.isEventDispatchThread()) {
-      setDialogState(DialogState.IS_COMPILING);
-    } else {
-      SwingUtilities.invokeAndWait(new Runnable() {
-        @Override
-        public void run() {
-          setDialogState(DialogState.IS_COMPILING);
-        }
-      });
-    }
+    setDialogState(DialogState.IS_COMPILING);
     createNewCompilationTab(taskOutput);
 
     /* Add abort compilation menu item */


### PR DESCRIPTION
Inline single-use variables, simplify logic, and remove unused return values, commented out code and always-true checks.