### PR TITLE
MspMoteType: restore firmware-only support

### DIFF
--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -62,6 +62,7 @@ public abstract class BaseContikiMoteType implements MoteType {
 
   /** Project configuration of the mote type. */
   protected ProjectConfig projectConfig = null;
+  // FIXME: combine fileSource and fileFirmware so only one can be active.
   /** Source file of the mote type. */
   protected File fileSource = null;
   /** Commands to compile the source into the firmware. */

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -122,8 +122,15 @@ public abstract class MspMoteType extends BaseContikiMoteType {
     if (getIdentifier() == null) {
       throw new MoteTypeCreationException("No identifier");
     }
-    final var commands = getCompileCommands();
-    if (commands == null) {
+    if (getContikiSourceFile() == null) {
+      // Source file is null for firmware-only simulations, so just return true if firmware exists.
+      final var firmware = getContikiFirmwareFile();
+      if (firmware == null || !firmware.exists()) {
+        throw new MoteTypeCreationException("Contiki firmware file does not exist: " + firmware);
+      }
+      return true;
+    }
+    if (getCompileCommands() == null) {
       throw new MoteTypeCreationException("No compile commands specified");
     }
 


### PR DESCRIPTION
Commit b347506b17d7 added too eager error checking with compilation commands, there is no need to compile firmware-only simulations.

Restore the old logic and add a FIXME to combine
the two fields into a single field so the error
cases cannot happen.