### PR TITLE
Move mote ID allocation code to ContikiMoteType

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -40,6 +40,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Random;
@@ -277,6 +278,13 @@ public class ContikiMoteType extends BaseContikiMoteType {
 
   @Override
   protected boolean showCompilationDialog(Simulation sim, MoteTypeConfig cfg) {
+    if (getIdentifier() == null) {
+      var usedNames = new HashSet<String>();
+      for (var mote : sim.getMoteTypes()) {
+        usedNames.add(mote.getIdentifier());
+      }
+      setIdentifier(generateUniqueMoteTypeID(usedNames));
+    }
     return ContikiMoteCompileDialog.showDialog(sim, this, cfg);
   }
 

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -36,9 +36,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.lang.reflect.InvocationTargetException;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.HashSet;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.JButton;
@@ -90,13 +87,6 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
 
   @Override
   public String getDefaultCompileCommands(String name) {
-    if (moteType.getIdentifier() == null) {
-      var usedNames = new HashSet<String>();
-      for (var mote : simulation.getMoteTypes()) {
-        usedNames.add(mote.getIdentifier());
-      }
-      moteType.setIdentifier(ContikiMoteType.generateUniqueMoteTypeID(usedNames));
-    }
     compilationEnvironment = moteType.getCompilationEnvironment();
     var env = compilationEnvironment.entrySet().stream()
             .map(e -> new Object[]{e.getKey(), e.getValue()}).toArray(Object[][]::new);

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -90,10 +90,6 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
 
   @Override
   public String getDefaultCompileCommands(String name) {
-    if (name == null || !Files.exists(Path.of(name))) {
-      return ""; // Not ready to compile yet.
-    }
-
     if (moteType.getIdentifier() == null) {
       var usedNames = new HashSet<String>();
       for (var mote : simulation.getMoteTypes()) {


### PR DESCRIPTION
Remove a spurious error check and move the mote ID allocation code to ContikiMoteType.