### PR TITLE
Cooja: use default stopSimulation method

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -4192,7 +4192,7 @@ public class Cooja extends Observable {
       // Stop the simulation if it is running.
       Simulation simulation = cooja.getSimulation();
       if (simulation != null) {
-        simulation.stopSimulation(true);
+        simulation.stopSimulation();
       }
     }
   }


### PR DESCRIPTION
Only use the explicit method when something
other than the default behavior is desired.