### PR TITLE
AbstractCompileDialog: simplify/fix state update code

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -441,13 +441,12 @@ public class ContikiMoteType extends BaseContikiMoteType {
   /**
    * Returns make target based on source file.
    *
-   * @param source The source file
+   * @param name The source file
    * @return Make target based on source file
    */
-  public static File getMakeTargetName(File source) {
-    File parentDir = source.getParentFile();
-    String sourceNoExtension = source.getName().substring(0, source.getName().length() - 2);
-    return new File(parentDir, sourceNoExtension + librarySuffix);
+  public static File getMakeTargetName(String name) {
+    String sourceNoExtension = name.substring(0, name.length() - 2);
+    return new File(new File(name).getParentFile(), sourceNoExtension + librarySuffix);
   }
 
   @Override

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -451,8 +451,8 @@ public class ContikiMoteType extends BaseContikiMoteType {
   }
 
   @Override
-  public File getExpectedFirmwareFile(File source) {
-    return new File(source.getParentFile(), "build/cooja/" + identifier + ContikiMoteType.librarySuffix);
+  public File getExpectedFirmwareFile(String name) {
+    return new File(new File(name).getParentFile(), "build/cooja/" + identifier + ContikiMoteType.librarySuffix);
   }
 
   /**

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -541,6 +541,7 @@ public abstract class AbstractCompileDialog extends JDialog {
       break;
 
     case SELECTED_SOURCE:
+    case AWAITING_COMPILATION:
       if (!input.endsWith(".c")) {
         setDialogState(DialogState.NO_SELECTION);
         return;
@@ -555,27 +556,11 @@ public abstract class AbstractCompileDialog extends JDialog {
     	compileButton.setEnabled(true);
     	createButton.setEnabled(false);
     	commandsArea.setEnabled(true);
-      setCompileCommands(getDefaultCompileCommands(input));
-      contikiFirmware = moteType.getExpectedFirmwareFile(input);
-      contikiSource = new File(input);
-      setDialogState(DialogState.AWAITING_COMPILATION);
-      break;
-
-    case AWAITING_COMPILATION:
-      if (!input.endsWith(".c")) {
-        setDialogState(DialogState.NO_SELECTION);
-        return;
+      if (dialogState == DialogState.SELECTED_SOURCE) {
+        setCompileCommands(getDefaultCompileCommands(input));
+        contikiFirmware = moteType.getExpectedFirmwareFile(input);
+        contikiSource = new File(input);
       }
-      if (!Files.exists(inputPath)) {
-        logger.warn("Could not find Contiki source: " + new File(input).getAbsolutePath());
-        setDialogState(DialogState.NO_SELECTION);
-        return;
-      }
-
-      cleanButton.setEnabled(true);
-      compileButton.setEnabled(true);
-      createButton.setEnabled(false);
-      commandsArea.setEnabled(true);
       break;
 
     case IS_COMPILING:

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -167,15 +167,15 @@ public abstract class AbstractCompileDialog extends JDialog {
     DocumentListener contikiFieldListener = new DocumentListener() {
       @Override
       public void changedUpdate(DocumentEvent e) {
-        setContikiSelection(new File(contikiField.getText()));
+        setContikiSelection(contikiField.getText());
       }
       @Override
       public void insertUpdate(DocumentEvent e) {
-        setContikiSelection(new File(contikiField.getText()));
+        setContikiSelection(contikiField.getText());
       }
       @Override
       public void removeUpdate(DocumentEvent e) {
-        setContikiSelection(new File(contikiField.getText()));
+        setContikiSelection(contikiField.getText());
       }
     };
     sourcePanel.add(contikiField);
@@ -512,21 +512,21 @@ public abstract class AbstractCompileDialog extends JDialog {
 
   protected String[] compilationEnvironment = null; /* Default environment: inherit from current process */
 
-  private void setContikiSelection(File file) {
-    if (!file.exists()) {
+  private void setContikiSelection(String name) {
+    if (!Files.exists(Path.of(name))) {
       setDialogState(DialogState.NO_SELECTION);
       return;
     }
 
-    lastFile = file;
+    lastFile = new File(name);
     Cooja.setExternalToolsSetting("COMPILE_LAST_FILE", gui.createPortablePath(lastFile).getPath());
 
-    if (file.getName().endsWith(".c")) {
+    if (name.endsWith(".c")) {
       setDialogState(DialogState.SELECTED_SOURCE);
       return;
     }
 
-    if (canLoadFirmware(file.getName())) {
+    if (canLoadFirmware(name)) {
       setDialogState(DialogState.SELECTED_FIRMWARE);
       return;
     }

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -232,17 +232,13 @@ public abstract class AbstractCompileDialog extends JDialog {
         fc.setFileFilter(new FileFilter() {
           @Override
           public boolean accept(File f) {
-            if (f.isDirectory()) {
+            String filename = f.getName();
+            if (f.isDirectory() || filename.endsWith(".c")) {
               return true;
             }
 
-            String filename = f.getName();
             if (filename.isEmpty()) {
               return false;
-            }
-
-            if (filename.endsWith(".c")) {
-              return true;
             }
 
             return canLoadFirmware(filename);

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -235,7 +235,7 @@ public abstract class AbstractCompileDialog extends JDialog {
               return true;
             }
 
-            return canLoadFirmware(f);
+            return canLoadFirmware(filename);
           }
 
           @Override
@@ -508,7 +508,7 @@ public abstract class AbstractCompileDialog extends JDialog {
    */
   public abstract void writeSettingsToMoteType();
 
-  public abstract boolean canLoadFirmware(File file);
+  public abstract boolean canLoadFirmware(String name);
 
   protected String[] compilationEnvironment = null; /* Default environment: inherit from current process */
 
@@ -526,7 +526,7 @@ public abstract class AbstractCompileDialog extends JDialog {
       return;
     }
 
-    if (canLoadFirmware(file)) {
+    if (canLoadFirmware(file.getName())) {
       setDialogState(DialogState.SELECTED_FIRMWARE);
       return;
     }
@@ -614,7 +614,7 @@ public abstract class AbstractCompileDialog extends JDialog {
         setDialogState(DialogState.NO_SELECTION);
         return;
       }
-      if (!canLoadFirmware(contikiFirmware)) {
+      if (!canLoadFirmware(input)) {
         setDialogState(DialogState.NO_SELECTION);
         return;
       }

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -557,7 +557,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     	createButton.setEnabled(false);
     	commandsArea.setEnabled(true);
       setCompileCommands(getDefaultCompileCommands(sourceFile));
-      contikiFirmware = moteType.getExpectedFirmwareFile(sourceFile);
+      contikiFirmware = moteType.getExpectedFirmwareFile(input);
       contikiSource = sourceFile;
       setDialogState(DialogState.AWAITING_COMPILATION);
       break;
@@ -752,7 +752,7 @@ public abstract class AbstractCompileDialog extends JDialog {
    */
   public String getDefaultCompileCommands(File source) {
     return Cooja.getExternalToolsSetting("PATH_MAKE") + " -j$(CPUS) " +
-           moteType.getExpectedFirmwareFile(source).getName() + " TARGET=" + moteType.getMoteType();
+           moteType.getExpectedFirmwareFile(source.getName()).getName() + " TARGET=" + moteType.getMoteType();
   }
 
   private void abortAnyCompilation() {

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -529,7 +529,6 @@ public abstract class AbstractCompileDialog extends JDialog {
   protected void setDialogState(DialogState dialogState) {
     final var input = contikiField.getText();
     final Path inputPath = Path.of(input);
-    File sourceFile = new File(input);
     compileButton.setText("Compile");
     getRootPane().setDefaultButton(compileButton);
 
@@ -547,7 +546,7 @@ public abstract class AbstractCompileDialog extends JDialog {
         return;
       }
       if (!Files.exists(inputPath)) {
-        logger.warn("Could not find Contiki source: " + sourceFile.getAbsolutePath());
+        logger.warn("Could not find Contiki source: " + new File(input).getAbsolutePath());
         setDialogState(DialogState.NO_SELECTION);
         return;
       }
@@ -558,7 +557,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     	commandsArea.setEnabled(true);
       setCompileCommands(getDefaultCompileCommands(input));
       contikiFirmware = moteType.getExpectedFirmwareFile(input);
-      contikiSource = sourceFile;
+      contikiSource = new File(input);
       setDialogState(DialogState.AWAITING_COMPILATION);
       break;
 
@@ -568,7 +567,7 @@ public abstract class AbstractCompileDialog extends JDialog {
         return;
       }
       if (!Files.exists(inputPath)) {
-        logger.warn("Could not find Contiki source: " + sourceFile.getAbsolutePath());
+        logger.warn("Could not find Contiki source: " + new File(input).getAbsolutePath());
         setDialogState(DialogState.NO_SELECTION);
         return;
       }

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -167,15 +167,25 @@ public abstract class AbstractCompileDialog extends JDialog {
     DocumentListener contikiFieldListener = new DocumentListener() {
       @Override
       public void changedUpdate(DocumentEvent e) {
-        setContikiSelection(contikiField.getText());
+        fileSelected(contikiField.getText());
       }
       @Override
       public void insertUpdate(DocumentEvent e) {
-        setContikiSelection(contikiField.getText());
+        fileSelected(contikiField.getText());
       }
       @Override
       public void removeUpdate(DocumentEvent e) {
-        setContikiSelection(contikiField.getText());
+        fileSelected(contikiField.getText());
+      }
+      private void fileSelected(String name) {
+        if (!Files.exists(Path.of(name))) {
+          setDialogState(DialogState.NO_SELECTION);
+          return;
+        }
+        lastFile = new File(name);
+        Cooja.setExternalToolsSetting("COMPILE_LAST_FILE", gui.createPortablePath(lastFile).getPath());
+        setDialogState(name.endsWith(".c") || !canLoadFirmware(name)
+                ? DialogState.SELECTED_SOURCE : DialogState.SELECTED_FIRMWARE);
       }
     };
     sourcePanel.add(contikiField);
@@ -511,19 +521,6 @@ public abstract class AbstractCompileDialog extends JDialog {
   public abstract boolean canLoadFirmware(String name);
 
   protected String[] compilationEnvironment = null; /* Default environment: inherit from current process */
-
-  private void setContikiSelection(String name) {
-    if (!Files.exists(Path.of(name))) {
-      setDialogState(DialogState.NO_SELECTION);
-      return;
-    }
-
-    lastFile = new File(name);
-    Cooja.setExternalToolsSetting("COMPILE_LAST_FILE", gui.createPortablePath(lastFile).getPath());
-
-    setDialogState(name.endsWith(".c") || !canLoadFirmware(name)
-            ? DialogState.SELECTED_SOURCE : DialogState.SELECTED_FIRMWARE);
-  }
 
   /**
    * @see DialogState

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -556,7 +556,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     	compileButton.setEnabled(true);
     	createButton.setEnabled(false);
     	commandsArea.setEnabled(true);
-      setCompileCommands(getDefaultCompileCommands(sourceFile));
+      setCompileCommands(getDefaultCompileCommands(input));
       contikiFirmware = moteType.getExpectedFirmwareFile(input);
       contikiSource = sourceFile;
       setDialogState(DialogState.AWAITING_COMPILATION);
@@ -747,12 +747,12 @@ public abstract class AbstractCompileDialog extends JDialog {
   }
 
   /**
-   * @param source Contiki source
+   * @param name Contiki source
    * @return Suggested compile commands for compiling source
    */
-  public String getDefaultCompileCommands(File source) {
+  public String getDefaultCompileCommands(String name) {
     return Cooja.getExternalToolsSetting("PATH_MAKE") + " -j$(CPUS) " +
-           moteType.getExpectedFirmwareFile(source.getName()).getName() + " TARGET=" + moteType.getMoteType();
+           moteType.getExpectedFirmwareFile(name).getName() + " TARGET=" + moteType.getMoteType();
   }
 
   private void abortAnyCompilation() {

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -596,8 +596,6 @@ public abstract class AbstractCompileDialog extends JDialog {
       break;
 
     case SELECTED_FIRMWARE:
-      contikiSource = null;
-      contikiFirmware = new File(input);
       if (!Files.exists(inputPath)) {
         setDialogState(DialogState.NO_SELECTION);
         return;
@@ -606,7 +604,8 @@ public abstract class AbstractCompileDialog extends JDialog {
         setDialogState(DialogState.NO_SELECTION);
         return;
       }
-
+      contikiSource = null;
+      contikiFirmware = new File(input);
     	cleanButton.setEnabled(true);
     	compileButton.setEnabled(false);
     	createButton.setEnabled(true);

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -537,7 +537,8 @@ public abstract class AbstractCompileDialog extends JDialog {
    * @param dialogState New dialog state
    */
   protected void setDialogState(DialogState dialogState) {
-    File sourceFile = new File(contikiField.getText());
+    final var input = contikiField.getText();
+    File sourceFile = new File(input);
     compileButton.setText("Compile");
     getRootPane().setDefaultButton(compileButton);
 
@@ -605,7 +606,7 @@ public abstract class AbstractCompileDialog extends JDialog {
 
     case SELECTED_FIRMWARE:
       contikiSource = null;
-      contikiFirmware = new File(contikiField.getText());
+      contikiFirmware = new File(input);
       if (!contikiFirmware.exists()) {
         setDialogState(DialogState.NO_SELECTION);
         return;

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -521,17 +521,8 @@ public abstract class AbstractCompileDialog extends JDialog {
     lastFile = new File(name);
     Cooja.setExternalToolsSetting("COMPILE_LAST_FILE", gui.createPortablePath(lastFile).getPath());
 
-    if (name.endsWith(".c")) {
-      setDialogState(DialogState.SELECTED_SOURCE);
-      return;
-    }
-
-    if (canLoadFirmware(name)) {
-      setDialogState(DialogState.SELECTED_FIRMWARE);
-      return;
-    }
-
-    setDialogState(DialogState.SELECTED_SOURCE);
+    setDialogState(name.endsWith(".c") || !canLoadFirmware(name)
+            ? DialogState.SELECTED_SOURCE : DialogState.SELECTED_FIRMWARE);
   }
 
   /**

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -45,6 +45,8 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 
 import javax.swing.AbstractAction;
@@ -538,6 +540,7 @@ public abstract class AbstractCompileDialog extends JDialog {
    */
   protected void setDialogState(DialogState dialogState) {
     final var input = contikiField.getText();
+    final Path inputPath = Path.of(input);
     File sourceFile = new File(input);
     compileButton.setText("Compile");
     getRootPane().setDefaultButton(compileButton);
@@ -551,11 +554,11 @@ public abstract class AbstractCompileDialog extends JDialog {
       break;
 
     case SELECTED_SOURCE:
-      if (!sourceFile.getName().endsWith(".c")) {
+      if (!input.endsWith(".c")) {
         setDialogState(DialogState.NO_SELECTION);
         return;
       }
-      if (!sourceFile.exists()) {
+      if (!Files.exists(inputPath)) {
         logger.warn("Could not find Contiki source: " + sourceFile.getAbsolutePath());
         setDialogState(DialogState.NO_SELECTION);
         return;
@@ -572,11 +575,11 @@ public abstract class AbstractCompileDialog extends JDialog {
       break;
 
     case AWAITING_COMPILATION:
-      if (!sourceFile.getName().endsWith(".c")) {
+      if (!input.endsWith(".c")) {
         setDialogState(DialogState.NO_SELECTION);
         return;
       }
-      if (!sourceFile.exists()) {
+      if (!Files.exists(inputPath)) {
         logger.warn("Could not find Contiki source: " + sourceFile.getAbsolutePath());
         setDialogState(DialogState.NO_SELECTION);
         return;
@@ -607,7 +610,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     case SELECTED_FIRMWARE:
       contikiSource = null;
       contikiFirmware = new File(input);
-      if (!contikiFirmware.exists()) {
+      if (!Files.exists(inputPath)) {
         setDialogState(DialogState.NO_SELECTION);
         return;
       }

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -38,6 +38,8 @@ import java.awt.event.ActionListener;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashSet;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -84,7 +86,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
 
     if (contikiSource != null) {
       /* Make sure compilation variables are updated */
-      getDefaultCompileCommands(contikiSource);
+      getDefaultCompileCommands(contikiSource.getName());
     }
 
     /* Add Contiki mote type specifics */
@@ -97,8 +99,8 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
   }
 
   @Override
-  public String getDefaultCompileCommands(final File source) {
-    if (source == null || !source.exists()) {
+  public String getDefaultCompileCommands(String name) {
+    if (name == null || !Files.exists(Path.of(name))) {
       return ""; // Not ready to compile yet.
     }
 
@@ -110,7 +112,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
       moteType.setIdentifier(ContikiMoteType.generateUniqueMoteTypeID(usedNames));
     }
 
-    moteType.setContikiSourceFile(source);
+    moteType.setContikiSourceFile(new File(name));
     var env = moteType.getCompilationEnvironment();
     compilationEnvironment = BaseContikiMoteType.oneDimensionalEnv(env);
     if (SwingUtilities.isEventDispatchThread()) {
@@ -119,7 +121,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
       try {
         SwingUtilities.invokeAndWait(() -> createEnvironmentTab(tabbedPane, env));
       } catch (InvocationTargetException | InterruptedException e) {
-        logger.fatal("Error when updating for source " + source + ": " + e.getMessage(), e);
+        logger.fatal("Error when updating for source " + name + ": " + e.getMessage(), e);
       }
     }
 
@@ -129,7 +131,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
     }
 
     return Cooja.getExternalToolsSetting("PATH_MAKE") + " -j$(CPUS) " +
-            ContikiMoteType.getMakeTargetName(source.getName()).getName() + " TARGET=cooja" + defines;
+            ContikiMoteType.getMakeTargetName(name).getName() + " TARGET=cooja" + defines;
   }
 
   @Override
@@ -235,7 +237,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
         SwingUtilities.invokeLater(new Runnable() {
           @Override
           public void run() {
-            getDefaultCompileCommands(moteType.getContikiSourceFile());
+            getDefaultCompileCommands(moteType.getContikiSourceFile().getName());
             for (int i=0; i < tabbedPane.getTabCount(); i++) {
               if (tabbedPane.getTitleAt(i).equals("Environment")) {
                 tabbedPane.setSelectedIndex(i);

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -92,7 +92,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
   }
 
   @Override
-  public boolean canLoadFirmware(File file) {
+  public boolean canLoadFirmware(String name) {
     return false; // Always recompile, CoreComm needs fresh names.
   }
 

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -129,7 +129,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
     }
 
     return Cooja.getExternalToolsSetting("PATH_MAKE") + " -j$(CPUS) " +
-            ContikiMoteType.getMakeTargetName(source).getName() + " TARGET=cooja" + defines;
+            ContikiMoteType.getMakeTargetName(source.getName()).getName() + " TARGET=cooja" + defines;
   }
 
   @Override

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -145,13 +145,13 @@ public abstract class BaseContikiMoteType implements MoteType {
     fileFirmware = file;
   }
 
-  public File getExpectedFirmwareFile(File source) {
-    File parentDir = source.getParentFile();
-    String sourceNoExtension = source.getName();
+  public File getExpectedFirmwareFile(String name) {
+    String sourceNoExtension = name;
     if (sourceNoExtension.endsWith(".c")) {
-      sourceNoExtension = sourceNoExtension.substring(0, source.getName().length() - 2);
+      sourceNoExtension = sourceNoExtension.substring(0, name.length() - 2);
     }
-    return new File(parentDir, "/build/" + getMoteType() + "/" + sourceNoExtension + '.' + getMoteType());
+    return new File(new File(name).getParentFile(),
+            "/build/" + getMoteType() + "/" + sourceNoExtension + '.' + getMoteType());
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/MspCompileDialog.java
+++ b/java/org/contikios/cooja/mspmote/MspCompileDialog.java
@@ -31,7 +31,6 @@
 package org.contikios.cooja.mspmote;
 
 import java.awt.Container;
-import java.io.File;
 
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
@@ -81,11 +80,11 @@ public class MspCompileDialog extends AbstractCompileDialog {
   }
 
   @Override
-  public boolean canLoadFirmware(File file) {
-    if (file.getName().endsWith("." + moteType.getMoteType())) {
+  public boolean canLoadFirmware(String name) {
+    if (name.endsWith("." + moteType.getMoteType())) {
       return true;
     }
-    return file.getName().equals("main.exe");
+    return name.equals("main.exe");
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/MspCompileDialog.java
+++ b/java/org/contikios/cooja/mspmote/MspCompileDialog.java
@@ -81,10 +81,7 @@ public class MspCompileDialog extends AbstractCompileDialog {
 
   @Override
   public boolean canLoadFirmware(String name) {
-    if (name.endsWith("." + moteType.getMoteType())) {
-      return true;
-    }
-    return name.equals("main.exe");
+    return name.endsWith("." + moteType.getMoteType()) || name.equals("main.exe");
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -124,7 +124,7 @@ public abstract class MspMoteType extends BaseContikiMoteType {
         description = element.getText();
       } else if (name.equals("source")) {
         fileSource = simulation.getCooja().restorePortablePath(new File(element.getText()));
-        fileFirmware = getExpectedFirmwareFile(fileSource);
+        fileFirmware = getExpectedFirmwareFile(fileSource.getName());
       } else if (name.equals("command") || name.equals("commands")) {
         compileCommands = element.getText();
       } else if (name.equals("firmware") || name.equals("elf")) {


### PR DESCRIPTION
There is one functional change in this PR, only update source/firmware names after input has been validated in the SELECTED_FIRMWARE case.

The other changes do not change functionality, some method signatures are updated, some code is moved to inner classes, and various simplifications of statements.