### PR TITLE
AbstractCompileDialog: pass mote config to constructor

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -275,8 +275,8 @@ public class ContikiMoteType extends BaseContikiMoteType {
   }
 
   @Override
-  protected boolean showCompilationDialog(Simulation sim) {
-    return ContikiMoteCompileDialog.showDialog(sim, this);
+  protected boolean showCompilationDialog(Simulation sim, MoteTypeConfig cfg) {
+    return ContikiMoteCompileDialog.showDialog(sim, this, cfg);
   }
 
   /** Load LibN.java and the corresponding .cooja file into memory. */

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -126,7 +126,7 @@ public abstract class AbstractCompileDialog extends JDialog {
   public File contikiSource = null;
   public File contikiFirmware = null;
 
-  public AbstractCompileDialog(Simulation sim, final BaseContikiMoteType moteType) {
+  public AbstractCompileDialog(Simulation sim, final BaseContikiMoteType moteType, BaseContikiMoteType.MoteTypeConfig cfg) {
     super(Cooja.getTopParentContainer(), "Create Mote Type: Compile Contiki", ModalityType.APPLICATION_MODAL);
     this.simulation = sim;
     this.gui = sim.getCooja();
@@ -437,27 +437,16 @@ public abstract class AbstractCompileDialog extends JDialog {
     pack();
     setLocationRelativeTo(Cooja.getTopParentContainer());
     
-    tryRestoreMoteType();
+    tryRestoreMoteType(cfg);
   }
 
-  private void tryRestoreMoteType() {
-    var dialogState = DialogState.NO_SELECTION;
-    /* Restore description */
-    if (moteType.getDescription() != null) {
-      descriptionField.setText(moteType.getDescription());
-    }
-
-    /* Restore Contiki source or firmware */
-    final var source = moteType.getContikiSourceFile();
-    final var firmware = moteType.getContikiFirmwareFile();
-    if (source != null) {
-      contikiField.setText(source.getAbsolutePath());
-      dialogState = DialogState.SELECTED_SOURCE;
-    } else if (firmware != null) {
-      contikiField.setText(firmware.getAbsolutePath());
-      dialogState = DialogState.SELECTED_FIRMWARE;
-    }
-
+  private void tryRestoreMoteType(BaseContikiMoteType.MoteTypeConfig cfg) {
+    descriptionField.setText(cfg.desc());
+    var file = cfg.file();
+    contikiField.setText(file == null ? "" : file);
+    var dialogState = file == null
+            ? DialogState.NO_SELECTION
+            : file.endsWith(".c") ? DialogState.SELECTED_SOURCE : DialogState.SELECTED_FIRMWARE;
     /* Restore mote interface classes */
     for (Component c : moteIntfBox.getComponents()) {
       if (c instanceof JCheckBox box) {
@@ -467,13 +456,12 @@ public abstract class AbstractCompileDialog extends JDialog {
     for (var intf : getAllMoteInterfaces()) {
       addMoteInterface(intf, false);
     }
-    var moteClasses = moteType.getMoteInterfaceClasses();
-    for (var intf : moteClasses == null ? getDefaultMoteInterfaces() : moteClasses) {
+    for (var intf : cfg.interfaces()) {
       addMoteInterface(intf, true);
     }
 
     /* Restore compile commands */
-    final var commands = moteType.getCompileCommands();
+    final var commands = cfg.commands();
     if (commands != null) {
       commandsArea.setText(commands);
       dialogState = DialogState.AWAITING_COMPILATION;

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -73,14 +73,14 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
 
   private final JComboBox<?> netStackComboBox = new JComboBox<>(NetworkStack.values());
 
-  public static boolean showDialog(Simulation sim, ContikiMoteType mote) {
-    final var dialog = new ContikiMoteCompileDialog(sim, mote);
+  public static boolean showDialog(Simulation sim, ContikiMoteType mote, BaseContikiMoteType.MoteTypeConfig cfg) {
+    final var dialog = new ContikiMoteCompileDialog(sim, mote, cfg);
     dialog.setVisible(true); // Blocks.
     return dialog.createdOK();
   }
 
-  private ContikiMoteCompileDialog(Simulation sim, ContikiMoteType moteType) {
-    super(sim, moteType);
+  private ContikiMoteCompileDialog(Simulation sim, ContikiMoteType moteType, BaseContikiMoteType.MoteTypeConfig cfg) {
+    super(sim, moteType, cfg);
     /* Add Contiki mote type specifics */
     addAdvancedTab(tabbedPane);
   }

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -298,7 +298,12 @@ public abstract class BaseContikiMoteType implements MoteType {
         setDescription(getMoteName() + " Mote Type #" + (sim.getMoteTypes().length + 1));
       }
 
-      if (!showCompilationDialog(sim)) {
+      final var source = getContikiSourceFile();
+      final var firmware = getContikiFirmwareFile();
+      String file = source != null ? source.getAbsolutePath() : firmware != null ? firmware.getAbsolutePath() : null;
+      var moteClasses = getMoteInterfaceClasses();
+      var interfaces = moteClasses == null ? getDefaultMoteInterfaceClasses() : moteClasses;
+      if (!showCompilationDialog(sim, new MoteTypeConfig(getDescription(), file, getCompileCommands(), interfaces))) {
         return false;
       }
     } else {
@@ -321,8 +326,11 @@ public abstract class BaseContikiMoteType implements MoteType {
     return true;
   }
 
+  /** Compilation-relevant parts of mote type configuration. */
+  public record MoteTypeConfig(String desc, String file, String commands, Class<? extends MoteInterface>[] interfaces) {}
+
   /** Show a compilation dialog for this mote type. */
-  protected abstract boolean showCompilationDialog(Simulation sim);
+  protected abstract boolean showCompilationDialog(Simulation sim, MoteTypeConfig cfg);
 
   /** Return a two-dimensional compilation environment. */
   public String[][] getCompilationEnvironment() {

--- a/java/org/contikios/cooja/mspmote/MspCompileDialog.java
+++ b/java/org/contikios/cooja/mspmote/MspCompileDialog.java
@@ -36,17 +36,18 @@ import javax.swing.JTextArea;
 
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.dialogs.AbstractCompileDialog;
+import org.contikios.cooja.mote.BaseContikiMoteType;
 
 public class MspCompileDialog extends AbstractCompileDialog {
-  public static boolean showDialog(Simulation sim, MspMoteType moteType) {
-    final AbstractCompileDialog dialog = new MspCompileDialog(sim, moteType);
+  public static boolean showDialog(Simulation sim, MspMoteType moteType, BaseContikiMoteType.MoteTypeConfig cfg) {
+    final var dialog = new MspCompileDialog(sim, moteType, cfg);
     /* Show dialog and wait for user */
     dialog.setVisible(true); /* BLOCKS */
     return dialog.createdOK();
   }
 
-  private MspCompileDialog(Simulation sim, MspMoteType moteType) {
-    super(sim, moteType);
+  private MspCompileDialog(Simulation sim, MspMoteType moteType, BaseContikiMoteType.MoteTypeConfig cfg) {
+    super(sim, moteType, cfg);
     setTitle("Create Mote Type: Compile Contiki for " + moteType.getMoteType());
     addCompilationTipsTab(tabbedPane);
   }

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -44,7 +44,6 @@ import org.jdom.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
-import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.Simulation;
 import se.sics.mspsim.util.DebugInfo;
 import se.sics.mspsim.util.ELF;
@@ -61,8 +60,8 @@ public abstract class MspMoteType extends BaseContikiMoteType {
   private static final Logger logger = LogManager.getLogger(MspMoteType.class);
 
   @Override
-  protected boolean showCompilationDialog(Simulation sim) {
-    return MspCompileDialog.showDialog(sim, this);
+  protected boolean showCompilationDialog(Simulation sim, MoteTypeConfig cfg) {
+    return MspCompileDialog.showDialog(sim, this, cfg);
   }
 
   @Override


### PR DESCRIPTION
Package the mote configuration into a record
and pass that from the caller instead of having
the dialog querying the mote type to figure out
the configuration.