### PR TITLE
AbstractCompileDialog: remove compilationEnvironment

### DIFF
--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -301,7 +301,7 @@ public abstract class AbstractCompileDialog extends JDialog {
             try {
               currentCompilationProcess = BaseContikiMoteType.compile(
                   command,
-                  compilationEnvironment,
+                  moteType.getCompilationEnvironment(),
                   new File(contikiField.getText()).getParentFile(),
                   commands.isEmpty() ? compilationSuccessAction : this,
                   compilationFailureAction,
@@ -328,7 +328,7 @@ public abstract class AbstractCompileDialog extends JDialog {
 				try {
 					currentCompilationProcess = BaseContikiMoteType.compile(
 							"make clean TARGET=" + moteType.getMoteType(),
-							compilationEnvironment,
+              moteType.getCompilationEnvironment(),
 							new File(contikiField.getText()).getParentFile(),
 							null,
 							null,
@@ -467,8 +467,6 @@ public abstract class AbstractCompileDialog extends JDialog {
   }
 
   public abstract boolean canLoadFirmware(String name);
-
-  protected LinkedHashMap<String, String> compilationEnvironment = null; // Default environment: inherit from current process.
 
   /**
    * @see DialogState


### PR DESCRIPTION
Stop holding the state in the dialog and just query the mote type for the environment on each call to compile.

This required putting the environment tab in the tab pane before a source file has been selected, but that does not make anything worse.

Also remove the code that is supposed to select the environment tab after modifying the environment. The environment tab is already selected since the button is in that tab, so the effect of the code was to select the advanced tab instead.