### PR TITLE
Cooja: simplify startPlugin

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1970,18 +1970,15 @@ public class Cooja extends Observable {
     // Construct plugin depending on plugin type
     Plugin plugin;
     try {
-      if (pluginType == PluginType.MOTE_PLUGIN) {
-        plugin =
-          pluginClass.getConstructor(Mote.class, Simulation.class, Cooja.class)
-          .newInstance(argMote, argSimulation, this);
-      } else if (pluginType == PluginType.SIM_PLUGIN || pluginType == PluginType.SIM_STANDARD_PLUGIN
-    		  || pluginType == PluginType.SIM_CONTROL_PLUGIN) {
-        plugin = pluginClass.getConstructor(Simulation.class, Cooja.class).newInstance(argSimulation, this);
-      } else if (pluginType == PluginType.COOJA_PLUGIN || pluginType == PluginType.COOJA_STANDARD_PLUGIN) {
-        plugin = pluginClass.getConstructor(Cooja.class).newInstance(this);
-      } else {
-        throw new PluginConstructionException("Bad plugin type: " + pluginType);
-      }
+      plugin = switch (pluginType) {
+        case PluginType.MOTE_PLUGIN -> pluginClass.getConstructor(Mote.class, Simulation.class, Cooja.class)
+                .newInstance(argMote, argSimulation, this);
+        case PluginType.SIM_PLUGIN, PluginType.SIM_STANDARD_PLUGIN, PluginType.SIM_CONTROL_PLUGIN ->
+                pluginClass.getConstructor(Simulation.class, Cooja.class).newInstance(argSimulation, this);
+        case PluginType.COOJA_PLUGIN, PluginType.COOJA_STANDARD_PLUGIN ->
+                pluginClass.getConstructor(Cooja.class).newInstance(this);
+        default -> throw new PluginConstructionException("Bad plugin type: " + pluginType);
+      };
     } catch (PluginRequiresVisualizationException e) {
       throw new PluginConstructionException("Tool class requires visualization: " + pluginClass.getName(), e);
     } catch (Exception e) {

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1940,14 +1940,13 @@ public class Cooja extends Observable {
    *
    * @see PluginType
    * @param pluginClass Plugin class
-   * @param argSimulation Plugin simulation argument
+   * @param sim Plugin simulation argument
    * @param argMote Plugin mote argument
    * @param root XML root element for plugin config
    * @return Started plugin
    * @throws PluginConstructionException At errors
    */
-  private Plugin startPlugin(final Class<? extends Plugin> pluginClass,
-      Simulation argSimulation, Mote argMote, Element root)
+  private Plugin startPlugin(final Class<? extends Plugin> pluginClass, Simulation sim, Mote argMote, Element root)
   throws PluginConstructionException
   {
     // Check that plugin class is registered
@@ -1956,8 +1955,7 @@ public class Cooja extends Observable {
     }
 
     int pluginType = pluginClass.getAnnotation(PluginType.class).value();
-    if (pluginType != PluginType.COOJA_PLUGIN && pluginType != PluginType.COOJA_STANDARD_PLUGIN &&
-            argSimulation == null) {
+    if (pluginType != PluginType.COOJA_PLUGIN && pluginType != PluginType.COOJA_STANDARD_PLUGIN && sim == null) {
       throw new PluginConstructionException("No simulation argument for plugin");
     }
     if (pluginType == PluginType.MOTE_PLUGIN && argMote == null) {
@@ -1972,9 +1970,9 @@ public class Cooja extends Observable {
     try {
       plugin = switch (pluginType) {
         case PluginType.MOTE_PLUGIN -> pluginClass.getConstructor(Mote.class, Simulation.class, Cooja.class)
-                .newInstance(argMote, argSimulation, this);
+                .newInstance(argMote, sim, this);
         case PluginType.SIM_PLUGIN, PluginType.SIM_STANDARD_PLUGIN, PluginType.SIM_CONTROL_PLUGIN ->
-                pluginClass.getConstructor(Simulation.class, Cooja.class).newInstance(argSimulation, this);
+                pluginClass.getConstructor(Simulation.class, Cooja.class).newInstance(sim, this);
         case PluginType.COOJA_PLUGIN, PluginType.COOJA_STANDARD_PLUGIN ->
                 pluginClass.getConstructor(Cooja.class).newInstance(this);
         default -> throw new PluginConstructionException("Bad plugin type: " + pluginType);

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -450,7 +450,7 @@ public class Cooja extends Observable {
     for (Class<? extends Plugin> pluginClass : pluginClasses) {
       int pluginType = pluginClass.getAnnotation(PluginType.class).value();
       if (pluginType == PluginType.COOJA_STANDARD_PLUGIN) {
-        tryStartPlugin(pluginClass, this, null, null);
+        tryStartPlugin(pluginClass, null, null);
       }
     }
 
@@ -918,7 +918,7 @@ public class Cooja extends Observable {
           for (var pluginClass : pluginClasses) {
             int type = pluginClass.getAnnotation(PluginType.class).value();
             if (type == PluginType.SIM_STANDARD_PLUGIN) {
-              tryStartPlugin(pluginClass, Cooja.this, sim, null);
+              tryStartPlugin(pluginClass, sim, null);
             }
           }
           setSimulation(sim);
@@ -1299,7 +1299,7 @@ public class Cooja extends Observable {
         public void actionPerformed(ActionEvent e) {
           Object pluginClass = ((JMenuItem)e.getSource()).getClientProperty("class");
           Object mote = ((JMenuItem)e.getSource()).getClientProperty("mote");
-          tryStartPlugin((Class<? extends Plugin>) pluginClass, Cooja.this, getSimulation(), (Mote)mote);
+          tryStartPlugin((Class<? extends Plugin>) pluginClass, getSimulation(), (Mote)mote);
         }
       };
       private JMenuItem createMenuItem(Class<? extends Plugin> newPluginClass) {
@@ -1898,22 +1898,20 @@ public class Cooja extends Observable {
   }
 
   /**
-   * Same as the {@link #startPlugin(Class, Cooja, Simulation, Mote, Element)} method,
+   * Same as the {@link #startPlugin(Class, Simulation, Mote, Element)} method,
    * but does not throw exceptions. If COOJA is visualised, an error dialog
    * is shown if plugin could not be started.
    *
-   * @see #startPlugin(Class, Cooja, Simulation, Mote, Element)
+   * @see #startPlugin(Class, Simulation, Mote, Element)
    * @param pluginClass Plugin class
-   * @param argGUI Plugin GUI argument
-   * @param argSimulation Plugin simulation argument
+   * @param sim Plugin simulation argument
    * @param argMote Plugin mote argument
    * @param root XML root element for plugin config
    * @return Started plugin
    */
-  private Plugin tryStartPlugin(final Class<? extends Plugin> pluginClass,
-     final Cooja argGUI, final Simulation argSimulation, final Mote argMote, Element root) {
+  private Plugin tryStartPlugin(Class<? extends Plugin> pluginClass, Simulation sim, Mote argMote, Element root) {
     try {
-      return startPlugin(pluginClass, argGUI, argSimulation, argMote, root);
+      return startPlugin(pluginClass, sim, argMote, root);
     } catch (PluginConstructionException ex) {
       if (Cooja.isVisualized()) {
         Cooja.showErrorDialog(Cooja.getTopParentContainer(), "Error when starting plugin", ex, false);
@@ -1933,9 +1931,8 @@ public class Cooja extends Observable {
     return null;
   }
 
-  public Plugin tryStartPlugin(final Class<? extends Plugin> pluginClass,
-      final Cooja argGUI, final Simulation argSimulation, final Mote argMote) {
-    return tryStartPlugin(pluginClass, argGUI, argSimulation, argMote, null);
+  public Plugin tryStartPlugin(Class<? extends Plugin> pluginClass, Simulation argSimulation, Mote argMote) {
+    return tryStartPlugin(pluginClass, argSimulation, argMote, null);
   }
 
   /**
@@ -1943,7 +1940,6 @@ public class Cooja extends Observable {
    *
    * @see PluginType
    * @param pluginClass Plugin class
-   * @param argGUI Plugin GUI argument
    * @param argSimulation Plugin simulation argument
    * @param argMote Plugin mote argument
    * @param root XML root element for plugin config
@@ -1951,7 +1947,7 @@ public class Cooja extends Observable {
    * @throws PluginConstructionException At errors
    */
   private Plugin startPlugin(final Class<? extends Plugin> pluginClass,
-      final Cooja argGUI, final Simulation argSimulation, final Mote argMote, Element root)
+      Simulation argSimulation, Mote argMote, Element root)
   throws PluginConstructionException
   {
     // Check that plugin class is registered
@@ -1968,9 +1964,6 @@ public class Cooja extends Observable {
         throw new PluginRequiresVisualizationException();
       }
       if (pluginType == PluginType.MOTE_PLUGIN) {
-        if (argGUI == null) {
-          throw new PluginConstructionException("No GUI argument for mote plugin");
-        }
         if (argSimulation == null) {
           throw new PluginConstructionException("No simulation argument for mote plugin");
         }
@@ -1979,21 +1972,15 @@ public class Cooja extends Observable {
         }
         plugin =
           pluginClass.getConstructor(Mote.class, Simulation.class, Cooja.class)
-          .newInstance(argMote, argSimulation, argGUI);
+          .newInstance(argMote, argSimulation, this);
       } else if (pluginType == PluginType.SIM_PLUGIN || pluginType == PluginType.SIM_STANDARD_PLUGIN
     		  || pluginType == PluginType.SIM_CONTROL_PLUGIN) {
-        if (argGUI == null) {
-          throw new PluginConstructionException("No GUI argument for simulation plugin");
-        }
         if (argSimulation == null) {
           throw new PluginConstructionException("No simulation argument for simulation plugin");
         }
-        plugin = pluginClass.getConstructor(Simulation.class, Cooja.class).newInstance(argSimulation, argGUI);
+        plugin = pluginClass.getConstructor(Simulation.class, Cooja.class).newInstance(argSimulation, this);
       } else if (pluginType == PluginType.COOJA_PLUGIN || pluginType == PluginType.COOJA_STANDARD_PLUGIN) {
-        if (argGUI == null) {
-          throw new PluginConstructionException("No GUI argument for GUI plugin");
-        }
-        plugin = pluginClass.getConstructor(Cooja.class).newInstance(argGUI);
+        plugin = pluginClass.getConstructor(Cooja.class).newInstance(this);
       } else {
         throw new PluginConstructionException("Bad plugin type: " + pluginType);
       }
@@ -2163,7 +2150,7 @@ public class Cooja extends Observable {
       public void actionPerformed(ActionEvent e) {
         Object pluginClass = ((JMenuItem)e.getSource()).getClientProperty("class");
         Object mote = ((JMenuItem)e.getSource()).getClientProperty("mote");
-        tryStartPlugin((Class<? extends Plugin>) pluginClass, Cooja.this, getSimulation(), (Mote)mote);
+        tryStartPlugin((Class<? extends Plugin>) pluginClass, getSimulation(), (Mote)mote);
       }
     };
 
@@ -3424,7 +3411,7 @@ public class Cooja extends Observable {
         }
       }
 
-      tryStartPlugin(pluginClass, this, sim, mote, pluginElement);
+      tryStartPlugin(pluginClass, sim, mote, pluginElement);
     }
 
     if (!isVisualized()) {
@@ -4113,7 +4100,7 @@ public class Cooja extends Observable {
           Class<Plugin> pluginClass =
             (Class<Plugin>) ((JMenuItem) e.getSource()).getClientProperty("class");
           Mote mote = (Mote) ((JMenuItem) e.getSource()).getClientProperty("mote");
-          tryStartPlugin(pluginClass, Cooja.this, mySimulation, mote);
+          tryStartPlugin(pluginClass, mySimulation, mote);
         }
       }, "StartPluginGUIAction").start();
     }

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1967,7 +1967,6 @@ public class Cooja extends Observable {
       if (!isVisualized() && VisPlugin.class.isAssignableFrom(pluginClass)) {
         throw new PluginRequiresVisualizationException();
       }
-
       if (pluginType == PluginType.MOTE_PLUGIN) {
         if (argGUI == null) {
           throw new PluginConstructionException("No GUI argument for mote plugin");
@@ -1978,11 +1977,9 @@ public class Cooja extends Observable {
         if (argMote == null) {
           throw new PluginConstructionException("No mote argument for mote plugin");
         }
-
         plugin =
           pluginClass.getConstructor(Mote.class, Simulation.class, Cooja.class)
           .newInstance(argMote, argSimulation, argGUI);
-
       } else if (pluginType == PluginType.SIM_PLUGIN || pluginType == PluginType.SIM_STANDARD_PLUGIN
     		  || pluginType == PluginType.SIM_CONTROL_PLUGIN) {
         if (argGUI == null) {
@@ -1991,19 +1988,12 @@ public class Cooja extends Observable {
         if (argSimulation == null) {
           throw new PluginConstructionException("No simulation argument for simulation plugin");
         }
-
-        plugin =
-          pluginClass.getConstructor(Simulation.class, Cooja.class)
-          .newInstance(argSimulation, argGUI);
-
-      } else if (pluginType == PluginType.COOJA_PLUGIN
-          || pluginType == PluginType.COOJA_STANDARD_PLUGIN) {
+        plugin = pluginClass.getConstructor(Simulation.class, Cooja.class).newInstance(argSimulation, argGUI);
+      } else if (pluginType == PluginType.COOJA_PLUGIN || pluginType == PluginType.COOJA_STANDARD_PLUGIN) {
         if (argGUI == null) {
           throw new PluginConstructionException("No GUI argument for GUI plugin");
         }
-
         plugin = pluginClass.getConstructor(Cooja.class).newInstance(argGUI);
-
       } else {
         throw new PluginConstructionException("Bad plugin type: " + pluginType);
       }

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1955,29 +1955,27 @@ public class Cooja extends Observable {
       throw new PluginConstructionException("Tool class not registered: " + pluginClass);
     }
 
-    // Construct plugin depending on plugin type
     int pluginType = pluginClass.getAnnotation(PluginType.class).value();
-    Plugin plugin;
+    if (pluginType != PluginType.COOJA_PLUGIN && pluginType != PluginType.COOJA_STANDARD_PLUGIN &&
+            argSimulation == null) {
+      throw new PluginConstructionException("No simulation argument for plugin");
+    }
+    if (pluginType == PluginType.MOTE_PLUGIN && argMote == null) {
+      throw new PluginConstructionException("No mote argument for mote plugin");
+    }
+    if (!isVisualized() && VisPlugin.class.isAssignableFrom(pluginClass)) {
+      throw new PluginConstructionException("Plugin " + pluginClass.getName() + " requires visualization");
+    }
 
+    // Construct plugin depending on plugin type
+    Plugin plugin;
     try {
-      if (!isVisualized() && VisPlugin.class.isAssignableFrom(pluginClass)) {
-        throw new PluginRequiresVisualizationException();
-      }
       if (pluginType == PluginType.MOTE_PLUGIN) {
-        if (argSimulation == null) {
-          throw new PluginConstructionException("No simulation argument for mote plugin");
-        }
-        if (argMote == null) {
-          throw new PluginConstructionException("No mote argument for mote plugin");
-        }
         plugin =
           pluginClass.getConstructor(Mote.class, Simulation.class, Cooja.class)
           .newInstance(argMote, argSimulation, this);
       } else if (pluginType == PluginType.SIM_PLUGIN || pluginType == PluginType.SIM_STANDARD_PLUGIN
     		  || pluginType == PluginType.SIM_CONTROL_PLUGIN) {
-        if (argSimulation == null) {
-          throw new PluginConstructionException("No simulation argument for simulation plugin");
-        }
         plugin = pluginClass.getConstructor(Simulation.class, Cooja.class).newInstance(argSimulation, this);
       } else if (pluginType == PluginType.COOJA_PLUGIN || pluginType == PluginType.COOJA_STANDARD_PLUGIN) {
         plugin = pluginClass.getConstructor(Cooja.class).newInstance(this);

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2023,9 +2023,8 @@ public class Cooja extends Observable {
                 location.y = Integer.parseInt(cfgElem.getText());
                 plugin.getCooja().setLocation(location);
               } else if (cfgElem.getName().equals("minimized")) {
-                boolean minimized = Boolean.parseBoolean(cfgElem.getText());
                 final var pluginGUI = plugin.getCooja();
-                if (minimized && pluginGUI != null) {
+                if (Boolean.parseBoolean(cfgElem.getText()) && pluginGUI != null) {
                   SwingUtilities.invokeLater(new Runnable() {
                     @Override
                     public void run() {

--- a/java/org/contikios/cooja/plugins/EventListener.java
+++ b/java/org/contikios/cooja/plugins/EventListener.java
@@ -137,8 +137,7 @@ public class EventListener extends VisPlugin {
         @Override
         public void actionPerformed(ActionEvent e) {
           MoteInterfaceViewer plugin =
-            (MoteInterfaceViewer) mySimulation.getCooja().tryStartPlugin(
-                MoteInterfaceViewer.class, mySimulation.getCooja(), mySimulation, myMote);
+            (MoteInterfaceViewer) mySimulation.getCooja().tryStartPlugin(MoteInterfaceViewer.class, mySimulation, myMote);
           plugin.setSelectedInterface(Cooja.getDescriptionOf(moteInterface.getClass()));
         }
       });

--- a/java/org/contikios/cooja/plugins/MoteInformation.java
+++ b/java/org/contikios/cooja/plugins/MoteInformation.java
@@ -109,7 +109,7 @@ public class MoteInformation extends VisPlugin implements MotePlugin {
     button.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(ActionEvent e) {
-        simulation.getCooja().tryStartPlugin(MoteTypeInformation.class, simulation.getCooja(), simulation, mote);
+        simulation.getCooja().tryStartPlugin(MoteTypeInformation.class, simulation, mote);
       }
     });
     smallPane.add(BorderLayout.EAST, button);
@@ -131,7 +131,7 @@ public class MoteInformation extends VisPlugin implements MotePlugin {
     button.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(ActionEvent e) {
-        simulation.getCooja().tryStartPlugin(MoteInterfaceViewer.class, simulation.getCooja(), simulation, mote);
+        simulation.getCooja().tryStartPlugin(MoteInterfaceViewer.class, simulation, mote);
       }
     });
     smallPane.add(BorderLayout.EAST, button);

--- a/java/org/contikios/cooja/plugins/Visualizer.java
+++ b/java/org/contikios/cooja/plugins/Visualizer.java
@@ -1687,7 +1687,6 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
       MoteInterfaceViewer viewer
               = (MoteInterfaceViewer) simulation.getCooja().tryStartPlugin(
                       MoteInterfaceViewer.class,
-                      simulation.getCooja(),
                       simulation,
                       mote);
       if (viewer == null) {
@@ -1736,7 +1735,6 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
       MoteInterfaceViewer viewer
               = (MoteInterfaceViewer) simulation.getCooja().tryStartPlugin(
                       MoteInterfaceViewer.class,
-                      simulation.getCooja(),
                       simulation,
                       mote);
       if (viewer == null) {


### PR DESCRIPTION
Hoist error checks to the beginning, use a switch-expression instead of a long if-then-else, and remove the Cooja parameter.