### PR TITLE
Use readelf for bss/data segment info

### DIFF
--- a/config/external_tools.config
+++ b/config/external_tools.config
@@ -7,10 +7,6 @@ PATH_JAVAC = javac
 DEFAULT_PROJECTDIRS =
 
 PARSE_WITH_COMMAND=false
-MAPFILE_DATA_START = ^.data[ \t]*0x([0-9A-Fa-f]*)[ \t]*0x[0-9A-Fa-f]*[ \t]*$
-MAPFILE_DATA_SIZE = ^.data[ \t]*0x[0-9A-Fa-f]*[ \t]*0x([0-9A-Fa-f]*)[ \t]*$
-MAPFILE_BSS_START = ^.bss[ \t]*0x([0-9A-Fa-f]*)[ \t]*0x[0-9A-Fa-f]*[ \t]*$
-MAPFILE_BSS_SIZE = ^.bss[ \t]*0x[0-9A-Fa-f]*[ \t]*0x([0-9A-Fa-f]*)[ \t]*$
 READELF_COMMAND = readelf -W --symbols $(LIBFILE)
 
 PARSE_COMMAND=nm -aP $(LIBFILE)

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -202,7 +202,7 @@ public class Cooja extends Observable {
    *  Version used to detect incompatibility with the Contiki-NG
    *  build system. The format is &lt;YYYY&gt;&lt;MM&gt;&lt;DD&gt;&lt;2 digit sequence number&gt;.
    */
-  public static final String CONTIKI_NG_BUILD_VERSION = "2022052601";
+  public static final String CONTIKI_NG_BUILD_VERSION = "2022071901";
 
   private static JFrame frame = null;
   private static final Logger logger = LogManager.getLogger(Cooja.class);
@@ -235,8 +235,6 @@ public class Cooja extends Observable {
 
     "PARSE_WITH_COMMAND",
 
-    "MAPFILE_DATA_START", "MAPFILE_DATA_SIZE",
-    "MAPFILE_BSS_START", "MAPFILE_BSS_SIZE",
     "READELF_COMMAND",
 
     "PARSE_COMMAND",


### PR DESCRIPTION
This replaces the parsing of the map file
with checking a few special symbol names
in the output from readelf.