### PR TITLE
Cooja: fix warnMemory return value

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2554,8 +2554,7 @@ public class Cooja extends Observable {
           new String[] { "Continue", "Abort"}, "Abort");
       return n != JOptionPane.YES_OPTION;
     }
-
-    return false;
+    return true;
   }
 
   /**


### PR DESCRIPTION
Return true in headless mode when low
on memory.