### PR TITLE
Simulation simplifications

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -63,8 +63,6 @@ public class Simulation extends Observable implements Runnable {
   /*private static long EVENT_COUNTER = 0;*/
 
   private final ArrayList<Mote> motes = new ArrayList<>();
-  private final ArrayList<Mote> motesUninit = new ArrayList<>();
-  
   private final ArrayList<MoteType> moteTypes = new ArrayList<>();
 
   /* If true, run simulation at full speed */
@@ -732,7 +730,6 @@ public class Simulation extends Observable implements Runnable {
       @Override
       public void run() {
         motes.remove(mote);
-        motesUninit.remove(mote);
         currentRadioMedium.unregisterMote(mote, Simulation.this);
 
         /* Dispose mote interface resources */
@@ -801,7 +798,6 @@ public class Simulation extends Observable implements Runnable {
         }
 
         motes.add(mote);
-        motesUninit.remove(mote);
         currentRadioMedium.registerMote(mote, Simulation.this);
 
         /* Notify mote interfaces that node was added */
@@ -814,9 +810,6 @@ public class Simulation extends Observable implements Runnable {
         cooja.updateGUIComponentState();
       }
     };
-
-    //Add to list of uninitialized motes
-    motesUninit.add(mote);
 
     if (!isRunning()) {
       /* Simulation is stopped, add mote immediately */

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -857,24 +857,6 @@ public class Simulation extends Observable implements Runnable {
   }
 
   /**
-   * Returns uninitialised simulation mote with given ID.
-   * 
-   * @param id ID
-   * @return Mote or null
-   * @see Mote#getID()
-   */
-  public Mote getMoteWithIDUninit(int id) {
-    for (Mote m: motesUninit) {
-      if (m.getID() == id) {
-        return m;
-      }
-    }
-    return null;
-  }
-
-
-
-  /**
    * Returns number of motes in this simulation.
    *
    * @return Number of motes
@@ -893,16 +875,6 @@ public class Simulation extends Observable implements Runnable {
     motes.toArray(arr);
     return arr;
   }
-
-  /**
-   * Returns uninitialised motes
-   *
-   * @return Motes
-   */
-  public Mote[] getMotesUninit() {
-    return motesUninit.toArray(new Mote[0]);
-  }
-
 
   /**
    * Returns all mote types in simulation.

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -456,7 +456,7 @@ public class Simulation extends Observable implements Runnable {
     config.add(element);
 
     // Mote types
-    for (MoteType moteType : getMoteTypes()) {
+    for (MoteType moteType : moteTypes) {
       element = new Element("motetype");
       element.setText(moteType.getClass().getName());
 


### PR DESCRIPTION
Remove unused methods, inline a single-use method, and remove the container that becomes unused from the removed methods.