### PR TITLE
Simulation: remove unused method

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -956,19 +956,6 @@ public class Simulation extends Observable implements Runnable {
   }
 
   /**
-   * Set simulation time to simulationTime.
-   *
-   * @param simulationTime
-   *          New simulation time (ms)
-   */
-  public void setSimulationTime(long simulationTime) {
-    currentSimulationTime = simulationTime;
-
-    this.setChanged();
-    this.notifyObservers(this);
-  }
-
-  /**
    * Returns current simulation time.
    *
    * @return Simulation time (microseconds)


### PR DESCRIPTION
Fast-forwarding the simulation time might
trigger the time-related asserts in the main
event loop.