### PR TITLE
MspMote: remove log noise about firmware

### DIFF
--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -236,7 +236,6 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
 
     this.myCpu.getLogger().addLogListener(ll);
 
-    logger.info("Loading firmware from: " + fileELF.getAbsolutePath());
     Cooja.setProgressMessage("Loading " + fileELF.getName());
     node.loadFirmware(((MspMoteType)getType()).getELF());
 


### PR DESCRIPTION
This just adds noise to the logs, the csc
file decides the name and the name of the csc
file is printed when the simulation starts