### PR TITLE
Move name methods to BaseContikiMoteType

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -199,6 +199,16 @@ public class ContikiMoteType extends BaseContikiMoteType {
   }
 
   @Override
+  public String getMoteType() {
+    return "cooja";
+  }
+
+  @Override
+  public String getMoteName() {
+    return "Cooja";
+  }
+
+  @Override
   public Mote generateMote(Simulation simulation) throws MoteTypeCreationException {
     return new ContikiMote(this, simulation);
   }

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -72,6 +72,12 @@ public abstract class BaseContikiMoteType implements MoteType {
   /** MoteInterface classes used by the mote type. */
   protected final ArrayList<Class<? extends MoteInterface>> moteInterfaceClasses = new ArrayList<>();
 
+  /** Returns file name extension for firmware. */
+  public abstract String getMoteType();
+
+  /** Returns human-readable name for mote type. */
+  public abstract String getMoteName();
+
   @Override
   public String getDescription() {
     return description;

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -72,10 +72,6 @@ import se.sics.mspsim.util.ELF;
 public abstract class MspMoteType extends BaseContikiMoteType {
   private static final Logger logger = LogManager.getLogger(MspMoteType.class);
 
-  public abstract String getMoteType();
-
-  public abstract String getMoteName();
-
   protected abstract String getMoteImage();
 
   @Override


### PR DESCRIPTION
These methods are required for making generic
methods that work for any mote type.