### PR TITLE
Cooja: consolidate mote creation code

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2098,40 +2098,6 @@ public class Cooja extends Observable {
   }
 
   /**
-   * Creates a new mote type of the given mote type class.
-   * This may include displaying a dialog for user configurations.
-   * <p>
-   * If mote type is created successfully, the add motes dialog will appear.
-   *
-   * @param moteTypeClass Mote type class
-   */
-  private void doCreateMoteType(Class<? extends MoteType> moteTypeClass) {
-    if (mySimulation == null) {
-      logger.fatal("Can't create mote type (no simulation)");
-      return;
-    }
-    mySimulation.stopSimulation();
-
-    // Create mote type
-    MoteType newMoteType;
-    try {
-      newMoteType = moteTypeClass == ContikiMoteType.class
-              ? new ContikiMoteType(this) : moteTypeClass.getDeclaredConstructor().newInstance();
-      if (!newMoteType.configureAndInit(Cooja.getTopParentContainer(), mySimulation, isVisualized())) {
-        return;
-      }
-      mySimulation.addMoteType(newMoteType);
-    } catch (Exception e) {
-      logger.fatal("Exception when creating mote type", e);
-      if (isVisualized()) {
-        showErrorDialog(getTopParentContainer(), "Mote type creation error", e, false);
-      }
-      return;
-    }
-    doAddMotes(newMoteType);
-  }
-
-  /**
    * Remove current simulation
    *
    * @param askForConfirmation
@@ -2733,8 +2699,30 @@ public class Cooja extends Observable {
     @Override
     public void actionPerformed(ActionEvent e) {
       if (e.getActionCommand().equals("create mote type")) {
-        cooja.doCreateMoteType((Class<? extends MoteType>) ((JMenuItem) e
-            .getSource()).getClientProperty("class"));
+        if (cooja.mySimulation == null) {
+          logger.fatal("Can't create mote type (no simulation)");
+          return;
+        }
+        cooja.mySimulation.stopSimulation();
+
+        // Create mote type
+        var clazz = (Class<? extends MoteType>) ((JMenuItem) e.getSource()).getClientProperty("class");
+        MoteType newMoteType;
+        try {
+          newMoteType = clazz == ContikiMoteType.class
+                  ? new ContikiMoteType(cooja) : clazz.getDeclaredConstructor().newInstance();
+          if (!newMoteType.configureAndInit(Cooja.getTopParentContainer(), cooja.mySimulation, isVisualized())) {
+            return;
+          }
+          cooja.mySimulation.addMoteType(newMoteType);
+        } catch (Exception e1) {
+          logger.fatal("Exception when creating mote type", e1);
+          if (isVisualized()) {
+            showErrorDialog(getTopParentContainer(), "Mote type creation error", e1, false);
+          }
+          return;
+        }
+        cooja.doAddMotes(newMoteType);
       } else if (e.getActionCommand().equals("add motes")) {
         cooja.doAddMotes((MoteType) ((JMenuItem) e.getSource())
             .getClientProperty("motetype"));

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2698,6 +2698,7 @@ public class Cooja extends Observable {
   private class GUIEventHandler implements ActionListener {
     @Override
     public void actionPerformed(ActionEvent e) {
+      MoteType newMoteType = null;
       final var cmd = e.getActionCommand();
       if (cmd.equals("create mote type")) {
         if (cooja.mySimulation == null) {
@@ -2708,7 +2709,6 @@ public class Cooja extends Observable {
 
         // Create mote type
         var clazz = (Class<? extends MoteType>) ((JMenuItem) e.getSource()).getClientProperty("class");
-        MoteType newMoteType;
         try {
           newMoteType = clazz == ContikiMoteType.class
                   ? new ContikiMoteType(cooja) : clazz.getDeclaredConstructor().newInstance();
@@ -2723,10 +2723,8 @@ public class Cooja extends Observable {
           }
           return;
         }
-        cooja.doAddMotes(newMoteType);
       } else if (cmd.equals("add motes")) {
-        cooja.doAddMotes((MoteType) ((JMenuItem) e.getSource())
-            .getClientProperty("motetype"));
+        newMoteType = (MoteType) ((JMenuItem) e.getSource()).getClientProperty("motetype");
       } else if (cmd.equals("edit paths")) {
         ExternalToolsDialog.showDialog(Cooja.getTopParentContainer());
       } else if (cmd.equals("manage extensions")) {
@@ -2754,6 +2752,9 @@ public class Cooja extends Observable {
         }
       } else {
         logger.warn("Unhandled action: " + cmd);
+      }
+      if (newMoteType != null) {
+        cooja.doAddMotes(newMoteType);
       }
     }
   }

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2703,10 +2703,8 @@ public class Cooja extends Observable {
           cooja.mySimulation.addMoteType(newMoteType);
         } catch (Exception e1) {
           logger.fatal("Exception when creating mote type", e1);
-          if (isVisualized()) {
-            showErrorDialog(getTopParentContainer(), "Mote type creation error", e1, false);
-          }
-          return;
+          showErrorDialog(getTopParentContainer(), "Mote type creation error", e1, false);
+          newMoteType = null;
         }
       } else if (cmd.equals("add motes")) {
         if (cooja.mySimulation == null) {
@@ -2730,13 +2728,11 @@ public class Cooja extends Observable {
             reparseProjectConfig();
           } catch (ParseProjectsException ex) {
             logger.fatal("Error when loading extensions: " + ex.getMessage(), ex);
-            if (isVisualized()) {
-            	JOptionPane.showMessageDialog(Cooja.getTopParentContainer(),
-            			"All Cooja extensions could not load.\n\n" +
-            			"To manage Cooja extensions:\n" +
-            			"Menu->Settings->Cooja extensions",
-            			"Reconfigure Cooja extensions", JOptionPane.INFORMATION_MESSAGE);
-            }
+            JOptionPane.showMessageDialog(Cooja.getTopParentContainer(),
+                    "All Cooja extensions could not load.\n\n" +
+                            "To manage Cooja extensions:\n" +
+                            "Menu->Settings->Cooja extensions",
+                    "Reconfigure Cooja extensions", JOptionPane.INFORMATION_MESSAGE);
             showErrorDialog(getTopParentContainer(), "Cooja extensions load error", ex, false);
           }
         }

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2698,7 +2698,8 @@ public class Cooja extends Observable {
   private class GUIEventHandler implements ActionListener {
     @Override
     public void actionPerformed(ActionEvent e) {
-      if (e.getActionCommand().equals("create mote type")) {
+      final var cmd = e.getActionCommand();
+      if (cmd.equals("create mote type")) {
         if (cooja.mySimulation == null) {
           logger.fatal("Can't create mote type (no simulation)");
           return;
@@ -2723,12 +2724,12 @@ public class Cooja extends Observable {
           return;
         }
         cooja.doAddMotes(newMoteType);
-      } else if (e.getActionCommand().equals("add motes")) {
+      } else if (cmd.equals("add motes")) {
         cooja.doAddMotes((MoteType) ((JMenuItem) e.getSource())
             .getClientProperty("motetype"));
-      } else if (e.getActionCommand().equals("edit paths")) {
+      } else if (cmd.equals("edit paths")) {
         ExternalToolsDialog.showDialog(Cooja.getTopParentContainer());
-      } else if (e.getActionCommand().equals("manage extensions")) {
+      } else if (cmd.equals("manage extensions")) {
         COOJAProject[] newProjects = ProjectDirectoriesDialog.showDialog(
             Cooja.getTopParentContainer(),
             Cooja.this,
@@ -2752,7 +2753,7 @@ public class Cooja extends Observable {
           }
         }
       } else {
-        logger.warn("Unhandled action: " + e.getActionCommand());
+        logger.warn("Unhandled action: " + cmd);
       }
     }
   }

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2686,6 +2686,7 @@ public class Cooja extends Observable {
       MoteType newMoteType = null;
       final var cmd = e.getActionCommand();
       if (cmd.equals("create mote type")) {
+        // FIXME: Simulation should never be null if this action is enabled.
         if (cooja.mySimulation == null) {
           logger.fatal("Can't create mote type (no simulation)");
           return;
@@ -2707,6 +2708,7 @@ public class Cooja extends Observable {
           newMoteType = null;
         }
       } else if (cmd.equals("add motes")) {
+        // FIXME: Simulation should never be null if this action is enabled.
         if (cooja.mySimulation == null) {
           logger.warn("No simulation active");
           return;

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2432,21 +2432,6 @@ public class Cooja extends Observable {
   }
 
   /**
-   * Add new mote to current simulation
-   */
-  private void doAddMotes(MoteType moteType) {
-    if (mySimulation == null) {
-      logger.warn("No simulation active");
-      return;
-    }
-
-    mySimulation.stopSimulation();
-    for (var mote : AddMoteDialog.showDialog(frame, mySimulation, moteType)) {
-      mySimulation.addMote(mote);
-    }
-  }
-
-  /**
    * Quit program
    *
    * @param askForConfirmation Should we ask for confirmation before quitting?
@@ -2724,6 +2709,11 @@ public class Cooja extends Observable {
           return;
         }
       } else if (cmd.equals("add motes")) {
+        if (cooja.mySimulation == null) {
+          logger.warn("No simulation active");
+          return;
+        }
+        cooja.mySimulation.stopSimulation();
         newMoteType = (MoteType) ((JMenuItem) e.getSource()).getClientProperty("motetype");
       } else if (cmd.equals("edit paths")) {
         ExternalToolsDialog.showDialog(Cooja.getTopParentContainer());
@@ -2754,7 +2744,9 @@ public class Cooja extends Observable {
         logger.warn("Unhandled action: " + cmd);
       }
       if (newMoteType != null) {
-        cooja.doAddMotes(newMoteType);
+        for (var mote : AddMoteDialog.showDialog(frame, cooja.mySimulation, newMoteType)) {
+          cooja.mySimulation.addMote(mote);
+        }
       }
     }
   }


### PR DESCRIPTION
Put the code for creating motes inside the action. This revealed some spurious isVisualized checks, and the consolidation avoids calling stopSimulation multiple times when adding new mote types.