### PR TITLE
LogScriptEngine: remove Runnable + time simplifications

### DIFF
--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -310,20 +310,6 @@ public class LogScriptEngine {
     engine.put("msg", "");
     engine.put("node", new ScriptMote());
 
-    Runnable activate = new Runnable() {
-      @Override
-      public void run() {
-        startRealTime = System.currentTimeMillis();
-        startTime = simulation.getSimulationTime();
-        long endTime = startTime + timeout;
-        nextProgress = startTime + (endTime - startTime)/20;
-
-        timeoutProgressEvent.remove();
-        simulation.scheduleEvent(timeoutProgressEvent, nextProgress);
-        timeoutEvent.remove();
-        simulation.scheduleEvent(timeoutEvent, endTime);
-      }
-    };
     // Script context initialized (engine.put calls), start thread that runs script to the first semaphore.
     scriptThread.start();
     // Wait for script thread to reach barrier in the beginning of the JavaScript run function.
@@ -334,11 +320,15 @@ public class LogScriptEngine {
         // FIXME: Something called interrupt() on this thread, stop the computation.
       }
     }
-    if (simulation.isRunning()) {
-      simulation.invokeSimulationThread(activate);
-    } else {
-      activate.run();
-    }
+    startRealTime = System.currentTimeMillis();
+    startTime = simulation.getSimulationTime();
+    long endTime = startTime + timeout;
+    nextProgress = startTime + (endTime - startTime)/20;
+
+    timeoutProgressEvent.remove();
+    simulation.scheduleEvent(timeoutProgressEvent, nextProgress);
+    timeoutEvent.remove();
+    simulation.scheduleEvent(timeoutEvent, endTime);
     return true;
   }
 

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -322,13 +322,12 @@ public class LogScriptEngine {
     }
     startRealTime = System.currentTimeMillis();
     startTime = simulation.getSimulationTime();
-    long endTime = startTime + timeout;
-    nextProgress = startTime + (endTime - startTime)/20;
+    nextProgress = startTime + timeout / 20;
 
     timeoutProgressEvent.remove();
     simulation.scheduleEvent(timeoutProgressEvent, nextProgress);
     timeoutEvent.remove();
-    simulation.scheduleEvent(timeoutEvent, endTime);
+    simulation.scheduleEvent(timeoutEvent, startTime + timeout);
     return true;
   }
 

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -122,7 +122,6 @@ public class LogScriptEngine {
   private long timeout;
   private long startTime;
   private long startRealTime;
-  private long nextProgress;
 
   private int exitCode = 0;
   
@@ -322,10 +321,9 @@ public class LogScriptEngine {
     }
     startRealTime = System.currentTimeMillis();
     startTime = simulation.getSimulationTime();
-    nextProgress = startTime + timeout / 20;
 
     timeoutProgressEvent.remove();
-    simulation.scheduleEvent(timeoutProgressEvent, nextProgress);
+    simulation.scheduleEvent(timeoutProgressEvent, startTime + timeout / 20);
     timeoutEvent.remove();
     simulation.scheduleEvent(timeoutEvent, startTime + timeout);
     return true;
@@ -346,8 +344,7 @@ public class LogScriptEngine {
   private final TimeEvent timeoutProgressEvent = new TimeEvent() {
     @Override
     public void execute(long t) {
-      nextProgress = t + timeout/20;
-      simulation.scheduleEvent(this, nextProgress);
+      simulation.scheduleEvent(this, t + timeout / 20);
 
       double progress = 1.0*(t - startTime)/timeout;
       long realDuration = System.currentTimeMillis()-startRealTime;


### PR DESCRIPTION
The method is never called when the simulation is running so remove the Runnable and make some simplifications to the time computations.