### PR TITLE
Remove spurious firmware existence checks

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -384,12 +384,8 @@ public class ContikiMoteType extends BaseContikiMoteType {
               "Core communicator already used: " + myCoreComm.getClass().getName());
     }
 
-    final var firmwareFile = getContikiFirmwareFile();
-    if (firmwareFile == null || !firmwareFile.exists()) {
-      throw new MoteTypeCreationException("Library file could not be found: " + firmwareFile);
-    }
-
     // Allocate core communicator class
+    final var firmwareFile = getContikiFirmwareFile();
     logger.debug("Creating core communicator between Java class " + javaClassName + " and Contiki library '" + firmwareFile.getPath() + "'");
     myCoreComm = CoreComm.createCoreComm(tempDir, javaClassName, firmwareFile);
 

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -480,13 +480,6 @@ public abstract class AbstractCompileDialog extends JDialog {
 			@Override
 			public void actionPerformed(ActionEvent e) {
         abortMenuItem.setEnabled(false);
-
-        /* Make sure firmware exists */
-        if (!contikiFirmware.exists()) {
-          logger.fatal("Contiki firmware does not exist: " + contikiFirmware.getAbsolutePath());
-          setDialogState(DialogState.AWAITING_COMPILATION);
-          return;
-        }
         setDialogState(DialogState.COMPILED_FIRMWARE);
       }
     };

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -128,15 +128,7 @@ public abstract class MspMoteType extends BaseContikiMoteType {
     }
 
     // Not visualized: Compile Contiki immediately.
-    if (!compileMoteType(visAvailable, null)) {
-      return false;
-    }
-    // FIXME: Contiki-NG build system guarantees the firmware exists if build was successful.
-    final var firmware = getContikiFirmwareFile();
-    if (firmware == null || !firmware.exists()) {
-      throw new MoteTypeCreationException("Contiki firmware file does not exist: " + firmware);
-    }
-    return true;
+    return compileMoteType(visAvailable, null);
   }
 
   @Override


### PR DESCRIPTION
The Contiki-NG build system guarantees
the firmware will be produced if the build
was successful. Cooja will not get
to these points if make fails.