### PR TITLE
Make compile dialogs return MoteTypeConfigs

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -68,6 +68,7 @@ import org.contikios.cooja.contikimote.interfaces.ContikiPIR;
 import org.contikios.cooja.contikimote.interfaces.ContikiRS232;
 import org.contikios.cooja.contikimote.interfaces.ContikiRadio;
 import org.contikios.cooja.contikimote.interfaces.ContikiVib;
+import org.contikios.cooja.dialogs.AbstractCompileDialog;
 import org.contikios.cooja.dialogs.ContikiMoteCompileDialog;
 import org.contikios.cooja.dialogs.MessageContainer;
 import org.contikios.cooja.dialogs.MessageList;
@@ -277,7 +278,7 @@ public class ContikiMoteType extends BaseContikiMoteType {
   }
 
   @Override
-  protected boolean showCompilationDialog(Simulation sim, MoteTypeConfig cfg) {
+  protected AbstractCompileDialog createCompilationDialog(Simulation sim, MoteTypeConfig cfg) {
     if (getIdentifier() == null) {
       var usedNames = new HashSet<String>();
       for (var mote : sim.getMoteTypes()) {
@@ -285,7 +286,7 @@ public class ContikiMoteType extends BaseContikiMoteType {
       }
       setIdentifier(generateUniqueMoteTypeID(usedNames));
     }
-    return ContikiMoteCompileDialog.showDialog(sim, this, cfg);
+    return new ContikiMoteCompileDialog(sim, this, cfg);
   }
 
   /** Load LibN.java and the corresponding .cooja file into memory. */

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -62,13 +62,7 @@ import org.contikios.cooja.mote.BaseContikiMoteType;
 public class ContikiMoteCompileDialog extends AbstractCompileDialog {
   private final JComboBox<?> netStackComboBox = new JComboBox<>(NetworkStack.values());
 
-  public static boolean showDialog(Simulation sim, ContikiMoteType mote, BaseContikiMoteType.MoteTypeConfig cfg) {
-    final var dialog = new ContikiMoteCompileDialog(sim, mote, cfg);
-    dialog.setVisible(true); // Blocks.
-    return dialog.createdOK();
-  }
-
-  private ContikiMoteCompileDialog(Simulation sim, ContikiMoteType moteType, BaseContikiMoteType.MoteTypeConfig cfg) {
+  public ContikiMoteCompileDialog(Simulation sim, ContikiMoteType moteType, BaseContikiMoteType.MoteTypeConfig cfg) {
     super(sim, moteType, cfg);
     /* Add Contiki mote type specifics */
     addAdvancedTab(tabbedPane);

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -58,6 +58,7 @@ import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.ProjectConfig;
 import org.contikios.cooja.Simulation;
+import org.contikios.cooja.dialogs.AbstractCompileDialog;
 import org.contikios.cooja.dialogs.MessageContainer;
 import org.contikios.cooja.dialogs.MessageList;
 import org.contikios.cooja.util.StringUtils;
@@ -330,8 +331,15 @@ public abstract class BaseContikiMoteType implements MoteType {
   /** Compilation-relevant parts of mote type configuration. */
   public record MoteTypeConfig(String desc, String file, String commands, Class<? extends MoteInterface>[] interfaces) {}
 
+  /** Create a compilation dialog for this mote type. */
+  protected abstract AbstractCompileDialog createCompilationDialog(Simulation sim, MoteTypeConfig cfg);
+
   /** Show a compilation dialog for this mote type. */
-  protected abstract boolean showCompilationDialog(Simulation sim, MoteTypeConfig cfg);
+  protected boolean showCompilationDialog(Simulation sim, MoteTypeConfig cfg) {
+    final var dialog = createCompilationDialog(sim, cfg);
+    dialog.setVisible(true); // Blocks.
+    return dialog.createdOK();
+  }
 
   /** Return a compilation environment. */
   public LinkedHashMap<String, String> getCompilationEnvironment() {

--- a/java/org/contikios/cooja/mspmote/MspCompileDialog.java
+++ b/java/org/contikios/cooja/mspmote/MspCompileDialog.java
@@ -39,14 +39,7 @@ import org.contikios.cooja.dialogs.AbstractCompileDialog;
 import org.contikios.cooja.mote.BaseContikiMoteType;
 
 public class MspCompileDialog extends AbstractCompileDialog {
-  public static boolean showDialog(Simulation sim, MspMoteType moteType, BaseContikiMoteType.MoteTypeConfig cfg) {
-    final var dialog = new MspCompileDialog(sim, moteType, cfg);
-    /* Show dialog and wait for user */
-    dialog.setVisible(true); /* BLOCKS */
-    return dialog.createdOK();
-  }
-
-  private MspCompileDialog(Simulation sim, MspMoteType moteType, BaseContikiMoteType.MoteTypeConfig cfg) {
+  public MspCompileDialog(Simulation sim, MspMoteType moteType, BaseContikiMoteType.MoteTypeConfig cfg) {
     super(sim, moteType, cfg);
     setTitle("Create Mote Type: Compile Contiki for " + moteType.getMoteType());
     addCompilationTipsTab(tabbedPane);

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.contikios.cooja.dialogs.AbstractCompileDialog;
 import org.contikios.cooja.mote.BaseContikiMoteType;
 import org.jdom.Element;
 
@@ -59,8 +60,8 @@ public abstract class MspMoteType extends BaseContikiMoteType {
   private static final Logger logger = LogManager.getLogger(MspMoteType.class);
 
   @Override
-  protected boolean showCompilationDialog(Simulation sim, MoteTypeConfig cfg) {
-    return MspCompileDialog.showDialog(sim, this, cfg);
+  protected AbstractCompileDialog createCompilationDialog(Simulation sim, MoteTypeConfig cfg) {
+    return new MspCompileDialog(sim, this, cfg);
   }
 
   @Override


### PR DESCRIPTION
This puts the plumbing in place for getting the configuration from the dialog with a MoteTypeConfig. Untangling the state inside AbstractCompileDialog is still challenging, so do that in future commits.