### PR TITLE
Stop after project parse error in headless mode

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -325,13 +325,17 @@ public class Cooja extends Observable {
    * @param logDirectory Directory for log files
    * @param vis          True if running in visual mode
    */
-  public static Cooja makeCooja(final String logDirectory, final boolean vis) {
+  public static Cooja makeCooja(final String logDirectory, final boolean vis) throws ParseProjectsException {
     if (vis) {
       assert !java.awt.EventQueue.isDispatchThread() : "Call from regular context";
       return new RunnableInEDT<Cooja>() {
         @Override
         public Cooja work() {
-          return new Cooja(logDirectory, vis);
+          try {
+            return new Cooja(logDirectory, vis);
+          } catch (ParseProjectsException e) {
+            throw new RuntimeException("Cooja constructor should never throw ParseProjectsException in GUI mode", e);
+          }
         }
       }.invokeAndWait();
     }
@@ -345,7 +349,7 @@ public class Cooja extends Observable {
    * @param logDirectory Directory for log files
    * @param vis          True if running in visual mode
    */
-  private Cooja(String logDirectory, boolean vis) {
+  private Cooja(String logDirectory, boolean vis) throws ParseProjectsException {
     cooja = this;
     this.logDirectory = logDirectory;
     mySimulation = null;
@@ -387,11 +391,7 @@ public class Cooja extends Observable {
       menuMoteTypes = null;
       moteHighlightObservable = null;
       moteRelationObservable = null;
-      try {
-        parseProjectConfig();
-      } catch (ParseProjectsException e) {
-        logger.fatal("Error when loading extensions: " + e.getMessage(), e);
-      }
+      parseProjectConfig();
       return;
     }
 
@@ -1672,13 +1672,9 @@ public class Cooja extends Observable {
     try {
       projectConfig = new ProjectConfig(true);
     } catch (FileNotFoundException e) {
-      logger.fatal("Could not find default extension config file: " + PROJECT_DEFAULT_CONFIG_FILENAME);
-      throw new ParseProjectsException(
-          "Could not find default extension config file: " + PROJECT_DEFAULT_CONFIG_FILENAME, e);
+      throw new ParseProjectsException("Could not find default extension config file: " + e.getMessage(), e);
     } catch (IOException e) {
-      logger.fatal("Error when reading default extension config file: " + PROJECT_DEFAULT_CONFIG_FILENAME);
-      throw new ParseProjectsException(
-          "Error when reading default extension config file: " + PROJECT_DEFAULT_CONFIG_FILENAME, e);
+      throw new ParseProjectsException("Error when reading default extension config file: " + e.getMessage(), e);
     }
     for (COOJAProject project: currentProjects) {
       try {

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -212,11 +212,6 @@ public class Cooja extends Observable {
   private static String specifiedContikiPath = null;
 
   /**
-   * Default extension configuration filename.
-   */
-  public static final String PROJECT_DEFAULT_CONFIG_FILENAME = "/cooja_default.config";
-
-  /**
    * User extension configuration filename.
    */
   public static final String PROJECT_CONFIG_FILENAME = "cooja.config";

--- a/java/org/contikios/cooja/ProjectConfig.java
+++ b/java/org/contikios/cooja/ProjectConfig.java
@@ -92,6 +92,11 @@ import org.apache.logging.log4j.LogManager;
 public class ProjectConfig {
   private static final Logger logger = LogManager.getLogger(ProjectConfig.class);
 
+  /**
+   * Default extension configuration filename.
+   */
+  public static final String PROJECT_DEFAULT_CONFIG_FILENAME = "/cooja_default.config";
+
   private Properties myConfig = new Properties();
   private ArrayList<File> myProjectDirHistory = new ArrayList<>();
 
@@ -108,14 +113,13 @@ public class ProjectConfig {
   public ProjectConfig(boolean useDefault) throws IOException,
       FileNotFoundException {
     if (useDefault) {
-      InputStream input = Cooja.class
-          .getResourceAsStream(Cooja.PROJECT_DEFAULT_CONFIG_FILENAME);
+      var input = Cooja.class.getResourceAsStream(PROJECT_DEFAULT_CONFIG_FILENAME);
       if (input != null) {
         try (input) {
           appendConfigStream(input);
         }
       } else {
-        throw new FileNotFoundException(Cooja.PROJECT_DEFAULT_CONFIG_FILENAME);
+        throw new FileNotFoundException(PROJECT_DEFAULT_CONFIG_FILENAME);
       }
     }
   }


### PR DESCRIPTION
Propagate exceptions so Cooja stops upon failure in headless mode.

Also move the field with the file name from Cooja to ProjectConfig where it is used.