### PR TITLE
Put firmware name logic in BaseContikiMoteType

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -371,8 +371,9 @@ public class ContikiMoteType extends BaseContikiMoteType {
     return new File(parentDir, sourceNoExtension + librarySuffix);
   }
 
-  public static File getExpectedFirmwareFile(String moteId, File source) {
-    return new File(source.getParentFile(), "build/cooja/" + moteId + ContikiMoteType.librarySuffix);
+  @Override
+  public File getExpectedFirmwareFile(File source) {
+    return new File(source.getParentFile(), "build/cooja/" + identifier + ContikiMoteType.librarySuffix);
   }
 
   /**

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -75,7 +75,6 @@ import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.MoteInterface;
-import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.interfaces.MoteID;
 import org.contikios.cooja.interfaces.Position;
@@ -109,7 +108,7 @@ public abstract class AbstractCompileDialog extends JDialog {
 
   protected final Simulation simulation;
   protected final Cooja gui;
-  protected final MoteType moteType;
+  protected final BaseContikiMoteType moteType;
 
   protected final JTabbedPane tabbedPane;
   protected Box moteIntfBox;
@@ -128,7 +127,7 @@ public abstract class AbstractCompileDialog extends JDialog {
   public File contikiSource = null;
   public File contikiFirmware = null;
 
-  public AbstractCompileDialog(Container parent, Simulation simulation, final MoteType moteType) {
+  public AbstractCompileDialog(Container parent, Simulation simulation, final BaseContikiMoteType moteType) {
     super(
         parent instanceof Dialog?(Dialog)parent:
           parent instanceof Window?(Window)parent:
@@ -574,7 +573,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     	createButton.setEnabled(false);
     	commandsArea.setEnabled(true);
       setCompileCommands(getDefaultCompileCommands(sourceFile));
-      contikiFirmware = getExpectedFirmwareFile(moteType.getIdentifier(), sourceFile);
+      contikiFirmware = moteType.getExpectedFirmwareFile(sourceFile);
       contikiSource = sourceFile;
       setDialogState(DialogState.AWAITING_COMPILATION);
       break;
@@ -803,24 +802,7 @@ public abstract class AbstractCompileDialog extends JDialog {
    */
   public String getDefaultCompileCommands(File source) {
     return Cooja.getExternalToolsSetting("PATH_MAKE") + " -j$(CPUS) " +
-           getExpectedFirmwareFile(source).getName() + " TARGET=" + getTargetName();
-  }
-
-  /**
-   * @param source Contiki source
-   * @return Expected Contiki firmware compiled from source
-   */
-  public abstract File getExpectedFirmwareFile(File source);
-
-  /**
-   * Returns the Contiki firmware name for moteId and source.
-   *
-   * @param moteId The ID of the mote
-   * @param source Contiki source
-   * @return Expected Contiki firmware compiled from source
-   */
-  public File getExpectedFirmwareFile(String moteId, File source) {
-    return getExpectedFirmwareFile(source);
+           moteType.getExpectedFirmwareFile(source).getName() + " TARGET=" + getTargetName();
   }
 
   private void abortAnyCompilation() {

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -136,17 +136,6 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
   }
 
   @Override
-  public File getExpectedFirmwareFile(File source) {
-    logger.fatal("Called getExpectedFirmwareFile(File)");
-    throw new RuntimeException("This method should not be called on ContikiMotes");
-  }
-
-  @Override
-  public File getExpectedFirmwareFile(String moteId, File source) {
-    return ContikiMoteType.getExpectedFirmwareFile(moteId, source);
-  }
-
-  @Override
   public Class<? extends MoteInterface>[] getAllMoteInterfaces() {
     return ((ContikiMoteType)moteType).getAllMoteInterfaceClasses();
   }

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -134,6 +134,15 @@ public abstract class BaseContikiMoteType implements MoteType {
     fileFirmware = file;
   }
 
+  public File getExpectedFirmwareFile(File source) {
+    File parentDir = source.getParentFile();
+    String sourceNoExtension = source.getName();
+    if (sourceNoExtension.endsWith(".c")) {
+      sourceNoExtension = sourceNoExtension.substring(0, source.getName().length() - 2);
+    }
+    return new File(parentDir, "/build/" + getMoteType() + "/" + sourceNoExtension + '.' + getMoteType());
+  }
+
   @Override
   public Class<? extends MoteInterface>[] getMoteInterfaceClasses() {
     if (moteInterfaceClasses.isEmpty()) {

--- a/java/org/contikios/cooja/mspmote/MspCompileDialog.java
+++ b/java/org/contikios/cooja/mspmote/MspCompileDialog.java
@@ -93,11 +93,6 @@ public class MspCompileDialog extends AbstractCompileDialog {
   }
 
   @Override
-  public File getExpectedFirmwareFile(File source) {
-    return ((MspMoteType)moteType).getExpectedFirmwareFile(source);
-  }
-
-  @Override
   public void writeSettingsToMoteType() {
     /* Nothing to do */
   }

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -338,15 +338,6 @@ public abstract class MspMoteType extends BaseContikiMoteType {
   public abstract Class<? extends MoteInterface>[] getAllMoteInterfaceClasses();
   public abstract Class<? extends MoteInterface>[] getDefaultMoteInterfaceClasses();
 
-  public File getExpectedFirmwareFile(File source) {
-    File parentDir = source.getParentFile();
-    String sourceNoExtension = source.getName();
-    if (sourceNoExtension.endsWith(".c")) {
-      sourceNoExtension = sourceNoExtension.substring(0, source.getName().length() - 2);
-    }
-    return new File(parentDir, "/build/" + getMoteType() + "/" + sourceNoExtension + '.' + getMoteType());
-  }
-
   private ELF elf; /* cached */
   public ELF getELF() throws IOException {
     if (elf == null) {


### PR DESCRIPTION
ContikiMoteType uses special naming rules, so implement that as an override in ContikiMoteType itself.