### PR TITLE
MspMote: initialize everything in constructor

### DIFF
--- a/java/org/contikios/cooja/mspmote/Exp5438Mote.java
+++ b/java/org/contikios/cooja/mspmote/Exp5438Mote.java
@@ -29,7 +29,6 @@
 
 package org.contikios.cooja.mspmote;
 
-import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import se.sics.mspsim.platform.GenericNode;
@@ -46,7 +45,6 @@ public class Exp5438Mote extends MspMote {
     super(moteType, sim, node);
     exp5438Node = node;
     description = desc;
-    myMoteInterfaceHandler = new MoteInterfaceHandler(this, moteType.getMoteInterfaceClasses());
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/Exp5438Mote.java
+++ b/java/org/contikios/cooja/mspmote/Exp5438Mote.java
@@ -29,9 +29,6 @@
 
 package org.contikios.cooja.mspmote;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-
 import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
@@ -41,23 +38,14 @@ import se.sics.mspsim.platform.GenericNode;
  * @author Fredrik Osterlind
  */
 public class Exp5438Mote extends MspMote {
-  private static final Logger logger = LogManager.getLogger(Exp5438Mote.class);
-
   public final GenericNode exp5438Node;
   private final String description;
   
   public Exp5438Mote(MspMoteType moteType, Simulation sim, GenericNode node, String desc)
           throws MoteType.MoteTypeCreationException {
-    super(moteType, sim);
+    super(moteType, sim, node);
     exp5438Node = node;
     description = desc;
-    registry = exp5438Node.getRegistry();
-    try {
-      prepareMote(exp5438Node);
-    } catch (Exception e) {
-      logger.fatal("Error when creating Exp5438 mote: ", e);
-      throw new MoteType.MoteTypeCreationException("Error creating Exp5438 mote: " + e.getMessage());
-    }
     myMoteInterfaceHandler = new MoteInterfaceHandler(this, moteType.getMoteInterfaceClasses());
   }
 

--- a/java/org/contikios/cooja/mspmote/Exp5438Mote.java
+++ b/java/org/contikios/cooja/mspmote/Exp5438Mote.java
@@ -36,11 +36,6 @@ import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import se.sics.mspsim.platform.GenericNode;
-import se.sics.mspsim.platform.ti.Exp1101Node;
-import se.sics.mspsim.platform.ti.Exp1120Node;
-import se.sics.mspsim.platform.ti.Exp5438Node;
-import se.sics.mspsim.platform.ti.Trxeb1120Node;
-import se.sics.mspsim.platform.ti.Trxeb2520Node;
 
 /**
  * @author Fredrik Osterlind
@@ -49,37 +44,15 @@ public class Exp5438Mote extends MspMote {
   private static final Logger logger = LogManager.getLogger(Exp5438Mote.class);
 
   public final GenericNode exp5438Node;
-  private String desc = "";
+  private final String description;
   
-  public Exp5438Mote(MspMoteType moteType, Simulation sim) throws MoteType.MoteTypeCreationException {
+  public Exp5438Mote(MspMoteType moteType, Simulation sim, GenericNode node, String desc)
+          throws MoteType.MoteTypeCreationException {
     super(moteType, sim);
-    final var fileELF = moteType.getContikiFirmwareFile();
-    // Hack: Try to figure out what type of MSPSim-node we should be used by checking file extension.
-    String filename = fileELF.getName();
-    if (filename.endsWith(".exp1101")) {
-      exp5438Node = new Exp1101Node();
-      desc = "Exp5438+CC1101";
-    } else if (filename.endsWith(".exp1120")) {
-      exp5438Node = new Exp1120Node();
-      desc = "Exp5438+CC1120";
-    } else if (filename.endsWith(".trxeb2520")) {
-      exp5438Node = new Trxeb2520Node();
-      desc = "Trxeb2520";
-    } else if (filename.endsWith(".trxeb1120")) {
-      exp5438Node = new Trxeb1120Node(false);
-      desc = "Trxeb1120";
-    } else if (filename.endsWith(".eth1120")) {
-      exp5438Node = new Trxeb1120Node(true);
-      desc = "Eth1120";
-    } else if (filename.endsWith(".exp2420") || filename.endsWith(".exp5438")) {
-      exp5438Node = new Exp5438Node();
-      desc = "Exp5438+CC2420";
-    } else {
-      throw new IllegalStateException("unknown file extension, cannot figure out what MSPSim node type to use: " + filename);
-    }
-
+    exp5438Node = node;
+    description = desc;
+    registry = exp5438Node.getRegistry();
     try {
-      registry = exp5438Node.getRegistry();
       prepareMote(exp5438Node);
     } catch (Exception e) {
       logger.fatal("Error when creating Exp5438 mote: ", e);
@@ -94,7 +67,7 @@ public class Exp5438Mote extends MspMote {
 
   @Override
   public String toString() {
-    return desc + " " + getID();
+    return description + " " + getID();
   }
 
 }

--- a/java/org/contikios/cooja/mspmote/Exp5438MoteType.java
+++ b/java/org/contikios/cooja/mspmote/Exp5438MoteType.java
@@ -46,6 +46,12 @@ import org.contikios.cooja.mspmote.interfaces.MspClock;
 import org.contikios.cooja.mspmote.interfaces.MspDebugOutput;
 import org.contikios.cooja.mspmote.interfaces.MspMoteID;
 import org.contikios.cooja.mspmote.interfaces.UsciA1Serial;
+import se.sics.mspsim.platform.GenericNode;
+import se.sics.mspsim.platform.ti.Exp1101Node;
+import se.sics.mspsim.platform.ti.Exp1120Node;
+import se.sics.mspsim.platform.ti.Exp5438Node;
+import se.sics.mspsim.platform.ti.Trxeb1120Node;
+import se.sics.mspsim.platform.ti.Trxeb2520Node;
 
 @ClassDescription("EXP430F5438 mote")
 @AbstractionLevelDescription("Emulated level")
@@ -53,7 +59,33 @@ public class Exp5438MoteType extends MspMoteType {
 
   @Override
   public MspMote generateMote(Simulation simulation) throws MoteTypeCreationException {
-    return new Exp5438Mote(this, simulation);
+    final var fileELF = getContikiFirmwareFile();
+    // Hack: Try to figure out what type of MSPSim-node we should be used by checking file extension.
+    String filename = fileELF.getName();
+    final GenericNode exp5438Node;
+    final String desc;
+    if (filename.endsWith(".exp1101")) {
+      exp5438Node = new Exp1101Node();
+      desc = "Exp5438+CC1101";
+    } else if (filename.endsWith(".exp1120")) {
+      exp5438Node = new Exp1120Node();
+      desc = "Exp5438+CC1120";
+    } else if (filename.endsWith(".trxeb2520")) {
+      exp5438Node = new Trxeb2520Node();
+      desc = "Trxeb2520";
+    } else if (filename.endsWith(".trxeb1120")) {
+      exp5438Node = new Trxeb1120Node(false);
+      desc = "Trxeb1120";
+    } else if (filename.endsWith(".eth1120")) {
+      exp5438Node = new Trxeb1120Node(true);
+      desc = "Eth1120";
+    } else if (filename.endsWith(".exp2420") || filename.endsWith(".exp5438")) {
+      exp5438Node = new Exp5438Node();
+      desc = "Exp5438+CC2420";
+    } else {
+      throw new IllegalStateException("Unknown file extension, cannot figure out what MSPSim node type to use: " + filename);
+    }
+    return new Exp5438Mote(this, simulation, exp5438Node, desc);
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -98,18 +98,25 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
   private final MspMoteType myMoteType;
   private MspMoteMemory myMemory = null;
   protected MoteInterfaceHandler myMoteInterfaceHandler;
-  public ComponentRegistry registry = null;
+  public final ComponentRegistry registry;
 
   /* Stack monitoring variables */
   private boolean stopNextInstruction = false;
 
-  public MspMote(MspMoteType moteType, Simulation simulation) throws MoteType.MoteTypeCreationException {
-    super(simulation);
+  public MspMote(MspMoteType moteType, Simulation sim, GenericNode node) throws MoteType.MoteTypeCreationException {
+    super(sim);
     myMoteType = moteType;
     try {
       debuggingInfo = moteType.getFirmwareDebugInfo();
     } catch (IOException e) {
       throw new MoteType.MoteTypeCreationException("Error: " + e.getMessage(), e);
+    }
+    registry = node.getRegistry();
+    try {
+      prepareMote(node);
+    } catch (Exception e) {
+      logger.fatal("Error when creating MSP430 mote: ", e);
+      throw new MoteType.MoteTypeCreationException("Error when creating MSP430 mote: " + e.getMessage());
     }
     /* Schedule us immediately */
     requestImmediateWakeup();
@@ -200,7 +207,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
    * @param node MSP430 cpu
    * @throws IOException Preparing mote failed
    */
-  protected void prepareMote(GenericNode node) throws IOException {
+  public void prepareMote(GenericNode node) throws IOException {
     node.setCommandHandler(commandHandler);
 
     node.setup(new ConfigManager());

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -96,7 +96,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
   private final MSP430 myCpu;
   private final MspMoteType myMoteType;
   private final MspMoteMemory myMemory;
-  protected MoteInterfaceHandler myMoteInterfaceHandler;
+  private final MoteInterfaceHandler myMoteInterfaceHandler;
   public final ComponentRegistry registry;
 
   /* Stack monitoring variables */
@@ -143,6 +143,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     // Create mote address memory.
     myMemory = new MspMoteMemory(this, elf.getMap().getAllEntries(), myCpu);
     myCpu.reset();
+    myMoteInterfaceHandler = new MoteInterfaceHandler(this, moteType.getMoteInterfaceClasses());
     registry.removeComponent("windowManager");
     registry.registerComponent("windowManager", new WindowManager() {
       @Override

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -93,7 +93,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     Visualizer.registerVisualizerSkin(CodeVisualizerSkin.class);
   }
 
-  private final CommandHandler commandHandler;
+  private final CommandHandler commandHandler = new CommandHandler(System.out, System.err);
   private MSP430 myCpu = null;
   private final MspMoteType myMoteType;
   private MspMoteMemory myMemory = null;
@@ -111,7 +111,6 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     } catch (IOException e) {
       throw new MoteType.MoteTypeCreationException("Error: " + e.getMessage(), e);
     }
-    commandHandler = new CommandHandler(System.out, System.err);
     /* Schedule us immediately */
     requestImmediateWakeup();
   }

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -143,14 +143,6 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     // Create mote address memory.
     myMemory = new MspMoteMemory(this, elf.getMap().getAllEntries(), myCpu);
     myCpu.reset();
-    initMote();
-
-    /* Schedule us immediately */
-    requestImmediateWakeup();
-  }
-
-  private void initMote() {
-    /* TODO Create COOJA-specific window manager */
     registry.removeComponent("windowManager");
     registry.registerComponent("windowManager", new WindowManager() {
       @Override
@@ -205,6 +197,8 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
         };
       }
     });
+    // Schedule us immediately.
+    requestImmediateWakeup();
   }
 
   /**

--- a/java/org/contikios/cooja/mspmote/SkyMote.java
+++ b/java/org/contikios/cooja/mspmote/SkyMote.java
@@ -30,9 +30,6 @@
 
 package org.contikios.cooja.mspmote;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-
 import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
@@ -42,20 +39,11 @@ import se.sics.mspsim.platform.sky.SkyNode;
  * @author Fredrik Osterlind
  */
 public class SkyMote extends MspMote {
-  private static final Logger logger = LogManager.getLogger(SkyMote.class);
-
   public final SkyNode skyNode;
 
   public SkyMote(MspMoteType moteType, Simulation sim, SkyNode node) throws MoteType.MoteTypeCreationException {
-    super(moteType, sim);
+    super(moteType, sim, node);
     skyNode = node;
-    registry = skyNode.getRegistry();
-    try {
-      prepareMote(skyNode);
-    } catch (Exception e) {
-      logger.fatal("Error when creating Sky mote: ", e);
-      throw new MoteType.MoteTypeCreationException("Error when creating Sky mote: " + e.getMessage());
-    }
     myMoteInterfaceHandler = new MoteInterfaceHandler(this, moteType.getMoteInterfaceClasses());
   }
 

--- a/java/org/contikios/cooja/mspmote/SkyMote.java
+++ b/java/org/contikios/cooja/mspmote/SkyMote.java
@@ -30,7 +30,6 @@
 
 package org.contikios.cooja.mspmote;
 
-import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import se.sics.mspsim.platform.sky.SkyNode;
@@ -44,7 +43,6 @@ public class SkyMote extends MspMote {
   public SkyMote(MspMoteType moteType, Simulation sim, SkyNode node) throws MoteType.MoteTypeCreationException {
     super(moteType, sim, node);
     skyNode = node;
-    myMoteInterfaceHandler = new MoteInterfaceHandler(this, moteType.getMoteInterfaceClasses());
   }
 
   /*private void configureWithMacAddressesTxt(int id) {

--- a/java/org/contikios/cooja/mspmote/SkyMote.java
+++ b/java/org/contikios/cooja/mspmote/SkyMote.java
@@ -36,7 +36,6 @@ import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
-import org.contikios.cooja.mspmote.interfaces.CoojaM25P80;
 import se.sics.mspsim.platform.sky.SkyNode;
 
 /**
@@ -47,11 +46,10 @@ public class SkyMote extends MspMote {
 
   public final SkyNode skyNode;
 
-  public SkyMote(MspMoteType moteType, Simulation sim) throws MoteType.MoteTypeCreationException {
+  public SkyMote(MspMoteType moteType, Simulation sim, SkyNode node) throws MoteType.MoteTypeCreationException {
     super(moteType, sim);
-    skyNode = new SkyNode();
+    skyNode = node;
     registry = skyNode.getRegistry();
-    skyNode.setFlash(new CoojaM25P80(skyNode.getCPU()));
     try {
       prepareMote(skyNode);
     } catch (Exception e) {

--- a/java/org/contikios/cooja/mspmote/SkyMoteType.java
+++ b/java/org/contikios/cooja/mspmote/SkyMoteType.java
@@ -40,6 +40,7 @@ import org.contikios.cooja.interfaces.Mote2MoteRelations;
 import org.contikios.cooja.interfaces.MoteAttributes;
 import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.RimeAddress;
+import org.contikios.cooja.mspmote.interfaces.CoojaM25P80;
 import org.contikios.cooja.mspmote.interfaces.Msp802154Radio;
 import org.contikios.cooja.mspmote.interfaces.MspClock;
 import org.contikios.cooja.mspmote.interfaces.MspDebugOutput;
@@ -50,6 +51,7 @@ import org.contikios.cooja.mspmote.interfaces.SkyCoffeeFilesystem;
 import org.contikios.cooja.mspmote.interfaces.SkyFlash;
 import org.contikios.cooja.mspmote.interfaces.SkyLED;
 import org.contikios.cooja.mspmote.interfaces.SkyTemperature;
+import se.sics.mspsim.platform.sky.SkyNode;
 
 @ClassDescription("Sky mote")
 @AbstractionLevelDescription("Emulated level")
@@ -57,7 +59,9 @@ public class SkyMoteType extends MspMoteType {
 
   @Override
   public MspMote generateMote(Simulation simulation) throws MoteTypeCreationException {
-    return new SkyMote(this, simulation);
+    var node = new SkyNode();
+    node.setFlash(new CoojaM25P80(node.getCPU()));
+    return new SkyMote(this, simulation, node);
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/Z1Mote.java
+++ b/java/org/contikios/cooja/mspmote/Z1Mote.java
@@ -29,7 +29,6 @@
  */
 
 package org.contikios.cooja.mspmote;
-import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import se.sics.mspsim.platform.z1.Z1Node;
@@ -41,7 +40,6 @@ public class Z1Mote extends MspMote {
 
     public Z1Mote(MspMoteType moteType, Simulation sim, Z1Node node) throws MoteType.MoteTypeCreationException {
         super(moteType, sim, node);
-        myMoteInterfaceHandler = new MoteInterfaceHandler(this, moteType.getMoteInterfaceClasses());
     }
 
     @Override

--- a/java/org/contikios/cooja/mspmote/Z1Mote.java
+++ b/java/org/contikios/cooja/mspmote/Z1Mote.java
@@ -29,8 +29,6 @@
  */
 
 package org.contikios.cooja.mspmote;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
@@ -41,17 +39,8 @@ import se.sics.mspsim.platform.z1.Z1Node;
  */
 public class Z1Mote extends MspMote {
 
-    private static final Logger logger = LogManager.getLogger(Z1Mote.class);
-
     public Z1Mote(MspMoteType moteType, Simulation sim, Z1Node node) throws MoteType.MoteTypeCreationException {
-        super(moteType, sim);
-        registry = node.getRegistry();
-        try {
-            prepareMote(node);
-        } catch (Exception e) {
-            logger.fatal("Error when creating Z1 mote: ", e);
-            throw new MoteType.MoteTypeCreationException("Error when creating Z1 mote: " + e.getMessage());
-        }
+        super(moteType, sim, node);
         myMoteInterfaceHandler = new MoteInterfaceHandler(this, moteType.getMoteInterfaceClasses());
     }
 

--- a/java/org/contikios/cooja/mspmote/Z1Mote.java
+++ b/java/org/contikios/cooja/mspmote/Z1Mote.java
@@ -34,7 +34,6 @@ import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
-import org.contikios.cooja.mspmote.interfaces.CoojaM25P80;
 import se.sics.mspsim.platform.z1.Z1Node;
 
 /**
@@ -44,13 +43,11 @@ public class Z1Mote extends MspMote {
 
     private static final Logger logger = LogManager.getLogger(Z1Mote.class);
 
-    public Z1Mote(MspMoteType moteType, Simulation sim) throws MoteType.MoteTypeCreationException {
+    public Z1Mote(MspMoteType moteType, Simulation sim, Z1Node node) throws MoteType.MoteTypeCreationException {
         super(moteType, sim);
-        Z1Node z1Node = new Z1Node();
-        registry = z1Node.getRegistry();
-        z1Node.setFlash(new CoojaM25P80(z1Node.getCPU()));
+        registry = node.getRegistry();
         try {
-            prepareMote(z1Node);
+            prepareMote(node);
         } catch (Exception e) {
             logger.fatal("Error when creating Z1 mote: ", e);
             throw new MoteType.MoteTypeCreationException("Error when creating Z1 mote: " + e.getMessage());

--- a/java/org/contikios/cooja/mspmote/Z1MoteType.java
+++ b/java/org/contikios/cooja/mspmote/Z1MoteType.java
@@ -39,6 +39,7 @@ import org.contikios.cooja.interfaces.Mote2MoteRelations;
 import org.contikios.cooja.interfaces.MoteAttributes;
 import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.RimeAddress;
+import org.contikios.cooja.mspmote.interfaces.CoojaM25P80;
 import org.contikios.cooja.mspmote.interfaces.Msp802154Radio;
 import org.contikios.cooja.mspmote.interfaces.MspButton;
 import org.contikios.cooja.mspmote.interfaces.MspClock;
@@ -46,6 +47,7 @@ import org.contikios.cooja.mspmote.interfaces.MspDebugOutput;
 import org.contikios.cooja.mspmote.interfaces.MspDefaultSerial;
 import org.contikios.cooja.mspmote.interfaces.MspLED;
 import org.contikios.cooja.mspmote.interfaces.MspMoteID;
+import se.sics.mspsim.platform.z1.Z1Node;
 
 @ClassDescription("Z1 mote")
 @AbstractionLevelDescription("Emulated level")
@@ -68,7 +70,9 @@ public class Z1MoteType extends MspMoteType {
 
     @Override
     public MspMote generateMote(Simulation simulation) throws MoteTypeCreationException {
-        return new Z1Mote(this, simulation);
+        var node = new Z1Node();
+        node.setFlash(new CoojaM25P80(node.getCPU()));
+        return new Z1Mote(this, simulation, node);
     }
 
     @Override


### PR DESCRIPTION
This moves all the initialization to the constructor of MspMote which shortens the code and simplifies the program flow. The change also enables making the CPU/memory fields final.