### PR TITLE
Allocate radio mediums in one place

### DIFF
--- a/java/org/contikios/cooja/MoteInterfaceHandler.java
+++ b/java/org/contikios/cooja/MoteInterfaceHandler.java
@@ -77,6 +77,12 @@ import org.contikios.cooja.mspmote.interfaces.MspSerial;
 import org.contikios.cooja.mspmote.interfaces.SkyCoffeeFilesystem;
 import org.contikios.cooja.mspmote.interfaces.SkyFlash;
 import org.contikios.cooja.mspmote.interfaces.SkyTemperature;
+import org.contikios.cooja.radiomediums.DirectedGraphMedium;
+import org.contikios.cooja.radiomediums.LogisticLoss;
+import org.contikios.cooja.radiomediums.SilentRadioMedium;
+import org.contikios.cooja.radiomediums.UDGM;
+import org.contikios.cooja.radiomediums.UDGMConstantLoss;
+import org.contikios.mrm.MRM;
 
 /**
  * The mote interface handler holds all interfaces for a specific mote.
@@ -167,6 +173,34 @@ public class MoteInterfaceHandler {
       case "org.contikios.cooja.mspmote.Z1MoteType" -> new Z1MoteType();
       default -> null;
     };
+  }
+
+  /** Fast translation from class name to object for radio mediums.
+   * @param sim Simulation
+   * @param name Name of radio medium to create
+   * @return Object or null
+   */
+  public static RadioMedium createRadioMedium(Simulation sim, String name) {
+    if (name.startsWith("se.sics")) {
+      name = name.replaceFirst("se\\.sics", "org.contikios");
+    }
+    switch (name) {
+      case "org.contikios.cooja.radiomediums.UDGM": return new UDGM(sim);
+      case "org.contikios.cooja.radiomediums.UDGMConstantLoss": return new UDGMConstantLoss(sim);
+      case "org.contikios.cooja.radiomediums.DirectedGraphMedium": return new DirectedGraphMedium(sim);
+      case "org.contikios.cooja.radiomediums.SilentRadioMedium": return new SilentRadioMedium(sim);
+      case "org.contikios.cooja.radiomediums.LogisticLoss": return new LogisticLoss(sim);
+      case "org.contikios.cooja.mrm.MRM": return new MRM(sim);
+    };
+    var clazz = sim.getCooja().tryLoadClass(sim, RadioMedium.class, name);
+    if (clazz == null) {
+      return null;
+    }
+    try {
+      return clazz.getConstructor(Simulation.class).newInstance(sim);
+    } catch (Exception e) {
+      return null;
+    }
   }
 
   /** Fast translation from class name to class file for builtin interfaces. Uses the classloader

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -573,19 +573,9 @@ public class Simulation extends Observable implements Runnable {
           break;
         case "radiomedium": {
           String radioMediumClassName = element.getText().trim();
-          /* Backwards compatibility: se.sics -> org.contikios */
-          if (radioMediumClassName.startsWith("se.sics")) {
-            radioMediumClassName = radioMediumClassName.replaceFirst("se\\.sics", "org.contikios");
-          }
-
-          var radioMediumClass = cooja.tryLoadClass(this, RadioMedium.class, radioMediumClassName);
-          if (radioMediumClass == null) {
+          currentRadioMedium = MoteInterfaceHandler.createRadioMedium(this, radioMediumClassName);
+          if (currentRadioMedium == null) {
             throw new MoteType.MoteTypeCreationException("Could not load " + radioMediumClassName);
-          }
-          try {
-            currentRadioMedium = radioMediumClass.getConstructor(Simulation.class).newInstance(this);
-          } catch (Exception e) {
-            throw new MoteType.MoteTypeCreationException("Could not create " + radioMediumClassName, e);
           }
 
           // Show configure simulation dialog


### PR DESCRIPTION
MoteInterfaceHandler is not the perfect
place for radio medium allocation, but
the other code that allocates other
things motes already resides there,
so group it together for now.

This commit also makes CreateSimDialog
return an error if the radiomedium could
not be allocated.