### PR TITLE
AbstractCompileDialog: detangle getDefaultCompileCommands

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -445,17 +445,6 @@ public class ContikiMoteType extends BaseContikiMoteType {
     return getAllMoteInterfaceClasses();
   }
 
-  /**
-   * Returns make target based on source file.
-   *
-   * @param name The source file
-   * @return Make target based on source file
-   */
-  public static File getMakeTargetName(String name) {
-    String sourceNoExtension = name.substring(0, name.length() - 2);
-    return new File(new File(name).getParentFile(), sourceNoExtension + librarySuffix);
-  }
-
   @Override
   public File getExpectedFirmwareFile(String name) {
     return new File(new File(name).getParentFile(), "build/cooja/" + identifier + ContikiMoteType.librarySuffix);

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -280,7 +280,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     		if (!compileButton.isEnabled()) {
     			return;
     		}
-        final var commands = StringUtils.splitOnNewline(getCompileCommands());
+        final var commands = StringUtils.splitOnNewline(commandsArea.getText());
         if (commands.isEmpty()) {
           return;
         }
@@ -367,7 +367,7 @@ public abstract class AbstractCompileDialog extends JDialog {
         }
         Class<? extends MoteInterface>[] arr = new Class[selected.size()];
         moteType.setMoteInterfaceClasses(selected.toArray(arr));
-      	moteType.setCompileCommands(getCompileCommands());
+        moteType.setCompileCommands(commandsArea.getText());
       	AbstractCompileDialog.this.dispose();
       }
     });
@@ -475,7 +475,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     /* Restore compile commands */
     final var commands = moteType.getCompileCommands();
     if (commands != null) {
-      setCompileCommands(commands);
+      commandsArea.setText(commands);
       dialogState = DialogState.AWAITING_COMPILATION;
     }
     setDialogState(dialogState);
@@ -532,7 +532,7 @@ public abstract class AbstractCompileDialog extends JDialog {
       if (dialogState == DialogState.SELECTED_SOURCE) {
         contikiSource = new File(input);
         moteType.setContikiSourceFile(contikiSource);
-        setCompileCommands(getDefaultCompileCommands(input));
+        commandsArea.setText(getDefaultCompileCommands(input));
         contikiFirmware = moteType.getExpectedFirmwareFile(input);
       }
       break;
@@ -569,7 +569,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     	createButton.setEnabled(true);
     	commandsArea.setEnabled(false);
       getRootPane().setDefaultButton(createButton);
-      setCompileCommands("");
+      commandsArea.setText("");
       break;
 
     default:
@@ -693,20 +693,6 @@ public abstract class AbstractCompileDialog extends JDialog {
     }
 
     moteIntfBox.add(intfCheckBox);
-  }
-
-  /**
-   * @param commands User configured compile commands
-   */
-  public void setCompileCommands(String commands) {
-    commandsArea.setText(commands);
-  }
-
-  /**
-   * @return User configured compile commands
-   */
-  public String getCompileCommands() {
-    return commandsArea.getText();
   }
 
   /**

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -701,7 +701,7 @@ public abstract class AbstractCompileDialog extends JDialog {
    */
   public String getDefaultCompileCommands(String name) {
     return Cooja.getExternalToolsSetting("PATH_MAKE") + " -j$(CPUS) " +
-           moteType.getExpectedFirmwareFile(name).getName() + " TARGET=" + moteType.getMoteType();
+           moteType.getMakeTargetName(name) + " TARGET=" + moteType.getMoteType();
   }
 
   private void abortAnyCompilation() {

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -530,9 +530,10 @@ public abstract class AbstractCompileDialog extends JDialog {
     	createButton.setEnabled(false);
     	commandsArea.setEnabled(true);
       if (dialogState == DialogState.SELECTED_SOURCE) {
+        contikiSource = new File(input);
+        moteType.setContikiSourceFile(contikiSource);
         setCompileCommands(getDefaultCompileCommands(input));
         contikiFirmware = moteType.getExpectedFirmwareFile(input);
-        contikiSource = new File(input);
       }
       break;
 

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -126,8 +126,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
       defines = " DEFINES=NETSTACK_CONF_H=" + ((ContikiMoteType) moteType).getNetworkStack().getHeaderFile();
     }
 
-    return Cooja.getExternalToolsSetting("PATH_MAKE") + " -j$(CPUS) " +
-            moteType.getMakeTargetName(name) + " TARGET=cooja" + defines;
+    return super.getDefaultCompileCommands(name) + defines;
   }
 
   private void addAdvancedTab(JTabbedPane parent) {

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -130,9 +130,6 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
   }
 
   private void addAdvancedTab(JTabbedPane parent) {
-
-    /* TODO System symbols */
-
     /* Communication stack */
     JLabel label = new JLabel("Default network stack header");
     label.setPreferredSize(LABEL_DIMENSION);

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -81,11 +81,6 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
 
   private ContikiMoteCompileDialog(Simulation sim, ContikiMoteType moteType) {
     super(sim, moteType);
-    if (contikiSource != null) {
-      /* Make sure compilation variables are updated */
-      getDefaultCompileCommands(contikiSource.getName());
-    }
-
     /* Add Contiki mote type specifics */
     addAdvancedTab(tabbedPane);
   }

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -109,7 +109,6 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
       moteType.setIdentifier(ContikiMoteType.generateUniqueMoteTypeID(usedNames));
     }
 
-    moteType.setContikiSourceFile(new File(name));
     var env = moteType.getCompilationEnvironment();
     compilationEnvironment = BaseContikiMoteType.oneDimensionalEnv(env);
     if (SwingUtilities.isEventDispatchThread()) {

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -214,14 +214,13 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
         SwingUtilities.invokeLater(new Runnable() {
           @Override
           public void run() {
-            getDefaultCompileCommands(moteType.getContikiSourceFile().getName());
             for (int i=0; i < tabbedPane.getTabCount(); i++) {
               if (tabbedPane.getTitleAt(i).equals("Environment")) {
                 tabbedPane.setSelectedIndex(i);
                 break;
               }
             }
-            setDialogState(DialogState.AWAITING_COMPILATION);
+            setDialogState(DialogState.SELECTED_SOURCE);
           }
         });
 

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -127,7 +127,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
     }
 
     return Cooja.getExternalToolsSetting("PATH_MAKE") + " -j$(CPUS) " +
-            ContikiMoteType.getMakeTargetName(name).getName() + " TARGET=cooja" + defines;
+            moteType.getMakeTargetName(name) + " TARGET=cooja" + defines;
   }
 
   private void addAdvancedTab(JTabbedPane parent) {

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -154,6 +154,17 @@ public abstract class BaseContikiMoteType implements MoteType {
             "/build/" + getMoteType() + "/" + sourceNoExtension + '.' + getMoteType());
   }
 
+  /**
+   * Returns make target based on source file name.
+   *
+   * @param name Name of source file.
+   * @return Make target based on source file
+   */
+  public String getMakeTargetName(String name) {
+    String sourceNoExtension = new File(name.substring(0, name.length() - 2)).getName();
+    return sourceNoExtension + "." + getMoteType();
+  }
+
   @Override
   public Class<? extends MoteInterface>[] getMoteInterfaceClasses() {
     if (moteInterfaceClasses.isEmpty()) {


### PR DESCRIPTION
Push code around to reduce the side effects of getDefaultCompileCommands.