### PR TITLE
Improve COOJAProject code

### DIFF
--- a/java/org/contikios/cooja/COOJAProject.java
+++ b/java/org/contikios/cooja/COOJAProject.java
@@ -64,7 +64,7 @@ public class COOJAProject {
 					Collections.addAll(dirs, newf);
 				}
 			}
-			if(subf.getName().equals(Cooja.PROJECT_CONFIG_FILENAME)){
+			if(subf.getName().equals(ProjectConfig.PROJECT_CONFIG_FILENAME)){
 				try{
 					dirs.add(folder);
 				} catch(Exception e){
@@ -85,7 +85,7 @@ public class COOJAProject {
 	public COOJAProject(File dir) {
 		try {
 			this.dir = dir;
-			configFile = new File(dir.getPath(), Cooja.PROJECT_CONFIG_FILENAME);
+			configFile = new File(dir.getPath(), ProjectConfig.PROJECT_CONFIG_FILENAME);
 			config = new ProjectConfig(false);
 			config.appendConfigFile(configFile);
 		} catch (Exception e) {

--- a/java/org/contikios/cooja/COOJAProject.java
+++ b/java/org/contikios/cooja/COOJAProject.java
@@ -29,6 +29,7 @@
 package org.contikios.cooja;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -76,22 +77,17 @@ public class COOJAProject {
 		
 	}
 
-	
-	public File dir = null;
-	public File configFile = null;
-	public ProjectConfig config = null;
-	
 
-	public COOJAProject(File dir) {
-		try {
-			this.dir = dir;
-			configFile = new File(dir.getPath(), ProjectConfig.PROJECT_CONFIG_FILENAME);
-			config = new ProjectConfig(false);
-			config.appendConfigFile(configFile);
-		} catch (Exception e) {
-			logger.fatal("Error when loading COOJA project: " + e.getMessage());
-		}
-	}
+  public final File dir;
+  public final File configFile;
+  public final ProjectConfig config;
+
+  public COOJAProject(File dir) throws IOException {
+    this.dir = dir;
+    configFile = new File(dir.getPath(), ProjectConfig.PROJECT_CONFIG_FILENAME);
+    config = new ProjectConfig(false);
+    config.appendConfigFile(configFile);
+  }
 
 	public boolean directoryExists() {
 		return dir.exists();

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -324,7 +324,7 @@ public class Cooja extends Observable {
           try {
             return new Cooja(logDirectory, vis);
           } catch (ParseProjectsException e) {
-            throw new RuntimeException("Cooja constructor should never throw ParseProjectsException in GUI mode", e);
+            throw new RuntimeException("Could not parse projects", e);
           }
         }
       }.invokeAndWait();
@@ -355,8 +355,11 @@ public class Cooja extends Observable {
     if (defaultProjectDirs != null && defaultProjectDirs.length() > 0) {
       String[] arr = defaultProjectDirs.split(";");
       for (String p : arr) {
-        File projectDir = restorePortablePath(new File(p));
-        currentProjects.add(new COOJAProject(projectDir));
+        try {
+          currentProjects.add(new COOJAProject(restorePortablePath(new File(p))));
+        } catch (IOException e) {
+          throw new ParseProjectsException("Failed to parse project: " + p, e);
+        }
       }
     }
 
@@ -369,7 +372,11 @@ public class Cooja extends Observable {
         File[] projects = COOJAProject.searchProjects(searchDir, 3);
         if(projects == null) continue;
         for(File p : projects){
-          currentProjects.add(new COOJAProject(p));
+          try {
+            currentProjects.add(new COOJAProject(p));
+          } catch (IOException e) {
+            throw new ParseProjectsException("Failed to parse project: " + p, e);
+          }
         }
       }
     }

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -211,11 +211,6 @@ public class Cooja extends Observable {
   private static String specifiedCoojaPath = null;
   private static String specifiedContikiPath = null;
 
-  /**
-   * User extension configuration filename.
-   */
-  public static final String PROJECT_CONFIG_FILENAME = "cooja.config";
-
   // External tools setting names
   public static Properties defaultExternalToolsSettings;
   public static Properties currentExternalToolsSettings;

--- a/java/org/contikios/cooja/ProjectConfig.java
+++ b/java/org/contikios/cooja/ProjectConfig.java
@@ -97,6 +97,11 @@ public class ProjectConfig {
    */
   public static final String PROJECT_DEFAULT_CONFIG_FILENAME = "/cooja_default.config";
 
+  /**
+   * User extension configuration filename.
+   */
+  public static final String PROJECT_CONFIG_FILENAME = "cooja.config";
+
   private Properties myConfig = new Properties();
   private ArrayList<File> myProjectDirHistory = new ArrayList<>();
 
@@ -145,7 +150,7 @@ public class ProjectConfig {
       throw new FileNotFoundException("Project directory does not exist: " + projectDir.getAbsolutePath());
     }
     
-    File projectConfig = new File(projectDir.getPath(), Cooja.PROJECT_CONFIG_FILENAME);
+    File projectConfig = new File(projectDir.getPath(), PROJECT_CONFIG_FILENAME);
     if (!projectConfig.exists()) {
       throw new FileNotFoundException("Project config does not exist: " + projectConfig.getAbsolutePath());
     }

--- a/java/org/contikios/cooja/dialogs/ProjectDirectoriesDialog.java
+++ b/java/org/contikios/cooja/dialogs/ProjectDirectoriesDialog.java
@@ -463,8 +463,12 @@ public class ProjectDirectoriesDialog extends JDialog {
 		((AbstractTableModel)table.getModel()).fireTableDataChanged();
 	}
 	protected void addProjectDir(File dir) {
-		currentProjects.add(new COOJAProject(dir));
-		((AbstractTableModel)table.getModel()).fireTableDataChanged();
+    try {
+      currentProjects.add(new COOJAProject(dir));
+      ((AbstractTableModel) table.getModel()).fireTableDataChanged();
+    } catch (IOException e) {
+      logger.error("Failed to parse Cooja project: {}", dir, e);
+    }
 	}
 	protected void addProjectDir(COOJAProject project, int index) {
 		currentProjects.add(index, project);

--- a/java/org/contikios/cooja/dialogs/ProjectDirectoriesDialog.java
+++ b/java/org/contikios/cooja/dialogs/ProjectDirectoriesDialog.java
@@ -762,7 +762,7 @@ class DirectoryTreePanel extends JPanel {
 			return false;
 		}
 		boolean containsConfig() {
-			return new File(dir, Cooja.PROJECT_CONFIG_FILENAME).exists();
+			return new File(dir, ProjectConfig.PROJECT_CONFIG_FILENAME).exists();
 		}
 		boolean subtreeContainsProject() {
 			try {


### PR DESCRIPTION
Propagate errors so callers can detect them and put the user filename in the same class as the default filename.