### PR TITLE
CoreComm: implement getMemory/setMemory in Java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,10 @@ application {
     '--enable-native-access', 'ALL-UNNAMED', '--add-modules', 'jdk.incubator.foreign']
 }
 
+tasks.withType(JavaCompile) {
+  options.compilerArgs += ['--add-modules', 'jdk.incubator.foreign']
+}
+
 jar {
   reproducibleFileOrder = true
   manifest {

--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -42,6 +42,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Objects;
+import jdk.incubator.foreign.MemoryAddress;
+import jdk.incubator.foreign.ResourceScope;
 import org.contikios.cooja.MoteType.MoteTypeCreationException;
 import org.contikios.cooja.contikimote.ContikiMoteType;
 import org.contikios.cooja.dialogs.MessageContainer;
@@ -83,6 +85,7 @@ import org.contikios.cooja.dialogs.MessageList;
 public abstract class CoreComm {
   private final static ArrayList<File> coreCommFiles = new ArrayList<>();
 
+  protected long offset = 0;
   private static int fileCounter = 1;
 
   /**
@@ -255,12 +258,13 @@ public abstract class CoreComm {
   public abstract long getReferenceAddress();
 
   /**
-   * Sets the relative memory address of the reference variable.
-   * Is used by Contiki to map between absolute and relative memory addresses.
+   * Set the offset between absolute and relative memory addresses.
    *
-   * @param addr Relative address
+   * @param offset Offset between absolute and relative addresses
    */
-  public abstract void setReferenceAddress(long addr);
+  public void setReferenceOffset(long offset) {
+    this.offset = offset;
+  }
 
   /**
    * Fills a byte array with memory segment identified by start and length.
@@ -269,7 +273,10 @@ public abstract class CoreComm {
    * @param length Length of segment
    * @param mem Array to fill with memory segment
    */
-  public abstract void getMemory(long relAddr, int length, byte[] mem);
+  public void getMemory(long relAddr, int length, byte[] mem) {
+    final var addr = MemoryAddress.ofLong(relAddr + offset);
+    addr.asSegment(length, ResourceScope.globalScope()).asByteBuffer().get(0, mem, 0, length);
+  }
 
   /**
    * Overwrites a memory segment identified by start and length.
@@ -278,6 +285,8 @@ public abstract class CoreComm {
    * @param length Length of segment
    * @param mem New memory segment data
    */
-  public abstract void setMemory(long relAddr, int length, byte[] mem);
-
+  public void setMemory(long relAddr, int length, byte[] mem) {
+    final var addr = MemoryAddress.ofLong(relAddr + offset);
+    addr.asSegment(length, ResourceScope.globalScope()).asByteBuffer().put(0, mem, 0, length);
+  }
 }

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -406,8 +406,8 @@ public class ContikiMoteType extends BaseContikiMoteType {
 
       try {
         long referenceVar = tmp.getSymbolMap().get("referenceVar").addr;
-        myCoreComm.setReferenceAddress(referenceVar);
         offset = myCoreComm.getReferenceAddress() - referenceVar;
+        myCoreComm.setReferenceOffset(offset);
       } catch (Exception e) {
         throw new MoteTypeCreationException("Error setting reference variable: " + e.getMessage(), e);
       }

--- a/java/org/contikios/cooja/corecomm/CoreCommTemplate.java
+++ b/java/org/contikios/cooja/corecomm/CoreCommTemplate.java
@@ -59,7 +59,4 @@ public class CoreCommTemplate extends CoreComm {
   public long getReferenceAddress() {
     return symbols.lookup("referenceVar").get().address().toRawLongValue();
   }
-  public native void setReferenceAddress(long addr);
-  public native void getMemory(long rel_addr, int length, byte[] mem);
-  public native void setMemory(long rel_addr, int length, byte[] mem);
 }


### PR DESCRIPTION
Move the memory copying from a JNI call to
Contiki-NG into Java.