### PR TITLE
BaseContikiMoteType: add interface methods

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -406,6 +406,7 @@ public class ContikiMoteType extends BaseContikiMoteType {
     return true;
   }
 
+  @Override
   public Class<? extends MoteInterface>[] getAllMoteInterfaceClasses() {
     String[] ifNames = getConfig().getStringArrayValue(ContikiMoteType.class, "MOTE_INTERFACES");
     ArrayList<Class<? extends MoteInterface>> classes = new ArrayList<>();
@@ -438,6 +439,12 @@ public class ContikiMoteType extends BaseContikiMoteType {
     }
     return classes.toArray(new Class[0]);
   }
+
+  @Override
+  public Class<? extends MoteInterface>[] getDefaultMoteInterfaceClasses() {
+    return getAllMoteInterfaceClasses();
+  }
+
   /**
    * Returns make target based on source file.
    *

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -651,8 +651,13 @@ public abstract class AbstractCompileDialog extends JDialog {
     parent.addTab("Mote interfaces", null, panel, "Mote interfaces");
   }
 
-  public abstract Class<? extends MoteInterface>[] getDefaultMoteInterfaces();
-  public abstract Class<? extends MoteInterface>[] getAllMoteInterfaces();
+  public Class<? extends MoteInterface>[] getAllMoteInterfaces() {
+    return moteType.getAllMoteInterfaceClasses();
+  }
+
+  public Class<? extends MoteInterface>[] getDefaultMoteInterfaces() {
+    return moteType.getDefaultMoteInterfaceClasses();
+  }
 
   /**
    * Adds given mote interface to mote interface list, represented by a checkbox.

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -59,7 +59,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.Cooja;
-import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.contikimote.ContikiMoteType;
 import org.contikios.cooja.contikimote.ContikiMoteType.NetworkStack;
@@ -132,16 +131,6 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
 
     return Cooja.getExternalToolsSetting("PATH_MAKE") + " -j$(CPUS) " +
             ContikiMoteType.getMakeTargetName(name).getName() + " TARGET=cooja" + defines;
-  }
-
-  @Override
-  public Class<? extends MoteInterface>[] getAllMoteInterfaces() {
-    return ((ContikiMoteType)moteType).getAllMoteInterfaceClasses();
-  }
-
-  @Override
-  public Class<? extends MoteInterface>[] getDefaultMoteInterfaces() {
-	  return getAllMoteInterfaces();
   }
 
   private void addAdvancedTab(JTabbedPane parent) {

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -170,6 +170,9 @@ public abstract class BaseContikiMoteType implements MoteType {
     moteInterfaceClasses.addAll(Arrays.asList(moteInterfaces));
   }
 
+  public abstract Class<? extends MoteInterface>[] getAllMoteInterfaceClasses();
+  public abstract Class<? extends MoteInterface>[] getDefaultMoteInterfaceClasses();
+
   /** Target hook for adding additional information to view. */
   protected abstract void appendVisualizerInfo(StringBuilder sb);
 

--- a/java/org/contikios/cooja/mspmote/MspCompileDialog.java
+++ b/java/org/contikios/cooja/mspmote/MspCompileDialog.java
@@ -36,7 +36,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JTextArea;
 
-import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.dialogs.AbstractCompileDialog;
 
@@ -57,15 +56,6 @@ public class MspCompileDialog extends AbstractCompileDialog {
     super(parent, simulation, moteType);
     setTitle("Create Mote Type: Compile Contiki for " + moteType.getMoteType());
     addCompilationTipsTab(tabbedPane);
-  }
-
-  @Override
-  public Class<? extends MoteInterface>[] getAllMoteInterfaces() {
-	  return ((MspMoteType)moteType).getAllMoteInterfaceClasses();
-  }
-  @Override
-  public Class<? extends MoteInterface>[] getDefaultMoteInterfaces() {
-	  return ((MspMoteType)moteType).getDefaultMoteInterfaceClasses();
   }
 
   private static void addCompilationTipsTab(JTabbedPane parent) {

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -172,9 +172,6 @@ public abstract class MspMoteType extends BaseContikiMoteType {
     return configureAndInit(Cooja.getTopParentContainer(), simulation, visAvailable);
   }
 
-  public abstract Class<? extends MoteInterface>[] getAllMoteInterfaceClasses();
-  public abstract Class<? extends MoteInterface>[] getDefaultMoteInterfaceClasses();
-
   private ELF elf; /* cached */
   public ELF getELF() throws IOException {
     if (elf == null) {


### PR DESCRIPTION
The functionality is already implemented for all
mote types, it just resides in the compile dialog. Move the code to the mote type where it belongs.