### PR TITLE
BaseContikiMoteType: add setBaseConfigXML method

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -956,7 +956,6 @@ public class ContikiMoteType extends BaseContikiMoteType {
         case "commstack":
           logger.warn("The Cooja communication stack config was removed: " + element.getText());
           logger.warn("Instead assuming default network stack.");
-          netStack = NetworkStack.DEFAULT;
           break;
         case "netstack":
           netStack = NetworkStack.parseConfig(element.getText());

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -948,26 +948,11 @@ public class ContikiMoteType extends BaseContikiMoteType {
   public boolean setConfigXML(Simulation simulation,
                               Collection<Element> configXML, boolean visAvailable)
           throws MoteTypeCreationException {
+    if (!setBaseConfigXML(simulation, configXML)) {
+      return false;
+    }
     for (Element element : configXML) {
-      String name = element.getName();
-      switch (name) {
-        case "identifier":
-          identifier = element.getText();
-          break;
-        case "description":
-          description = element.getText();
-          break;
-        case "contikiapp":
-        case "source":
-          fileSource = simulation.getCooja().restorePortablePath(new File(element.getText()));
-          fileFirmware = getMoteFile(librarySuffix);
-          break;
-        case "commands":
-          compileCommands = element.getText();
-          break;
-        case "symbols":
-          // Ignored, this information has never been used.
-          break;
+      switch (element.getName()) {
         case "commstack":
           logger.warn("The Cooja communication stack config was removed: " + element.getText());
           logger.warn("Instead assuming default network stack.");
@@ -976,34 +961,18 @@ public class ContikiMoteType extends BaseContikiMoteType {
         case "netstack":
           netStack = NetworkStack.parseConfig(element.getText());
           break;
-        case "moteinterface":
-          String intfClass = element.getText().trim();
-          var clazz = MoteInterfaceHandler.getInterfaceClass(simulation.getCooja(), this, intfClass);
-          if (clazz == null) {
-            logger.warn("Can't find mote interface class: " + intfClass);
-            return false;
-          }
-          moteInterfaceClasses.add(clazz);
-          break;
-        case "contikibasedir":
-        case "contikicoredir":
-        case "projectdir":
-        case "compilefile":
-        case "process":
-        case "sensor":
-        case "coreinterface":
-          logger.fatal("Old Cooja mote type detected, aborting..");
-          return false;
-        default:
-          logger.fatal("Unrecognized entry in loaded configuration: " + name);
-          break;
       }
     }
+    final var sourceFile = getContikiSourceFile();
+    if (sourceFile != null) { // Compensate for non-standard naming rules.
+      fileFirmware = getMoteFile(librarySuffix);
+    }
+    // FIXME: These checks should always be on.
     if (!visAvailable || simulation.isQuickSetup()) {
       if (getIdentifier() == null) {
         throw new MoteTypeCreationException("No identifier specified");
       }
-      if (getContikiSourceFile() == null) {
+      if (sourceFile == null) {
         throw new MoteTypeCreationException("No Contiki application specified");
       }
       if (getCompileCommands() == null) {

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -115,33 +115,9 @@ public abstract class MspMoteType extends BaseContikiMoteType {
   public boolean setConfigXML(Simulation simulation,
       Collection<Element> configXML, boolean visAvailable)
       throws MoteTypeCreationException {
-    for (Element element : configXML) {
-      String name = element.getName();
-
-      if (name.equals("identifier")) {
-        identifier = element.getText();
-      } else if (name.equals("description")) {
-        description = element.getText();
-      } else if (name.equals("source")) {
-        fileSource = simulation.getCooja().restorePortablePath(new File(element.getText()));
-        fileFirmware = getExpectedFirmwareFile(fileSource.getName());
-      } else if (name.equals("command") || name.equals("commands")) {
-        compileCommands = element.getText();
-      } else if (name.equals("firmware") || name.equals("elf")) {
-        fileFirmware = simulation.getCooja().restorePortablePath(new File(element.getText()));
-      } else if (name.equals("moteinterface")) {
-        String intfClass = element.getText().trim();
-        var moteInterfaceClass = MoteInterfaceHandler.getInterfaceClass(simulation.getCooja(), this, intfClass);
-        if (moteInterfaceClass == null) {
-          logger.warn("Can't find mote interface class: " + intfClass);
-          return false;
-        }
-        moteInterfaceClasses.add(moteInterfaceClass);
-      } else {
-        logger.warn("Unrecognized entry in loaded configuration: " + name);
-      }
+    if (!setBaseConfigXML(simulation, configXML)) {
+      return false;
     }
-
     if (moteInterfaceClasses.isEmpty()) {
       /* Backwards compatibility: No interfaces specified */
       logger.warn("Old simulation config detected: no mote interfaces specified, assuming all.");


### PR DESCRIPTION
Put the common configuration work in the base
class, and call that from the subclasses.

This means that ContikiMoteType will now accept
specifying compile commands with "command" instead
of "commands". The same thing happens for MspMoteType
that now accepts "contikibasedir", and gives an error
message when that is encountered. These elements
are never written by the respective mote types though,
so the leniency should not be a problem in practice.
