### PR TITLE
Move LogScriptEngine to cooja package

### DIFF
--- a/java/org/contikios/cooja/LogScriptEngine.java
+++ b/java/org/contikios/cooja/LogScriptEngine.java
@@ -28,7 +28,7 @@
  *
  */
 
-package org.contikios.cooja.plugins;
+package org.contikios.cooja;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.APPEND;
@@ -47,12 +47,12 @@ import javax.script.ScriptException;
 import javax.swing.JTextArea;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.contikios.cooja.Cooja;
-import org.contikios.cooja.Mote;
 import org.contikios.cooja.SimEventCentral.LogOutputEvent;
 import org.contikios.cooja.SimEventCentral.LogOutputListener;
-import org.contikios.cooja.Simulation;
-import org.contikios.cooja.TimeEvent;
+import org.contikios.cooja.plugins.ScriptRunner;
+import org.contikios.cooja.script.ScriptLog;
+import org.contikios.cooja.script.ScriptMote;
+import org.contikios.cooja.script.ScriptParser;
 import org.openjdk.nashorn.api.scripting.NashornScriptEngine;
 import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
 

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -36,6 +36,7 @@ import java.util.Random;
 
 import javax.swing.JOptionPane;
 
+import javax.swing.JTextArea;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.contikimote.ContikiMoteType;
@@ -43,6 +44,7 @@ import org.contikios.cooja.motes.DisturberMoteType;
 import org.contikios.cooja.motes.ImportAppMoteType;
 import org.contikios.cooja.mspmote.SkyMoteType;
 import org.contikios.cooja.mspmote.Z1MoteType;
+import org.contikios.cooja.plugins.LogScriptEngine;
 import org.jdom.Element;
 
 import org.contikios.cooja.dialogs.CreateSimDialog;
@@ -101,6 +103,9 @@ public class Simulation extends Observable implements Runnable {
 
   /* Event queue */
   private final EventQueue eventQueue = new EventQueue();
+
+  /** List of active script engines. */
+  private final ArrayList<LogScriptEngine> scriptEngines = new ArrayList<>();
 
   /* Poll requests */
   private boolean hasPollRequests = false;
@@ -272,6 +277,20 @@ public class Simulation extends Observable implements Runnable {
   public Simulation(Cooja cooja) {
     this.cooja = cooja;
     randomGenerator = new SafeRandom(this);
+  }
+
+  /** Create a new script engine that logs to the logTextArea and add it to the list
+   *  of active script engines. */
+  public LogScriptEngine newScriptEngine(JTextArea logTextArea) {
+    var engine = new LogScriptEngine(this, logTextArea);
+    scriptEngines.add(engine);
+    return engine;
+  }
+
+  /** Remove a script engine from the list of active script engines. */
+  public void removeScriptEngine(LogScriptEngine engine) {
+    engine.closeLog();
+    scriptEngines.remove(engine);
   }
 
   /**

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -44,7 +44,6 @@ import org.contikios.cooja.motes.DisturberMoteType;
 import org.contikios.cooja.motes.ImportAppMoteType;
 import org.contikios.cooja.mspmote.SkyMoteType;
 import org.contikios.cooja.mspmote.Z1MoteType;
-import org.contikios.cooja.plugins.LogScriptEngine;
 import org.jdom.Element;
 
 import org.contikios.cooja.dialogs.CreateSimDialog;

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -107,7 +107,7 @@ public class ScriptRunner implements Plugin {
       frame = null;
       codeEditor = null;
       logTextArea = null;
-      engine = new LogScriptEngine(simulation, null);
+      engine = simulation.newScriptEngine(null);
       return;
     }
 
@@ -132,7 +132,7 @@ public class ScriptRunner implements Plugin {
     logTextArea.setMargin(new Insets(5,5,5,5));
     logTextArea.setEditable(false);
     logTextArea.setCursor(null);
-    engine = new LogScriptEngine(simulation, logTextArea);
+    engine = simulation.newScriptEngine(logTextArea);
 
     var newScript = new JMenuItem("New");
     newScript.addActionListener(l -> {
@@ -382,7 +382,7 @@ public class ScriptRunner implements Plugin {
   public void closePlugin() {
     checkForUpdatesAndSave();
     deactivateScript();
-    engine.closeLog();
+    simulation.removeScriptEngine(engine);
   }
 
   @Override

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -63,6 +63,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
+import org.contikios.cooja.LogScriptEngine;
 import org.contikios.cooja.Plugin;
 import org.contikios.cooja.PluginType;
 import org.contikios.cooja.Simulation;

--- a/java/org/contikios/cooja/script/ScriptLog.java
+++ b/java/org/contikios/cooja/script/ScriptLog.java
@@ -28,7 +28,7 @@
  *
  */
 
-package org.contikios.cooja.plugins;
+package org.contikios.cooja.script;
 
 
 /* Morty: This interface must be public, otherwise openjdk will fail */

--- a/java/org/contikios/cooja/script/ScriptMote.java
+++ b/java/org/contikios/cooja/script/ScriptMote.java
@@ -28,7 +28,7 @@
  *
  */
 
-package org.contikios.cooja.plugins;
+package org.contikios.cooja.script;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.interfaces.Log;
 import org.contikios.cooja.interfaces.SerialPort;

--- a/java/org/contikios/cooja/script/ScriptParser.java
+++ b/java/org/contikios/cooja/script/ScriptParser.java
@@ -28,7 +28,7 @@
  *
  */
 
-package org.contikios.cooja.plugins;
+package org.contikios.cooja.script;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;


### PR DESCRIPTION
This moves the LogScriptEngine to the cooja
package and its interfaces to cooja.script.

This will enable the simulation and script
engine to communicate directly without
switching threads and without requiring
synchronization.