### PR TITLE
MessageContainer: remove spurious check

### DIFF
--- a/java/org/contikios/cooja/dialogs/MessageContainer.java
+++ b/java/org/contikios/cooja/dialogs/MessageContainer.java
@@ -1,5 +1,4 @@
 package org.contikios.cooja.dialogs;
-import java.awt.GraphicsEnvironment;
 
 import org.contikios.cooja.Cooja;
 
@@ -22,7 +21,7 @@ public class MessageContainer {
      * headless info.
      */
     public static MessageList createMessageList(boolean withUI) {
-        if (withUI && !GraphicsEnvironment.isHeadless() && Cooja.isVisualized()) {
+        if (withUI && Cooja.isVisualized()) {
             return new Cooja.RunnableInEDT<MessageList>() {
                 @Override
                 public MessageList work() {


### PR DESCRIPTION
The startup code sets headless mode nowadays
so it is sufficient to check Cooja.isVisualized().