### PR TITLE
Cooja: remove external tools printouts

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2802,10 +2802,8 @@ public class Cooja extends Observable {
                 "Could not find " + filename + ", jar file seems broken", "Cooja", "");
       }
       settings.load(in);
-
       currentExternalToolsSettings = settings;
       defaultExternalToolsSettings = (Properties) currentExternalToolsSettings.clone();
-      logger.info("External tools default settings: " + filename);
     } catch (IOException e) {
       throw new MissingResourceException(e.getMessage(), "Cooja", "");
     }

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2826,7 +2826,6 @@ public class Cooja extends Observable {
         String key = (String) en.nextElement();
         setExternalToolsSetting(key, settings.getProperty(key));
       }
-      logger.info("External tools user settings: " + externalToolsUserSettingsFile);
     } catch (IOException e) {
       logger.warn("Error when reading user settings from: " + externalToolsUserSettingsFile);
     }


### PR DESCRIPTION
Remove the printouts of external tools settings files. The OS-specific file cannot be altered by the user, and the user-specific file is used/changed by the GUI so the console printout is not useful.

These changes prints the simulation file/seed, the compilation, and then the simulation status/progress updates. An example output of this with `QUIET=1`:
```
 INFO [main] (Simulation.java:385) - Simulation /home/user/contiki-ng/tests/07-simulation-base/02-ringbufindex.csc random seed: 1
> make TARGET=cooja clean
> make -j12 test-ringbufindex.cooja TARGET=cooja
 INFO [main] (LogScriptEngine.java:238) - Script timeout in 10000 ms
 INFO [sim] (LogScriptEngine.java:351) -  5% completed, 0.0 sec remaining
 INFO [script] (LogScriptEngine.java:277) - TEST OK

 INFO [sim] (Simulation.java:240) - Runtime: 63 ms. Simulated time: 549 ms. Speedup: 8.714285714285714
```