### PR TITLE
AbstractCompileDialog: remove no-op

### DIFF
--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -286,7 +286,6 @@ public abstract class AbstractCompileDialog extends JDialog {
         }
         setDialogState(DialogState.IS_COMPILING);
         final MessageListUI taskOutput = new MessageListUI();
-        abortAnyCompilation(); // FIXME: button is disabled by DialogState.IS_COMPILING.
         tabbedPane.remove(currentCompilationOutput);
         currentCompilationOutput = new JScrollPane(taskOutput);
         tabbedPane.addTab("Compilation output", null, currentCompilationOutput, "Shows Contiki compilation output");


### PR DESCRIPTION
The process can only be started by pressing
the button, and the button is disabled after
it has been pressed, so this call is not
required.