### PR TITLE
Allocate mote types in one place

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2881,8 +2881,10 @@ public class Cooja extends Observable {
         // Create mote type
         var clazz = (Class<? extends MoteType>) ((JMenuItem) e.getSource()).getClientProperty("class");
         try {
-          newMoteType = clazz == ContikiMoteType.class
-                  ? new ContikiMoteType(cooja) : clazz.getDeclaredConstructor().newInstance();
+          newMoteType = MoteInterfaceHandler.createMoteType(Cooja.this, clazz.getName());
+          if (newMoteType == null) {
+            newMoteType = clazz.getDeclaredConstructor().newInstance();
+          }
           if (!newMoteType.configureAndInit(Cooja.getTopParentContainer(), cooja.mySimulation, isVisualized())) {
             return;
           }

--- a/java/org/contikios/cooja/MoteInterfaceHandler.java
+++ b/java/org/contikios/cooja/MoteInterfaceHandler.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.contikios.cooja.contikimote.ContikiMoteType;
 import org.contikios.cooja.contikimote.interfaces.ContikiBeeper;
 import org.contikios.cooja.contikimote.interfaces.ContikiButton;
 import org.contikios.cooja.contikimote.interfaces.ContikiCFS;
@@ -62,6 +63,10 @@ import org.contikios.cooja.interfaces.PIR;
 import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.interfaces.RimeAddress;
+import org.contikios.cooja.motes.DisturberMoteType;
+import org.contikios.cooja.motes.ImportAppMoteType;
+import org.contikios.cooja.mspmote.SkyMoteType;
+import org.contikios.cooja.mspmote.Z1MoteType;
 import org.contikios.cooja.mspmote.interfaces.Msp802154Radio;
 import org.contikios.cooja.mspmote.interfaces.MspClock;
 import org.contikios.cooja.mspmote.interfaces.MspDebugOutput;
@@ -146,6 +151,22 @@ public class MoteInterfaceHandler {
         throw new MoteType.MoteTypeCreationException("Exception when calling constructor of " + interfaceClass, e);
       }
     }
+  }
+
+  /** Fast translation from class name to object for builtin mote types.
+   * @param cooja Cooja
+   * @param name Name of mote type to create
+   * @return Object or null
+   */
+  public static MoteType createMoteType(Cooja cooja, String name) {
+    return switch (name) {
+      case "org.contikios.cooja.motes.ImportAppMoteType" -> new ImportAppMoteType();
+      case "org.contikios.cooja.motes.DisturberMoteType" -> new DisturberMoteType();
+      case "org.contikios.cooja.contikimote.ContikiMoteType" -> new ContikiMoteType(cooja);
+      case "org.contikios.cooja.mspmote.SkyMoteType" -> new SkyMoteType();
+      case "org.contikios.cooja.mspmote.Z1MoteType" -> new Z1MoteType();
+      default -> null;
+    };
   }
 
   /** Fast translation from class name to class file for builtin interfaces. Uses the classloader

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -40,11 +40,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JTextArea;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.contikios.cooja.contikimote.ContikiMoteType;
-import org.contikios.cooja.motes.DisturberMoteType;
-import org.contikios.cooja.motes.ImportAppMoteType;
-import org.contikios.cooja.mspmote.SkyMoteType;
-import org.contikios.cooja.mspmote.Z1MoteType;
 import org.jdom.Element;
 
 import org.contikios.cooja.dialogs.CreateSimDialog;
@@ -635,34 +630,17 @@ public class Simulation extends Observable implements Runnable {
             }
           }
 
-          MoteType moteType;
-          switch (moteTypeClassName) {
-            case "org.contikios.cooja.motes.ImportAppMoteType":
-              moteType = new ImportAppMoteType();
-              break;
-            case "org.contikios.cooja.motes.DisturberMoteType":
-              moteType = new DisturberMoteType();
-              break;
-            case "org.contikios.cooja.contikimote.ContikiMoteType":
-              moteType = new ContikiMoteType(getCooja());
-              break;
-            case "org.contikios.cooja.mspmote.SkyMoteType":
-              moteType = new SkyMoteType();
-              break;
-            case "org.contikios.cooja.mspmote.Z1MoteType":
-              moteType = new Z1MoteType();
-              break;
-            default:
-              Class<? extends MoteType> moteTypeClass = null;
-              for (int i = 0; i < availableMoteTypes.length; i++) {
-                if (moteTypeClassName.equals(availableMoteTypes[i])) {
-                  moteTypeClass = availableMoteTypesObjs.get(i);
-                  break;
-                }
+          var moteType = MoteInterfaceHandler.createMoteType(getCooja(), moteTypeClassName);
+          if (moteType == null) {
+            Class<? extends MoteType> moteTypeClass = null;
+            for (int i = 0; i < availableMoteTypes.length; i++) {
+              if (moteTypeClassName.equals(availableMoteTypes[i])) {
+                moteTypeClass = availableMoteTypesObjs.get(i);
+                break;
               }
-              assert moteTypeClass != null : "Selected MoteType class is null";
-              moteType = moteTypeClass.getConstructor((Class<? extends MoteType>[]) null).newInstance();
-              break;
+            }
+            assert moteTypeClass != null : "Selected MoteType class is null";
+            moteType = moteTypeClass.getConstructor((Class<? extends MoteType>[]) null).newInstance();
           }
           if (!moteType.setConfigXML(this, element.getChildren(), visAvailable)) {
             logger.fatal("Mote type was not created: " + element.getText().trim());


### PR DESCRIPTION
MoteInterfaceHandler is not the perfect
place for mote type allocation, but
the other code that allocates other
things relating to motes already resides
there so group it together for now.