### PR TITLE
Remove one exit thread

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2641,12 +2641,16 @@ public class Cooja extends Observable {
           return;
         }
       }
-      doRemoveSimulation(false);
     }
 
-    // Clean up resources
-    for (var plugin : startedPlugins.toArray(new Plugin[0])) {
-      removePlugin(plugin, false);
+    // Clean up resources. Catch all exceptions to ensure that System.exit will be called.
+    try {
+      doRemoveSimulation(false);
+      for (var plugin : startedPlugins.toArray(new Plugin[0])) {
+        removePlugin(plugin, false);
+      }
+    } catch (Exception e) {
+      logger.error("Failed to remove simulation/plugins on shutdown.", e);
     }
 
     /* Store frame size and position */

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -153,11 +153,6 @@ public class LogScriptEngine {
     // Check if testOK()/testFailed() were called from the script in headless mode.
     if (quitCooja) {
       new Thread(() -> simulation.getCooja().doQuit(false, exitCode), "Cooja.doQuit").start();
-      new Thread(() -> {
-        try { Thread.sleep(2000); } catch (InterruptedException e) {}
-        logger.warn("Killing Cooja");
-        System.exit(exitCode);
-      }, "System.exit").start();
     }
     quitCooja = false;
   }


### PR DESCRIPTION
Make doQuit more robust against thrown exceptions and remove the spare exit thread in LogScriptEngine.