### PR TITLE
Tweak script engine shutdown routine

### DIFF
--- a/java/org/contikios/cooja/LogScriptEngine.java
+++ b/java/org/contikios/cooja/LogScriptEngine.java
@@ -123,7 +123,7 @@ public class LogScriptEngine {
   private long startTime;
   private long startRealTime;
 
-  public LogScriptEngine(Simulation simulation, JTextArea logTextArea) {
+  protected LogScriptEngine(Simulation simulation, JTextArea logTextArea) {
     this.simulation = simulation;
     if (!Cooja.isVisualized()) {
       var logName = engineInstances++ == 0 ? "COOJA.testlog" : String.format("COOJA-%02d.testlog", engineInstances);
@@ -175,7 +175,7 @@ public class LogScriptEngine {
     /* ... script is now again waiting for script semaphore ... */
   }
 
-  public void closeLog() {
+  protected void closeLog() {
     if (Cooja.isVisualized()) {
       return;
     }

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -289,6 +289,7 @@ public class Simulation extends Observable implements Runnable {
 
   /** Remove a script engine from the list of active script engines. */
   public void removeScriptEngine(LogScriptEngine engine) {
+    engine.deactivateScript();
     engine.closeLog();
     scriptEngines.remove(engine);
   }

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -172,7 +172,10 @@ public class ScriptRunner implements Plugin {
     final JCheckBoxMenuItem activateMenuItem = new JCheckBoxMenuItem("Activate");
     activateMenuItem.addActionListener(ev -> {
       if (activated) {
-        deactivateScript();
+        engine.deactivateScript();
+        codeEditor.setEnabled(true);
+        updateTitle();
+        activated = false;
       } else {
         activateScript();
       }
@@ -258,15 +261,6 @@ public class ScriptRunner implements Plugin {
       Cooja.setExternalToolsSetting("SCRIPTRUNNER_LAST_SCRIPTFILE", source.getAbsolutePath());
     }
     return true;
-  }
-
-  private void deactivateScript() {
-    engine.deactivateScript();
-    if (Cooja.isVisualized()) {
-      codeEditor.setEnabled(true);
-      updateTitle();
-    }
-    activated = false;
   }
 
   private boolean activateScript() {

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -173,9 +173,9 @@ public class ScriptRunner implements Plugin {
     activateMenuItem.addActionListener(ev -> {
       if (activated) {
         engine.deactivateScript();
+        activated = false;
         codeEditor.setEnabled(true);
         updateTitle();
-        activated = false;
       } else {
         activateScript();
       }
@@ -278,12 +278,12 @@ public class ScriptRunner implements Plugin {
     if (!engine.activateScript(script)) {
       return false;
     }
+    activated = true;
     if (Cooja.isVisualized()) {
       logTextArea.setText("");
       codeEditor.setEnabled(false);
       updateTitle();
     }
-    activated = true;
     return true;
   }
 

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -378,7 +378,6 @@ public class ScriptRunner implements Plugin {
   @Override
   public void closePlugin() {
     checkForUpdatesAndSave();
-    deactivateScript();
     simulation.removeScriptEngine(engine);
   }
 

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -171,7 +171,7 @@ public class ScriptRunner implements Plugin {
 
     final JCheckBoxMenuItem activateMenuItem = new JCheckBoxMenuItem("Activate");
     activateMenuItem.addActionListener(ev -> {
-      if (isActive()) {
+      if (activated) {
         deactivateScript();
       } else {
         activateScript();
@@ -189,8 +189,8 @@ public class ScriptRunner implements Plugin {
     MenuListener toggleMenuItems = new MenuListener() {
       @Override
       public void menuSelected(MenuEvent e) {
-        activateMenuItem.setSelected(isActive());
-        examplesMenu.setEnabled(!isActive());
+        activateMenuItem.setSelected(activated);
+        examplesMenu.setEnabled(!activated);
       }
       @Override
       public void menuDeselected(MenuEvent e) {
@@ -298,7 +298,7 @@ public class ScriptRunner implements Plugin {
     if (linkedFile != null) {
       title += " (" + linkedFile.getName() + ")";
     }
-    if (isActive()) {
+    if (activated) {
       title += " *active*";
     }
     frame.setTitle(title);
@@ -366,17 +366,13 @@ public class ScriptRunner implements Plugin {
       config.add(element);
     }
 
-    if (isActive()) {
+    if (activated) {
       Element element = new Element("active");
       element.setText(String.valueOf(true));
       config.add(element);
     }
 
     return config;
-  }
-
-  public boolean isActive() {
-    return activated;
   }
 
   @Override


### PR DESCRIPTION
Ensure removeScriptEngine deactivates the script, reduce visibility of methods, and make the editor title reflect the actual activation status of the script.