### PR TITLE
Remove Container parameter from dialogs

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2906,7 +2906,7 @@ public class Cooja extends Observable {
         cooja.mySimulation.stopSimulation();
         newMoteType = (MoteType) ((JMenuItem) e.getSource()).getClientProperty("motetype");
       } else if (cmd.equals("edit paths")) {
-        ExternalToolsDialog.showDialog(Cooja.getTopParentContainer());
+        ExternalToolsDialog.showDialog();
       } else if (cmd.equals("manage extensions")) {
         COOJAProject[] newProjects = ProjectDirectoriesDialog.showDialog(
             Cooja.getTopParentContainer(),

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2932,7 +2932,7 @@ public class Cooja extends Observable {
         logger.warn("Unhandled action: " + cmd);
       }
       if (newMoteType != null) {
-        for (var mote : AddMoteDialog.showDialog(frame, cooja.mySimulation, newMoteType)) {
+        for (var mote : AddMoteDialog.showDialog(cooja.mySimulation, newMoteType)) {
           cooja.mySimulation.addMote(mote);
         }
       }

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1051,7 +1051,7 @@ public class Cooja extends Observable {
         if (mySimulation == null) {
           return;
         }
-        BufferSettings.showDialog(myDesktopPane, mySimulation);
+        BufferSettings.showDialog(mySimulation);
       }
       @Override
       public boolean shouldBeEnabled() {

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -924,7 +924,7 @@ public class Cooja extends Observable {
         }
 
         var sim = new Simulation(cooja);
-        if (CreateSimDialog.showDialog(Cooja.getTopParentContainer(), sim)) {
+        if (CreateSimDialog.showDialog(sim)) {
           // Start GUI plugins.
           for (var pluginClass : pluginClasses) {
             int type = pluginClass.getAnnotation(PluginType.class).value();

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2908,11 +2908,7 @@ public class Cooja extends Observable {
       } else if (cmd.equals("edit paths")) {
         ExternalToolsDialog.showDialog();
       } else if (cmd.equals("manage extensions")) {
-        COOJAProject[] newProjects = ProjectDirectoriesDialog.showDialog(
-            Cooja.getTopParentContainer(),
-            Cooja.this,
-            getProjects()
-        );
+        COOJAProject[] newProjects = ProjectDirectoriesDialog.showDialog(Cooja.this, getProjects());
         if (newProjects != null) {
         	currentProjects.clear();
           currentProjects.addAll(Arrays.asList(newProjects));

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -595,7 +595,7 @@ public class Simulation extends Observable implements Runnable {
         // Show configure simulation dialog
         if (visAvailable && !quick) {
           // FIXME: this should run from the AWT thread.
-          if (!CreateSimDialog.showDialog(Cooja.getTopParentContainer(), this)) {
+          if (!CreateSimDialog.showDialog(this)) {
             logger.debug("Simulation not created, aborting");
             throw new Exception("Load aborted by user");
           }

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -276,7 +276,7 @@ public class ContikiMoteType extends BaseContikiMoteType {
 
   @Override
   protected boolean showCompilationDialog(Simulation sim) {
-    return ContikiMoteCompileDialog.showDialog(Cooja.getTopParentContainer(), sim, this);
+    return ContikiMoteCompileDialog.showDialog(sim, this);
   }
 
   /** Load LibN.java and the corresponding .cooja file into memory. */

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -31,13 +31,9 @@ package org.contikios.cooja.dialogs;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
-import java.awt.Container;
-import java.awt.Dialog;
 import java.awt.Dimension;
-import java.awt.Frame;
 import java.awt.GraphicsEnvironment;
 import java.awt.Rectangle;
-import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -130,14 +126,10 @@ public abstract class AbstractCompileDialog extends JDialog {
   public File contikiSource = null;
   public File contikiFirmware = null;
 
-  public AbstractCompileDialog(Container parent, Simulation simulation, final BaseContikiMoteType moteType) {
-    super(
-        parent instanceof Dialog?(Dialog)parent:
-          parent instanceof Window?(Window)parent:
-            (Frame)parent, "Create Mote Type: Compile Contiki", ModalityType.APPLICATION_MODAL);
-
-    this.simulation = simulation;
-    this.gui = simulation.getCooja();
+  public AbstractCompileDialog(Simulation sim, final BaseContikiMoteType moteType) {
+    super(Cooja.getTopParentContainer(), "Create Mote Type: Compile Contiki", ModalityType.APPLICATION_MODAL);
+    this.simulation = sim;
+    this.gui = sim.getCooja();
     this.moteType = moteType;
 
     JPanel mainPanel = new JPanel(new BorderLayout());
@@ -447,7 +439,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     });
 
     pack();
-    setLocationRelativeTo(parent);
+    setLocationRelativeTo(Cooja.getTopParentContainer());
     
     tryRestoreMoteType();
   }

--- a/java/org/contikios/cooja/dialogs/AddMoteDialog.java
+++ b/java/org/contikios/cooja/dialogs/AddMoteDialog.java
@@ -52,7 +52,6 @@ import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JDialog;
 import javax.swing.JFormattedTextField;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -101,25 +100,20 @@ public class AddMoteDialog extends JDialog {
    * Shows a dialog which enables a user to create and add motes of the given
    * type.
    *
-   * @param parentContainer
-   *          Parent container for dialog
-   * @param simulation
-   *          Simulation
-   * @param moteType
-   *          Mote type
+   * @param sim Simulation
+   * @param moteType Mote type
    * @return New motes or null if aborted
    */
-  public static ArrayList<Mote> showDialog(JFrame parentContainer,
-      Simulation simulation, MoteType moteType) {
-    var myDialog = new AddMoteDialog(parentContainer, simulation, moteType);
-    myDialog.setLocationRelativeTo(parentContainer);
+  public static ArrayList<Mote> showDialog(Simulation sim, MoteType moteType) {
+    var myDialog = new AddMoteDialog(sim, moteType);
+    myDialog.setLocationRelativeTo(Cooja.getTopParentContainer());
     myDialog.checkSettings();
     myDialog.setVisible(true);
     return myDialog.newMotes;
   }
 
-  private AddMoteDialog(JFrame window, Simulation simulation, MoteType moteType) {
-    super(window, "Add motes (" + moteType.getDescription() + ")", ModalityType.APPLICATION_MODAL);
+  private AddMoteDialog(Simulation simulation, MoteType moteType) {
+    super(Cooja.getTopParentContainer(), "Add motes (" + moteType.getDescription() + ")", ModalityType.APPLICATION_MODAL);
     this.moteType = moteType;
     this.simulation = simulation;
 

--- a/java/org/contikios/cooja/dialogs/BufferSettings.java
+++ b/java/org/contikios/cooja/dialogs/BufferSettings.java
@@ -44,7 +44,6 @@ import javax.swing.Box;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JComponent;
-import javax.swing.JDesktopPane;
 import javax.swing.JDialog;
 import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
@@ -60,9 +59,9 @@ public class BufferSettings extends JDialog {
 
   private final SimEventCentral central;
 
-  public static void showDialog(JDesktopPane parent, Simulation simulation) {
+  public static void showDialog(Simulation simulation) {
     BufferSettings dialog = new BufferSettings(simulation);
-    dialog.setLocationRelativeTo(parent); 
+    dialog.setLocationRelativeTo(Cooja.getTopParentContainer());
     dialog.setVisible(true);
   }
 

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -229,7 +229,7 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
       @Override
       public void actionPerformed(ActionEvent e) {
         /* Show external tools dialog */
-        ExternalToolsDialog.showDialog(Cooja.getTopParentContainer());
+        ExternalToolsDialog.showDialog();
 
         /* Update and select environment tab */
         SwingUtilities.invokeLater(new Runnable() {

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -32,7 +32,6 @@ package org.contikios.cooja.dialogs;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
-import java.awt.Container;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
@@ -75,15 +74,14 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
 
   private final JComboBox<?> netStackComboBox = new JComboBox<>(NetworkStack.values());
 
-  public static boolean showDialog(Container parent, Simulation sim, ContikiMoteType mote) {
-    final var dialog = new ContikiMoteCompileDialog(parent, sim, mote);
+  public static boolean showDialog(Simulation sim, ContikiMoteType mote) {
+    final var dialog = new ContikiMoteCompileDialog(sim, mote);
     dialog.setVisible(true); // Blocks.
     return dialog.createdOK();
   }
 
-  private ContikiMoteCompileDialog(Container parent, Simulation simulation, ContikiMoteType moteType) {
-    super(parent, simulation, moteType);
-
+  private ContikiMoteCompileDialog(Simulation sim, ContikiMoteType moteType) {
+    super(sim, moteType);
     if (contikiSource != null) {
       /* Make sure compilation variables are updated */
       getDefaultCompileCommands(contikiSource.getName());

--- a/java/org/contikios/cooja/dialogs/CreateSimDialog.java
+++ b/java/org/contikios/cooja/dialogs/CreateSimDialog.java
@@ -34,7 +34,6 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
-import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -90,12 +89,11 @@ public class CreateSimDialog extends JDialog {
   /**
    * Shows a dialog for configuring a simulation.
    *
-   * @param parent Parent container for dialog
    * @param simulation Simulation to configure
    * @return True if simulation configured correctly
    */
-  public static boolean showDialog(Container parent, Simulation simulation) {
-    final CreateSimDialog dialog = new CreateSimDialog((Window) parent, simulation.getCooja());
+  public static boolean showDialog(Simulation simulation) {
+    final CreateSimDialog dialog = new CreateSimDialog(simulation.getCooja());
     dialog.setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
     dialog.addWindowListener(new WindowAdapter() {
       @Override
@@ -146,7 +144,7 @@ public class CreateSimDialog extends JDialog {
 
 
     // Set position and focus of dialog
-    dialog.setLocationRelativeTo(parent);
+    dialog.setLocationRelativeTo(Cooja.getTopParentContainer());
     dialog.title.requestFocus();
     dialog.title.select(0, dialog.title.getText().length());
 
@@ -167,8 +165,8 @@ public class CreateSimDialog extends JDialog {
     return dialog.mySimulation != null;
   }
 
-  private CreateSimDialog(Window window, Cooja gui) {
-    super(window, "Create new simulation", ModalityType.APPLICATION_MODAL);
+  private CreateSimDialog(Cooja gui) {
+    super(Cooja.getTopParentContainer(), "Create new simulation", ModalityType.APPLICATION_MODAL);
     Box vertBox = Box.createVerticalBox();
 
     JLabel label;

--- a/java/org/contikios/cooja/dialogs/ExternalToolsDialog.java
+++ b/java/org/contikios/cooja/dialogs/ExternalToolsDialog.java
@@ -34,10 +34,7 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
-import java.awt.Dialog;
 import java.awt.Dimension;
-import java.awt.Frame;
-import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
@@ -70,49 +67,19 @@ public class ExternalToolsDialog extends JDialog {
   private final static int LABEL_WIDTH = 220;
   private final static int LABEL_HEIGHT = 15;
 
-  private ExternalToolsDialog myDialog;
+  private final ExternalToolsDialog myDialog;
 
-  private JTextField[] textFields;
+  private final JTextField[] textFields;
 
-  /**
-   * Creates a dialog for viewing/editing external tools settings.
-   *
-   * @param parentContainer
-   *          Parent container for dialog
-   */
-  public static void showDialog(Container parentContainer) {
-    ExternalToolsDialog myDialog;
-    if (parentContainer instanceof Window) {
-      myDialog = new ExternalToolsDialog((Window) parentContainer);
-    } else if (parentContainer instanceof Dialog) {
-      myDialog = new ExternalToolsDialog((Dialog) parentContainer);
-    } else if (parentContainer instanceof Frame) {
-      myDialog = new ExternalToolsDialog((Frame) parentContainer);
-    } else {
-      logger.fatal("Unknown parent container type: " + parentContainer);
-      return;
-    }
-    myDialog.setLocationRelativeTo(parentContainer);
-
-    if (myDialog != null) {
-      myDialog.setVisible(true);
-    }
+  /** Creates a dialog for viewing/editing external tools settings. */
+  public static void showDialog() {
+    var myDialog = new ExternalToolsDialog();
+    myDialog.setLocationRelativeTo(Cooja.getTopParentContainer());
+    myDialog.setVisible(true);
   }
 
-  private ExternalToolsDialog(Dialog dialog) {
-    super(dialog, "Edit Settings", ModalityType.APPLICATION_MODAL);
-    setupDialog();
-  }
-  private ExternalToolsDialog(Window window) {
-    super(window, "Edit Settings", ModalityType.APPLICATION_MODAL);
-    setupDialog();
-  }
-  private ExternalToolsDialog(Frame frame) {
-    super(frame, "Edit Settings", ModalityType.APPLICATION_MODAL);
-    setupDialog();
-  }
-
-  private void setupDialog() {
+  private ExternalToolsDialog() {
+    super(Cooja.getTopParentContainer(), "Edit Settings", ModalityType.APPLICATION_MODAL);
     myDialog = this;
 
     JLabel label;

--- a/java/org/contikios/cooja/dialogs/ImportAppMoteDialog.java
+++ b/java/org/contikios/cooja/dialogs/ImportAppMoteDialog.java
@@ -31,9 +31,7 @@
 package org.contikios.cooja.dialogs;
 import java.awt.BorderLayout;
 import java.awt.Component;
-import java.awt.Container;
 import java.awt.Dimension;
-import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -76,9 +74,8 @@ public class ImportAppMoteDialog extends JDialog {
   private final JButton cancelButton;
   private boolean hasSelected = false;
 
-  public ImportAppMoteDialog(Container parent, final Simulation simulation, final ImportAppMoteType moteType) {
-    super((Window)parent, "Create Mote Type: Application Mote", ModalityType.APPLICATION_MODAL);
-
+  public ImportAppMoteDialog(final Simulation simulation, final ImportAppMoteType moteType) {
+    super(Cooja.getTopParentContainer(), "Create Mote Type: Application Mote", ModalityType.APPLICATION_MODAL);
     JPanel mainPanel = new JPanel(new BorderLayout());
 
     JPanel topPanel = new JPanel();
@@ -235,7 +232,7 @@ public class ImportAppMoteDialog extends JDialog {
     descriptionField.selectAll();
 
     pack();
-    setLocationRelativeTo(parent);
+    setLocationRelativeTo(Cooja.getTopParentContainer());
   }
 
   private boolean trySetClass(Simulation simulation, ImportAppMoteType moteType, File classFile) {

--- a/java/org/contikios/cooja/dialogs/ProjectDirectoriesDialog.java
+++ b/java/org/contikios/cooja/dialogs/ProjectDirectoriesDialog.java
@@ -40,7 +40,6 @@ import java.awt.Font;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Rectangle;
-import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -110,25 +109,20 @@ public class ProjectDirectoriesDialog extends JDialog {
 	 * Shows a blocking configuration dialog.
 	 * Returns a list of new COOJA project directories, or null if canceled by the user. 
 	 *  
-	 * @param parent Parent container
 	 * @param gui COOJA
 	 * @param currentProjects Current projects
 	 * @return New COOJA projects, or null
 	 */
-	public static COOJAProject[] showDialog(Container parent, Cooja gui, COOJAProject[] currentProjects) {
-		ProjectDirectoriesDialog dialog = new ProjectDirectoriesDialog(parent, currentProjects);
+  public static COOJAProject[] showDialog(Cooja gui, COOJAProject[] currentProjects) {
+    ProjectDirectoriesDialog dialog = new ProjectDirectoriesDialog(currentProjects);
 		dialog.gui = gui;
-		dialog.setLocationRelativeTo(parent);
+		dialog.setLocationRelativeTo(Cooja.getTopParentContainer());
 		dialog.setVisible(true);
 		return dialog.returnedProjects;
 	}
 
-	private ProjectDirectoriesDialog(Container parent, COOJAProject[] projects) {
-		super(
-				parent instanceof Dialog?(Dialog)parent:
-					parent instanceof Window?(Window)parent:
-						(Frame)parent, "Cooja extensions", ModalityType.APPLICATION_MODAL);
-
+  private ProjectDirectoriesDialog(COOJAProject[] projects) {
+    super(Cooja.getTopParentContainer(), "Cooja extensions", ModalityType.APPLICATION_MODAL);
 		table = new JTable(new AbstractTableModel() {
 			@Override
 			public int getColumnCount() {

--- a/java/org/contikios/cooja/motes/ImportAppMoteType.java
+++ b/java/org/contikios/cooja/motes/ImportAppMoteType.java
@@ -126,7 +126,7 @@ public class ImportAppMoteType extends AbstractApplicationMoteType {
 
     if (visAvailable) {
       /* Select mote class file */
-      ImportAppMoteDialog dialog = new ImportAppMoteDialog(parentContainer, simulation, this);
+      ImportAppMoteDialog dialog = new ImportAppMoteDialog(simulation, this);
       if (!dialog.waitForUserResponse()) {
         return false;
       }

--- a/java/org/contikios/cooja/mspmote/MspCompileDialog.java
+++ b/java/org/contikios/cooja/mspmote/MspCompileDialog.java
@@ -30,8 +30,6 @@
 
 package org.contikios.cooja.mspmote;
 
-import java.awt.Container;
-
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTextArea;
@@ -41,20 +39,15 @@ import org.contikios.cooja.Simulation;
 import org.contikios.cooja.dialogs.AbstractCompileDialog;
 
 public class MspCompileDialog extends AbstractCompileDialog {
-  public static boolean showDialog(
-      Container parent,
-      Simulation simulation,
-      MspMoteType moteType) {
-
-    final AbstractCompileDialog dialog = new MspCompileDialog(parent, simulation, moteType);
-
+  public static boolean showDialog(Simulation sim, MspMoteType moteType) {
+    final AbstractCompileDialog dialog = new MspCompileDialog(sim, moteType);
     /* Show dialog and wait for user */
     dialog.setVisible(true); /* BLOCKS */
     return dialog.createdOK();
   }
 
-  private MspCompileDialog(Container parent, Simulation simulation, MspMoteType moteType) {
-    super(parent, simulation, moteType);
+  private MspCompileDialog(Simulation sim, MspMoteType moteType) {
+    super(sim, moteType);
     setTitle("Create Mote Type: Compile Contiki for " + moteType.getMoteType());
     addCompilationTipsTab(tabbedPane);
   }

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -44,7 +44,6 @@ import org.jdom.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
-import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.Simulation;
 import se.sics.mspsim.util.DebugInfo;
@@ -63,7 +62,7 @@ public abstract class MspMoteType extends BaseContikiMoteType {
 
   @Override
   protected boolean showCompilationDialog(Simulation sim) {
-    return MspCompileDialog.showDialog(Cooja.getTopParentContainer(), sim, this);
+    return MspCompileDialog.showDialog(sim, this);
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -32,7 +32,6 @@ package org.contikios.cooja.mspmote.plugins;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.IOException;
@@ -485,7 +484,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
 
     /* table with rules */
     rulesDebuggingOutput.clearMessages();
-    final JDialog dialog = new JDialog((Window)Cooja.getTopParentContainer(), "Locate source files");
+    final JDialog dialog = new JDialog(Cooja.getTopParentContainer(), "Locate source files");
     dialog.setModal(true);
     updateRulesUsage();
     AbstractTableModel model = new AbstractTableModel() {

--- a/java/org/contikios/mrm/AreaViewer.java
+++ b/java/org/contikios/mrm/AreaViewer.java
@@ -35,7 +35,6 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Cursor;
-import java.awt.Dialog;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.Graphics;
@@ -47,7 +46,6 @@ import java.awt.MediaTracker;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
-import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -958,20 +956,8 @@ public class AreaViewer extends VisPlugin {
       /**
        * Creates a new dialog for settings background parameters
        */
-      protected ImageSettingsDialog(File imageFile, Image image, Frame frame) {
-        super(frame, "Image settings");
-        setupDialog();
-      }
-      protected ImageSettingsDialog(File imageFile, Image image, Dialog dialog) {
-        super(dialog, "Image settings");
-        setupDialog();
-      }
-      protected ImageSettingsDialog(File imageFile, Image image, Window window) {
-        super(window, "Image settings");
-        setupDialog();
-      }
-
-      private void setupDialog() {
+      private ImageSettingsDialog() {
+        super(Cooja.getTopParentContainer(), "Image settings");
         JPanel mainPanel, tempPanel;
         setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
         doubleFormat.setMinimumIntegerDigits(1);
@@ -1154,13 +1140,7 @@ public class AreaViewer extends VisPlugin {
       }
 
       /* Set virtual size of image */
-      var topParent = Cooja.getTopParentContainer();
-      if (topParent == null) {
-        logger.fatal("Unknown parent container, aborting");
-        return false;
-      }
-      var dialog = new ImageSettingsDialog(file, image, topParent);
-
+      var dialog = new ImageSettingsDialog();
       if (!dialog.terminatedOK()) {
         logger.fatal("User canceled, aborting");
         return false;


### PR DESCRIPTION
This is a leftover from the applet support,
just put the Cooja.getTopParentContainer()
at the innermost constructor that needs it
instead.