### PR TITLE
LogScriptEngine: shutdown without exceptions

### DIFF
--- a/java/org/contikios/cooja/script/ScriptLog.java
+++ b/java/org/contikios/cooja/script/ScriptLog.java
@@ -35,8 +35,6 @@ package org.contikios.cooja.script;
 
 public interface ScriptLog {
     void log(String log);
-    void testOK();
-    void testFailed();
     void generateMessage(long delay, String msg);
     void append(String filename, String msg);
     void writeFile(String filename, String msg);

--- a/java/org/contikios/cooja/script/ScriptParser.java
+++ b/java/org/contikios/cooja/script/ScriptParser.java
@@ -61,6 +61,8 @@ public class ScriptParser {
 
     code = replaceWaitUntils(code);
 
+    code = replaceTestStatus(code);
+
     this.code = code;
   }
 
@@ -141,7 +143,7 @@ public class ScriptParser {
     }
 
     timeoutTime = Long.parseLong(matcher.group(1))*Simulation.MILLISECOND;
-    timeoutCode = matcher.group(2);
+    timeoutCode = replaceTestStatus(matcher.group(2));
 
     matcher.reset(code);
     code = matcher.replaceFirst(";");
@@ -196,17 +198,52 @@ public class ScriptParser {
     return code;
   }
 
+  private static String replaceTestStatus(String code) {
+    code = Pattern.compile("log\\.testOK\\(\\)").matcher(code).replaceAll("throw new TestOK()");
+    return Pattern.compile("log\\.testFailed\\(\\)").matcher(code).replaceAll("throw new TestFailed()");
+  }
+
   public String getJSCode() {
     return getJSCode(code, timeoutCode);
   }
     
   public static String getJSCode(String code, String timeoutCode) {
+    // Nashorn can be created with --language=es6, but "class TestFailed extends Error .." is not supported.
     return
+    """
+    function TestFailed(msg, name, line) {
+       var err = new Error(msg, name, line);
+       Object.setPrototypeOf(err, Object.getPrototypeOf(this));
+       return err;
+     }
+     TestFailed.prototype = Object.create(Error.prototype, {
+       constructor: { value: Error, enumerable: false, writable: true, configurable: true }
+     });
+     Object.setPrototypeOf(TestFailed, Error);
+     function TestOK(msg, name, line) {
+       var err = new Error(msg, name, line);
+       Object.setPrototypeOf(err, Object.getPrototypeOf(this));
+       return err;
+     }
+     TestOK.prototype = Object.create(Error.prototype, {
+       constructor: { value: Error, enumerable: false, writable: true, configurable: true }
+     });
+     Object.setPrototypeOf(TestOK, Error);
+     function Shutdown(msg, name, line) {
+       var err = new Error(msg, name, line);
+       Object.setPrototypeOf(err, Object.getPrototypeOf(this));
+       return err;
+     }
+     Shutdown.prototype = Object.create(Error.prototype, {
+       constructor: { value: Error, enumerable: false, writable: true, configurable: true }
+     });
+     Object.setPrototypeOf(Shutdown, Error);
+    """ +
     "timeout_function = null; " +
     "function run() { try {" +
     "SEMAPHORE_SIM.acquire(); " +
     "SEMAPHORE_SCRIPT.acquire(); " + /* STARTUP BLOCKS HERE! */
-    "if (SHUTDOWN) { SCRIPT_KILL(); } " +
+    "if (SHUTDOWN) { throw new Shutdown(); } " +
     "if (TIMEOUT) { SCRIPT_TIMEOUT(); } " +
     "msg = new java.lang.String(msg); " +
     "node.setMoteMsg(mote, msg); " +
@@ -214,34 +251,28 @@ public class ScriptParser {
     "\n" +
     "\n" +
     "while (true) { SCRIPT_SWITCH(); } " /* SCRIPT ENDED */+
-    "} catch (error) { throw(error); }" +
+    "} catch (error) { " +
+    "if (error instanceof TestOK) return 0; " +
+    "if (error instanceof TestFailed) return 1; " +
+    "if (error instanceof Shutdown) return -1; " +
+    "throw(error); }" +
     "};" +
     "\n" +
     "function GENERATE_MSG(time, msg) { " +
     " log.generateMessage(time, msg); " +
     "};\n" +
     "\n" +
-    "function SCRIPT_KILL() { " +
-    " SEMAPHORE_SIM.release(100); " +
-    " throw('test script killed'); " +
-    "};\n" +
-    "\n" +
     "function SCRIPT_TIMEOUT() { " +
     timeoutCode + "; " +
     " if (timeout_function != null) { timeout_function(); } " +
     " log.log('TEST TIMEOUT\\n'); " +
-    " log.testFailed(); " +
-    " while (!SHUTDOWN) { " +
-    "  SEMAPHORE_SIM.release(); " +
-    "  SEMAPHORE_SCRIPT.acquire(); " /* SWITCH BLOCKS HERE! */ +
-    " } " +
-    " SCRIPT_KILL(); " +
+    " throw new TestFailed(); " +
     "};\n" +
     "\n" +
     "function SCRIPT_SWITCH() { " +
     " SEMAPHORE_SIM.release(); " +
     " SEMAPHORE_SCRIPT.acquire(); " /* SWITCH BLOCKS HERE! */ +
-    " if (SHUTDOWN) { SCRIPT_KILL(); } " +
+    " if (SHUTDOWN) { throw new Shutdown(); } " +
     " if (TIMEOUT) { SCRIPT_TIMEOUT(); } " +
     " msg = new java.lang.String(msg); " +
     " node.setMoteMsg(mote, msg); " +

--- a/java/org/contikios/cooja/script/ScriptParser.java
+++ b/java/org/contikios/cooja/script/ScriptParser.java
@@ -203,7 +203,7 @@ public class ScriptParser {
   public static String getJSCode(String code, String timeoutCode) {
     return
     "timeout_function = null; " +
-    "function run() { " +
+    "function run() { try {" +
     "SEMAPHORE_SIM.acquire(); " +
     "SEMAPHORE_SCRIPT.acquire(); " + /* STARTUP BLOCKS HERE! */
     "if (SHUTDOWN) { SCRIPT_KILL(); } " +
@@ -214,6 +214,7 @@ public class ScriptParser {
     "\n" +
     "\n" +
     "while (true) { SCRIPT_SWITCH(); } " /* SCRIPT ENDED */+
+    "} catch (error) { throw(error); }" +
     "};" +
     "\n" +
     "function GENERATE_MSG(time, msg) { " +


### PR DESCRIPTION
Change the return mechanism of scripts from
throwing exceptions even on successful exits
into being a regular return value that is
inspected upon return.

The implementation still uses exceptions inside
the script, but there is an outer catch that
converts the exception into a return value.

This also eliminates the need for spawning
a thread to exit Cooja in headless mode,
the script thread can just call doQuit after
it is done.
