### PR TITLE
CreateSimDialog: return config

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -905,7 +905,13 @@ public class Cooja extends Observable {
         }
 
         var sim = new Simulation(Cooja.this, 123456);
-        if (CreateSimDialog.showDialog(sim, sim.getSimConfig())) {
+        boolean ok;
+        try {
+          ok = sim.setSimConfig(CreateSimDialog.showDialog(Cooja.this, sim.getSimConfig()));
+        } catch (MoteTypeCreationException ex) {
+          ok = false;
+        }
+        if (ok) {
           // Start GUI plugins.
           for (var pluginClass : pluginClasses) {
             int type = pluginClass.getAnnotation(PluginType.class).value();

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -591,10 +591,6 @@ public class Simulation extends Observable implements Runnable {
         case "radiomedium": {
           String radioMediumClassName = element.getText().trim();
           currentRadioMedium = MoteInterfaceHandler.createRadioMedium(this, radioMediumClassName);
-          if (currentRadioMedium == null) {
-            throw new MoteType.MoteTypeCreationException("Could not load " + radioMediumClassName);
-          }
-
           // Show configure simulation dialog
           if (visAvailable && !quick) {
             // FIXME: this should run from the AWT thread.
@@ -602,7 +598,9 @@ public class Simulation extends Observable implements Runnable {
               return false;
             }
           }
-
+          if (currentRadioMedium == null) {
+            throw new MoteType.MoteTypeCreationException("Could not load " + radioMediumClassName);
+          }
           // Check if radio medium specific config should be applied
           if (radioMediumClassName.equals(currentRadioMedium.getClass().getName())) {
             currentRadioMedium.setConfigXML(element.getChildren(), visAvailable);

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -286,6 +286,22 @@ public class Simulation extends Observable implements Runnable {
             randomSeedGenerated, randomSeed, maxMoteStartupDelay / MILLISECOND);
   }
 
+  public boolean setSimConfig(SimConfig cfg) throws MoteType.MoteTypeCreationException {
+    if (cfg == null) {
+      return false;
+    }
+    title = cfg.title;
+    var radioMedium = MoteInterfaceHandler.createRadioMedium(this, cfg.radioMedium);
+    if (radioMedium == null) {
+      throw new MoteType.MoteTypeCreationException("Could not load " + cfg.radioMedium);
+    }
+    setRadioMedium(radioMedium);
+    randomSeedGenerated = cfg.generatedSeed;
+    setRandomSeed(cfg.randomSeed);
+    maxMoteStartupDelay = Math.max(0, cfg.moteStartDelay);
+    return true;
+  }
+
   /** Create a new script engine that logs to the logTextArea and add it to the list
    *  of active script engines. */
   public LogScriptEngine newScriptEngine(JTextArea logTextArea) {
@@ -582,8 +598,8 @@ public class Simulation extends Observable implements Runnable {
           // Show configure simulation dialog
           if (visAvailable && !quick) {
             // FIXME: this should run from the AWT thread.
-            if (!CreateSimDialog.showDialog(this, getSimConfig())) {
-              throw new Exception("Load aborted by user");
+            if (!setSimConfig(CreateSimDialog.showDialog(getCooja(), getSimConfig()))) {
+              return false;
             }
           }
 

--- a/java/org/contikios/cooja/dialogs/CreateSimDialog.java
+++ b/java/org/contikios/cooja/dialogs/CreateSimDialog.java
@@ -58,7 +58,6 @@ import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 
 import org.contikios.cooja.Cooja;
-import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.RadioMedium;
 import org.contikios.cooja.Simulation;
 
@@ -71,25 +70,24 @@ public class CreateSimDialog extends JDialog {
   private final static int LABEL_WIDTH = 170;
   private final static int LABEL_HEIGHT = 25;
 
-  private Simulation mySimulation;
+  private Simulation.SimConfig config = null;
 
   /**
    * Shows a dialog for configuring a simulation.
    *
-   * @param sim Simulation to configure
+   * @param gui Cooja
    * @param cfg Initial configuration
-   * @return True if simulation configured correctly
+   * @return Configuration selected by user, null if dialog is cancelled.
    */
-  public static boolean showDialog(Simulation sim, Simulation.SimConfig cfg) {
-    final var dialog = new CreateSimDialog(sim.getCooja(), sim, cfg);
+  public static Simulation.SimConfig showDialog(Cooja gui, Simulation.SimConfig cfg) {
+    final var dialog = new CreateSimDialog(gui, cfg);
     dialog.setVisible(true);
     // Simulation configured correctly
-    return dialog.mySimulation != null;
+    return dialog.config;
   }
 
-  private CreateSimDialog(Cooja gui, Simulation sim, Simulation.SimConfig cfg) {
+  private CreateSimDialog(Cooja gui, Simulation.SimConfig cfg) {
     super(Cooja.getTopParentContainer(), "Create new simulation", ModalityType.APPLICATION_MODAL);
-    mySimulation = sim;
     Box vertBox = Box.createVerticalBox();
     NumberFormat integerFormat = NumberFormat.getIntegerInstance();
 
@@ -103,7 +101,6 @@ public class CreateSimDialog extends JDialog {
     cancelButton.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(ActionEvent e) {
-        mySimulation = null;
         dispose();
       }
     });
@@ -278,21 +275,12 @@ public class CreateSimDialog extends JDialog {
     createButton.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(ActionEvent e) {
-        mySimulation.setTitle(title.getText());
-        if (randomSeedGenerated.isSelected()) {
-          mySimulation.setRandomSeedGenerated(true);
-          mySimulation.setRandomSeed(new Random().nextLong());
-        } else {
-          mySimulation.setRandomSeedGenerated(false);
-          mySimulation.setRandomSeed(((Number) randomSeed.getValue()).longValue());
-        }
-        mySimulation.setDelayedMoteStartupTime(((Number) delayedStartup.getValue()).intValue() * Simulation.MILLISECOND);
-        var radioMediumName = gui.getRegisteredRadioMediums().get(radioMediumBox.getSelectedIndex()).getName();
-        var radioMedium = MoteInterfaceHandler.createRadioMedium(mySimulation, radioMediumName);
-        mySimulation.setRadioMedium(radioMedium);
-        if (radioMedium == null) {
-          mySimulation = null;
-        }
+        config = new Simulation.SimConfig(title.getText(),
+                gui.getRegisteredRadioMediums().get(radioMediumBox.getSelectedIndex()).getName(),
+                randomSeedGenerated.isSelected(),
+                randomSeedGenerated.isSelected()
+                        ? new Random().nextLong() : ((Number) randomSeed.getValue()).longValue(),
+                ((Number) delayedStartup.getValue()).intValue() * Simulation.MILLISECOND);
         dispose();
       }
     });

--- a/java/org/contikios/cooja/dialogs/CreateSimDialog.java
+++ b/java/org/contikios/cooja/dialogs/CreateSimDialog.java
@@ -287,15 +287,9 @@ public class CreateSimDialog extends JDialog {
           mySimulation.setRandomSeed(((Number) randomSeed.getValue()).longValue());
         }
         mySimulation.setDelayedMoteStartupTime(((Number) delayedStartup.getValue()).intValue() * Simulation.MILLISECOND);
-        String radioMediumName = (String) radioMediumBox.getSelectedItem();
-        RadioMedium radioMedium = null;
-        for (var radioMediumClass: gui.getRegisteredRadioMediums()) {
-          if (Cooja.getDescriptionOf(radioMediumClass).equals(radioMediumName)) {
-            radioMedium = MoteInterfaceHandler.createRadioMedium(mySimulation, radioMediumClass.getName());
-            mySimulation.setRadioMedium(radioMedium);
-            break;
-          }
-        }
+        var radioMediumName = gui.getRegisteredRadioMediums().get(radioMediumBox.getSelectedIndex()).getName();
+        var radioMedium = MoteInterfaceHandler.createRadioMedium(mySimulation, radioMediumName);
+        mySimulation.setRadioMedium(radioMedium);
         if (radioMedium == null) {
           mySimulation = null;
         }


### PR DESCRIPTION
CreateSimDialog no longer pokes around in the internal state of the simulation after this commit.