### PR TITLE
ScriptParser: rename SCRIPT_SWITCH to YIELD

### DIFF
--- a/java/org/contikios/cooja/script/ScriptParser.java
+++ b/java/org/contikios/cooja/script/ScriptParser.java
@@ -57,8 +57,6 @@ public class ScriptParser {
 
     code = replaceYieldThenWaitUntils(code);
 
-    code = replaceYields(code);
-
     code = replaceWaitUntils(code);
 
     code = replaceTestStatus(code);
@@ -155,13 +153,6 @@ public class ScriptParser {
     return code;
   }
 
-  private static String replaceYields(String code) {
-    Pattern pattern = Pattern.compile(
-        "YIELD\\(\\)"
-    );
-    return pattern.matcher(code).replaceAll("SCRIPT_SWITCH()");
-  }
-
   private static String replaceYieldThenWaitUntils(String code) {
     Pattern pattern = Pattern.compile(
         "YIELD_THEN_WAIT_UNTIL\\(" +
@@ -190,7 +181,7 @@ public class ScriptParser {
     while (matcher.find()) {
       code = matcher.replaceFirst(
           "while (!(" + matcher.group(1) + ")) { " +
-          " SCRIPT_SWITCH(); " +
+          " YIELD(); " +
       "}");
       matcher.reset(code);
     }
@@ -250,7 +241,7 @@ public class ScriptParser {
     code + 
     "\n" +
     "\n" +
-    "while (true) { SCRIPT_SWITCH(); } " /* SCRIPT ENDED */+
+    "while (true) { YIELD(); } " /* SCRIPT ENDED */+
     "} catch (error) { " +
     "if (error instanceof TestOK) return 0; " +
     "if (error instanceof TestFailed) return 1; " +
@@ -269,7 +260,7 @@ public class ScriptParser {
     " throw new TestFailed(); " +
     "};\n" +
     "\n" +
-    "function SCRIPT_SWITCH() { " +
+    "function YIELD() { " +
     " SEMAPHORE_SIM.release(); " +
     " SEMAPHORE_SCRIPT.acquire(); " /* SWITCH BLOCKS HERE! */ +
     " if (SHUTDOWN) { throw new Shutdown(); } " +


### PR DESCRIPTION
Make the YIELD function native and stop
renaming it in the ScriptParser.