### PR TITLE
Simplify compile()

### DIFF
--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -332,7 +332,7 @@ public abstract class AbstractCompileDialog extends JDialog {
 							new File(contikiField.getText()).getParentFile(),
 							null,
 							null,
-							null,
+              new MessageListUI(),
 							true
 					);
 				} catch (Exception e1) {

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -59,6 +59,7 @@ import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.contikimote.ContikiMoteType;
 import org.contikios.cooja.contikimote.ContikiMoteType.NetworkStack;
+import org.contikios.cooja.mote.BaseContikiMoteType;
 
 /**
  * Contiki Mote Type compile dialog.

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -44,7 +44,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.swing.Action;
@@ -347,7 +346,7 @@ public abstract class BaseContikiMoteType implements MoteType {
    * @param directory Directory in which to execute command
    * @param onSuccess Action called if compilation succeeds
    * @param onFailure Action called if compilation fails
-   * @param compilationOutput Is written both std and err process output
+   * @param messageDialog Is written both std and err process output
    * @param synchronous If true, method blocks until process completes
    * @return Sub-process if called asynchronously
    * @throws MoteTypeCreationException If process returns error, or outputFile does not exist
@@ -358,7 +357,7 @@ public abstract class BaseContikiMoteType implements MoteType {
           final File directory,
           final Action onSuccess,
           final Action onFailure,
-          final MessageList compilationOutput,
+          final MessageList messageDialog,
           boolean synchronous)
           throws MoteTypeCreationException {
     Pattern p = Pattern.compile("([^\\s\"']+|\"[^\"]*\"|'[^']*')");
@@ -373,9 +372,6 @@ public abstract class BaseContikiMoteType implements MoteType {
       }
       commandList.add(arg);
     }
-
-    final MessageList messageDialog =
-            Objects.requireNonNullElseGet(compilationOutput, () -> MessageContainer.createMessageList(true));
     messageDialog.addMessage("> " + String.join(" ", commandList), MessageList.NORMAL);
     final var pb = new ProcessBuilder(commandList).directory(directory);
     if (env != null) {


### PR DESCRIPTION
Ensure the required parameters are allocated by the callers, and move out non-throwing code from the try-block.