### PR TITLE
ScriptRunner: add a "New" menu item

### DIFF
--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -266,7 +266,6 @@ public class ScriptRunner implements Plugin {
     updateScript(script);
     if (Cooja.isVisualized()) {
       Cooja.setExternalToolsSetting("SCRIPTRUNNER_LAST_SCRIPTFILE", source.getAbsolutePath());
-      updateTitle();
     }
     return true;
   }
@@ -384,6 +383,7 @@ public class ScriptRunner implements Plugin {
       codeEditor.setText(script);
       codeEditorChanged = false;
       logTextArea.setText("");
+      updateTitle();
     } else {
       headlessScript = script;
     }

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -160,6 +160,7 @@ public class ScriptRunner implements Plugin {
       if (f == null) {
         return;
       }
+      checkForUpdatesAndSave();
       setLinkFile(f);
     });
     fileMenu.add(open);
@@ -172,6 +173,7 @@ public class ScriptRunner implements Plugin {
       final String file = EXAMPLE_SCRIPTS[i];
       JMenuItem exampleItem = new JMenuItem(EXAMPLE_SCRIPTS[i+1]);
       exampleItem.addActionListener(e -> {
+        checkForUpdatesAndSave();
         linkedFile = null;
         updateScript(loadScript(file));
       });

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -154,6 +154,13 @@ public class ScriptRunner implements Plugin {
       logTextArea.setCaretPosition(logTextArea.getText().length());
     });
 
+    var newScript = new JMenuItem("New");
+    newScript.addActionListener(l -> {
+      checkForUpdatesAndSave();
+      linkedFile = null;
+      updateScript("");
+    });
+    fileMenu.add(newScript);
     var open = new JMenuItem("Open...");
     open.addActionListener(l -> {
       var f = showFileChooser(true);


### PR DESCRIPTION
This makes it possible to switch from a file-backed script to the other kind of script without selecting one of the example scripts and then clear the code editor by hand.