### PR TITLE
Cooja: have main thread call doQuit

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -3106,7 +3106,10 @@ public class Cooja extends Observable {
       }
       if (!vis) {
         sim.setSpeedLimit(null);
-        sim.startSimulation();
+        var rv = sim.startSimulation(true);
+        if (rv != null) {
+          gui.doQuit(false, rv);
+        }
       }
     }
   }

--- a/java/org/contikios/cooja/LogScriptEngine.java
+++ b/java/org/contikios/cooja/LogScriptEngine.java
@@ -283,10 +283,7 @@ public class LogScriptEngine {
               break;
           }
           deactivateScript();
-          simulation.stopSimulation(false);
-          if (!Cooja.isVisualized() && rv >= 0) {
-            simulation.getCooja().doQuit(false, rv);
-          }
+          simulation.stopSimulation(false, rv >= 0 ? rv : null);
         } catch (Exception e) {
           logger.fatal("Script error:", e);
           if (!Cooja.isVisualized()) {


### PR DESCRIPTION
Add a blocking mode to startSimulation()
and call stopSimulation with the desired
return value from that.

This is preparation for being able to run
multiple simulations in a single Cooja
invocation.