### PR TITLE
LogScriptEngine: simplify logic

### DIFF
--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -197,20 +197,6 @@ public class LogScriptEngine {
     }
     scriptActive = true;
 
-    if (semaphoreScript != null) {
-      logger.fatal("semaphoreScript was not reset correctly");
-      semaphoreScript.release(100);
-      semaphoreScript = null;
-      throw new RuntimeException("semaphoreScript was not reset correctly");
-    }
-    if (semaphoreSim != null) {
-      logger.fatal("semaphoreSim was not reset correctly");
-      semaphoreSim.release(100);
-      semaphoreSim = null;
-      throw new RuntimeException("semaphoreSim was not reset correctly");
-    }
-    scriptThread = null;
-
     /* Parse current script */
     ScriptParser parser = new ScriptParser(scriptCode);
     String jsCode = parser.getJSCode();

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -306,10 +306,7 @@ public class LogScriptEngine {
     }
     startRealTime = System.currentTimeMillis();
     startTime = simulation.getSimulationTime();
-
-    timeoutProgressEvent.remove();
     simulation.scheduleEvent(timeoutProgressEvent, startTime + Math.max(1000, timeout / 20));
-    timeoutEvent.remove();
     simulation.scheduleEvent(timeoutEvent, startTime + timeout);
     return true;
   }

--- a/java/org/contikios/cooja/plugins/LogScriptEngine.java
+++ b/java/org/contikios/cooja/plugins/LogScriptEngine.java
@@ -113,8 +113,6 @@ public class LogScriptEngine {
 
   private final Simulation simulation;
 
-  private boolean scriptActive = false;
-
   private long timeout;
   private long startTime;
   private long startRealTime;
@@ -150,11 +148,6 @@ public class LogScriptEngine {
    * Deactivate script
    */
   public void deactivateScript() {
-    if (!scriptActive) {
-      return;
-    }
-    scriptActive = false;
-
     timeoutEvent.remove();
     timeoutProgressEvent.remove();
 
@@ -192,15 +185,8 @@ public class LogScriptEngine {
   }
 
   public boolean activateScript(String scriptCode) throws ScriptException {
-    if (scriptActive) {
-      return false;
-    }
-    scriptActive = true;
-
-    /* Parse current script */
     ScriptParser parser = new ScriptParser(scriptCode);
     String jsCode = parser.getJSCode();
-
     timeout = parser.getTimeoutTime();
     if (timeout < 0) {
       timeout = DEFAULT_TIMEOUT;
@@ -223,7 +209,6 @@ public class LogScriptEngine {
       semaphoreScript.acquire();
     } catch (InterruptedException e) {
       logger.fatal("Error when creating engine: " + e.getMessage(), e);
-      scriptActive = false;
       return false;
     }
     ThreadGroup group = new ThreadGroup("script") {
@@ -300,9 +285,6 @@ public class LogScriptEngine {
   private final TimeEvent timeoutEvent = new TimeEvent() {
     @Override
     public void execute(long t) {
-      if (!scriptActive) {
-        return;
-      }
       logger.info("Timeout event @ " + t);
       engine.put("TIMEOUT", true);
       stepScript();


### PR DESCRIPTION
There is only one call into these methods in LogScriptEngine so remove the code that guards against mis-usage of the API and ensure the call from ScriptRunner adheres to the invariants.