### PR TITLE
LogScriptEngine: compile script before running

### DIFF
--- a/java/org/contikios/cooja/plugins/ScriptParser.java
+++ b/java/org/contikios/cooja/plugins/ScriptParser.java
@@ -248,7 +248,8 @@ public class ScriptParser {
     "\n" +
     "function write(mote,msg) { " +
     " mote.getInterfaces().getLog().writeString(msg); " +
-    "};\n";
+    "};\n" +
+    "run();\n";
   }
 
   public long getTimeoutTime() {


### PR DESCRIPTION
The NashornScriptEngine has a compile method
that is described as "allowing for efficient
precompilation and execution of scripts".
Use that method, which as an additional benefit
makes the entry point to the script explicit.