### PR TITLE
Simulation: pass seed to constructor

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -75,6 +75,7 @@ import java.util.MissingResourceException;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Properties;
+import java.util.Random;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.SynchronousQueue;
@@ -912,7 +913,7 @@ public class Cooja extends Observable {
           return;
         }
 
-        var sim = new Simulation(Cooja.this);
+        var sim = new Simulation(Cooja.this, 123456);
         if (CreateSimDialog.showDialog(sim)) {
           // Start GUI plugins.
           for (var pluginClass : pluginClasses) {
@@ -3224,9 +3225,12 @@ public class Cooja extends Observable {
       }
     }
     System.gc();
-    Simulation newSim = new Simulation(this);
+    var cfgSeed = root.getChild("simulation").getChild("randomseed").getText();
+    long seed = manualRandomSeed != null ? manualRandomSeed
+            : "generated".equals(cfgSeed) ? new Random().nextLong() : Long.parseLong(cfgSeed);
+    var newSim = new Simulation(this, seed);
     try {
-      if (!newSim.setConfigXML(root.getChild("simulation"), isVisualized(), quick, manualRandomSeed)) {
+      if (!newSim.setConfigXML(root.getChild("simulation"), isVisualized(), quick)) {
         logger.info("Simulation not loaded");
         return null;
       }

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -88,7 +88,7 @@ public class Simulation extends Observable implements Runnable {
 
   private final Cooja cooja;
 
-  private long randomSeed = 123456;
+  private long randomSeed;
 
   private boolean randomSeedGenerated = false;
 
@@ -272,9 +272,10 @@ public class Simulation extends Observable implements Runnable {
   /**
    * Creates a new simulation
    */
-  public Simulation(Cooja cooja) {
+  public Simulation(Cooja cooja, long seed) {
     this.cooja = cooja;
     randomGenerator = new SafeRandom(this);
+    randomSeed = seed;
   }
 
   /** Create a new script engine that logs to the logTextArea and add it to the list
@@ -529,12 +530,10 @@ public class Simulation extends Observable implements Runnable {
    *
    * @param root Simulation configuration
    * @param visAvailable True if simulation is allowed to show visualizers
-   * @param manualRandomSeed Simulation random seed. May be null, in which case the configuration is used
    * @return True if simulation was configured successfully
    * @throws Exception If configuration could not be loaded
    */
-  public boolean setConfigXML(Element root,
-      boolean visAvailable, boolean quick, Long manualRandomSeed) throws Exception {
+  public boolean setConfigXML(Element root, boolean visAvailable, boolean quick) throws Exception {
     this.quick = quick;
     // Parse elements
     for (var element : (List<Element>) root.getChildren()) {
@@ -552,17 +551,11 @@ public class Simulation extends Observable implements Runnable {
           break;
         }
         case "randomseed": {
-          long newSeed;
           if (element.getText().equals("generated")) {
             randomSeedGenerated = true;
-            newSeed = new Random().nextLong();
-          } else {
-            newSeed = Long.parseLong(element.getText());
           }
-          if (manualRandomSeed != null) {
-            newSeed = manualRandomSeed;
-          }
-          setRandomSeed(newSeed);
+          // Seed already passed into the constructor, init random generator.
+          setRandomSeed(randomSeed);
           break;
         }
         case "motedelay":


### PR DESCRIPTION
This moves the choice of default seed
from Simulation (which should not make
policy decisions) into Cooja.

The long term plan is to make the seed
final, but that requires CreateSimDialog
to not directly modify the simulation.