### PR TITLE
GenericNode: remove unused field

### DIFF
--- a/java/se/sics/mspsim/platform/GenericNode.java
+++ b/java/se/sics/mspsim/platform/GenericNode.java
@@ -80,7 +80,6 @@ public abstract class GenericNode extends Chip implements Runnable {
   protected ConfigManager config;
 
   protected String firmwareFile = null;
-  protected ELF elf;
   protected OperatingModeStatistics stats;
 
 
@@ -319,7 +318,6 @@ public abstract class GenericNode extends Chip implements Runnable {
     if (cpu.isRunning()) {
         stop();
     }
-    this.elf = elf;
     elf.loadPrograms(cpu.memory);
     MapTable map = elf.getMap();
     cpu.getDisAsm().setMap(map);

--- a/java/se/sics/mspsim/platform/sky/CC2420Node.java
+++ b/java/se/sics/mspsim/platform/sky/CC2420Node.java
@@ -60,10 +60,6 @@ public abstract class CC2420Node extends GenericNode implements PortListener, US
         return cpu.getDebug();
     }
 
-    public ELF getElfInfo() {
-        return elf;
-    }
-
     public void setNodeID(int id) {
         ds2411.setMACID(id & 0xff, id & 0xff, id & 0xff, (id >> 8) & 0xff, id & 0xff, id & 0xff);
     }


### PR DESCRIPTION
Remove an unused method in CC2420Node, and then remove the unused field from the base class.