### PR TITLE
AbstractCompileDialog improvements

### DIFF
--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -454,9 +454,6 @@ public abstract class AbstractCompileDialog extends JDialog {
         box.setSelected(false);
       }
     }
-    for (var intf : getAllMoteInterfaces()) {
-      addMoteInterface(intf, false);
-    }
     for (var intf : cfg.interfaces()) {
       addMoteInterface(intf, true);
     }
@@ -617,6 +614,9 @@ public abstract class AbstractCompileDialog extends JDialog {
     panel.add(BorderLayout.NORTH, b);
     panel.add(BorderLayout.CENTER, new JScrollPane(moteIntfBox));
     parent.addTab("Mote interfaces", null, panel, "Mote interfaces");
+    for (var moteInterfaces : getAllMoteInterfaces()) {
+      addMoteInterface(moteInterfaces, false);
+    }
   }
 
   public Class<? extends MoteInterface>[] getAllMoteInterfaces() {

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -437,23 +437,17 @@ public abstract class AbstractCompileDialog extends JDialog {
 
     pack();
     setLocationRelativeTo(Cooja.getTopParentContainer());
-    
-    tryRestoreMoteType(cfg);
-  }
 
-  private void tryRestoreMoteType(BaseContikiMoteType.MoteTypeConfig cfg) {
+    // Set default values of text fields from the MoteTypeConfig contents.
     descriptionField.setText(cfg.desc());
     var file = cfg.file();
     contikiField.setText(file == null ? "" : file);
     var dialogState = file == null
             ? DialogState.NO_SELECTION
             : file.endsWith(".c") ? DialogState.SELECTED_SOURCE : DialogState.SELECTED_FIRMWARE;
-    /* Restore mote interface classes */
     for (var intf : cfg.interfaces()) {
       addMoteInterface(intf, true);
     }
-
-    /* Restore compile commands */
     final var commands = cfg.commands();
     if (commands != null) {
       commandsArea.setText(commands);

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -600,7 +600,7 @@ public abstract class AbstractCompileDialog extends JDialog {
         }
 
         // Select default.
-        for (Class<? extends MoteInterface> moteIntf : getDefaultMoteInterfaces()) {
+        for (var moteIntf : moteType.getDefaultMoteInterfaceClasses()) {
           addMoteInterface(moteIntf, true);
         }
       }
@@ -609,17 +609,9 @@ public abstract class AbstractCompileDialog extends JDialog {
     panel.add(BorderLayout.NORTH, b);
     panel.add(BorderLayout.CENTER, new JScrollPane(moteIntfBox));
     parent.addTab("Mote interfaces", null, panel, "Mote interfaces");
-    for (var moteInterfaces : getAllMoteInterfaces()) {
+    for (var moteInterfaces : moteType.getAllMoteInterfaceClasses()) {
       addMoteInterface(moteInterfaces, false);
     }
-  }
-
-  public Class<? extends MoteInterface>[] getAllMoteInterfaces() {
-    return moteType.getAllMoteInterfaceClasses();
-  }
-
-  public Class<? extends MoteInterface>[] getDefaultMoteInterfaces() {
-    return moteType.getDefaultMoteInterfaceClasses();
   }
 
   /**

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -449,11 +449,6 @@ public abstract class AbstractCompileDialog extends JDialog {
             ? DialogState.NO_SELECTION
             : file.endsWith(".c") ? DialogState.SELECTED_SOURCE : DialogState.SELECTED_FIRMWARE;
     /* Restore mote interface classes */
-    for (Component c : moteIntfBox.getComponents()) {
-      if (c instanceof JCheckBox box) {
-        box.setSelected(false);
-      }
-    }
     for (var intf : cfg.interfaces()) {
       addMoteInterface(intf, true);
     }

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -59,6 +59,7 @@ import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.contikimote.ContikiMoteType;
 import org.contikios.cooja.contikimote.ContikiMoteType.NetworkStack;
+import org.contikios.cooja.mote.BaseContikiMoteType;
 
 /**
  * Contiki Mote Type compile dialog.


### PR DESCRIPTION
Make the dialog big enough to avoid scrollbars for the interfaces by moving around some code. Also remove some dead code, inline some single-use methods, and pull more code into the constructor.