### PR TITLE
AbstractCompileDialog: remove target field

### DIFF
--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -274,14 +274,14 @@ public abstract class AbstractCompileDialog extends JDialog {
     	}
     };
     cleanButton = new JButton("Clean");
-    cleanButton.setToolTipText("make clean TARGET=" + getTargetName());
+    cleanButton.setToolTipText("make clean TARGET=" + moteType.getMoteType());
     cleanButton.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(ActionEvent e) {
         createButton.setEnabled(false);
 				try {
 					currentCompilationProcess = BaseContikiMoteType.compile(
-							"make clean TARGET=" + getTargetName(),
+							"make clean TARGET=" + moteType.getMoteType(),
 							compilationEnvironment,
 							new File(contikiField.getText()).getParentFile(),
 							null,
@@ -802,7 +802,7 @@ public abstract class AbstractCompileDialog extends JDialog {
    */
   public String getDefaultCompileCommands(File source) {
     return Cooja.getExternalToolsSetting("PATH_MAKE") + " -j$(CPUS) " +
-           moteType.getExpectedFirmwareFile(source).getName() + " TARGET=" + getTargetName();
+           moteType.getExpectedFirmwareFile(source).getName() + " TARGET=" + moteType.getMoteType();
   }
 
   private void abortAnyCompilation() {
@@ -823,6 +823,4 @@ public abstract class AbstractCompileDialog extends JDialog {
     tabbedPane.setSelectedComponent(scrollOutput);
     currentCompilationOutput = scrollOutput;
   }
-
-  protected abstract String getTargetName();
 }

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -260,10 +260,4 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
   @Override
   public void writeSettingsToMoteType() {
   }
-
-  @Override
-  protected String getTargetName() {
-  	return "cooja";
-  }
-
 }

--- a/java/org/contikios/cooja/mspmote/MspCompileDialog.java
+++ b/java/org/contikios/cooja/mspmote/MspCompileDialog.java
@@ -42,25 +42,21 @@ import org.contikios.cooja.Simulation;
 import org.contikios.cooja.dialogs.AbstractCompileDialog;
 
 public class MspCompileDialog extends AbstractCompileDialog {
-  private final String target;
-
   public static boolean showDialog(
       Container parent,
       Simulation simulation,
-      MspMoteType moteType,
-      String target) {
+      MspMoteType moteType) {
 
-    final AbstractCompileDialog dialog = new MspCompileDialog(parent, simulation, moteType, target);
+    final AbstractCompileDialog dialog = new MspCompileDialog(parent, simulation, moteType);
 
     /* Show dialog and wait for user */
     dialog.setVisible(true); /* BLOCKS */
     return dialog.createdOK();
   }
 
-  private MspCompileDialog(Container parent, Simulation simulation, MspMoteType moteType, String target) {
+  private MspCompileDialog(Container parent, Simulation simulation, MspMoteType moteType) {
     super(parent, simulation, moteType);
-    this.target = target;
-    setTitle("Create Mote Type: Compile Contiki for " + target);
+    setTitle("Create Mote Type: Compile Contiki for " + moteType.getMoteType());
     addCompilationTipsTab(tabbedPane);
   }
 
@@ -86,7 +82,7 @@ public class MspCompileDialog extends AbstractCompileDialog {
 
   @Override
   public boolean canLoadFirmware(File file) {
-    if (file.getName().endsWith("." + target)) {
+    if (file.getName().endsWith("." + moteType.getMoteType())) {
       return true;
     }
     return file.getName().equals("main.exe");
@@ -96,11 +92,4 @@ public class MspCompileDialog extends AbstractCompileDialog {
   public void writeSettingsToMoteType() {
     /* Nothing to do */
   }
-
-  @Override
-  protected String getTargetName() {
-  	/* Override me */
-  	return target;
-  }
-
 }

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -112,7 +112,7 @@ public abstract class MspMoteType extends BaseContikiMoteType {
       if (getDescription() == null) {
         setDescription(getMoteName() + " Mote Type #" + getIdentifier());
       }
-      return MspCompileDialog.showDialog(parentContainer, simulation, this, getMoteType());
+      return MspCompileDialog.showDialog(parentContainer, simulation, this);
     }
 
     if (getIdentifier() == null) {


### PR DESCRIPTION
The initialization of target is getMoteType(),
so use that inside AbstractCompileDialog instead.