### PR TITLE
Fix MSP430 compilation dialog

### DIFF
--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -146,9 +146,9 @@ public abstract class BaseContikiMoteType implements MoteType {
   }
 
   public File getExpectedFirmwareFile(String name) {
-    String sourceNoExtension = name;
+    String sourceNoExtension = new File(name).getName();
     if (sourceNoExtension.endsWith(".c")) {
-      sourceNoExtension = sourceNoExtension.substring(0, name.length() - 2);
+      sourceNoExtension = sourceNoExtension.substring(0, sourceNoExtension.length() - 2);
     }
     return new File(new File(name).getParentFile(),
             "/build/" + getMoteType() + "/" + sourceNoExtension + '.' + getMoteType());


### PR DESCRIPTION
Commit 1250b345 introduced absolute paths
for the input files which was not what
getExpectedFirmwareFile was expecting.
Restore the previous behavior without
reverting the API changes so MSP430-based
motes can be created again.