### PR TITLE
AbstractCompileDialog: decouple from MoteType state

### DIFF
--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -482,7 +482,6 @@ public abstract class AbstractCompileDialog extends JDialog {
     	commandsArea.setEnabled(true);
       if (dialogState == DialogState.SELECTED_SOURCE) {
         contikiSource = new File(input);
-        moteType.setContikiSourceFile(contikiSource);
         commandsArea.setText(getDefaultCompileCommands(input));
         contikiFirmware = moteType.getExpectedFirmwareFile(input);
       }

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -646,8 +646,9 @@ public abstract class AbstractCompileDialog extends JDialog {
    * @return Suggested compile commands for compiling source
    */
   public String getDefaultCompileCommands(String name) {
+    String sourceNoExtension = new File(name.substring(0, name.length() - 2)).getName();
     return Cooja.getExternalToolsSetting("PATH_MAKE") + " -j$(CPUS) " +
-           moteType.getMakeTargetName(name) + " TARGET=" + targetName;
+            sourceNoExtension + "." + targetName + " TARGET=" + targetName;
   }
 
   private void abortAnyCompilation() {

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -118,6 +118,7 @@ public abstract class AbstractCompileDialog extends JDialog {
   private final JButton compileButton;
   private final JButton createButton = new JButton("Create");
 
+  protected final String targetName;
   private Component currentCompilationOutput = null;
   private Process currentCompilationProcess = null;
 
@@ -129,6 +130,7 @@ public abstract class AbstractCompileDialog extends JDialog {
     super(Cooja.getTopParentContainer(), "Create Mote Type: Compile Contiki", ModalityType.APPLICATION_MODAL);
     this.gui = sim.getCooja();
     this.moteType = moteType;
+    this.targetName = cfg.targetName();
 
     JPanel mainPanel = new JPanel(new BorderLayout());
     JLabel label;
@@ -314,14 +316,14 @@ public abstract class AbstractCompileDialog extends JDialog {
         nextCommandAction.actionPerformed(null); /* Recursive calls for all commands */
       }
     };
-    cleanButton.setToolTipText("make clean TARGET=" + moteType.getMoteType());
+    cleanButton.setToolTipText("make clean TARGET=" + targetName);
     cleanButton.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(ActionEvent e) {
         createButton.setEnabled(false);
 				try {
 					currentCompilationProcess = BaseContikiMoteType.compile(
-							"make clean TARGET=" + moteType.getMoteType(),
+							"make clean TARGET=" + targetName,
               moteType.getCompilationEnvironment(),
 							new File(contikiField.getText()).getParentFile(),
 							null,
@@ -441,7 +443,8 @@ public abstract class AbstractCompileDialog extends JDialog {
       }
     }
     Class<? extends MoteInterface>[] arr = new Class[selected.size()];
-    return new BaseContikiMoteType.MoteTypeConfig(descriptionField.getText(), contikiField.getText(), commandsArea.getText(), selected.toArray(arr));
+    return new BaseContikiMoteType.MoteTypeConfig(descriptionField.getText(), null, contikiField.getText(),
+            commandsArea.getText(), selected.toArray(arr));
   }
 
   public abstract boolean canLoadFirmware(String name);
@@ -644,7 +647,7 @@ public abstract class AbstractCompileDialog extends JDialog {
    */
   public String getDefaultCompileCommands(String name) {
     return Cooja.getExternalToolsSetting("PATH_MAKE") + " -j$(CPUS) " +
-           moteType.getMakeTargetName(name) + " TARGET=" + moteType.getMoteType();
+           moteType.getMakeTargetName(name) + " TARGET=" + targetName;
   }
 
   private void abortAnyCompilation() {

--- a/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/ContikiMoteCompileDialog.java
@@ -150,12 +150,8 @@ public class ContikiMoteCompileDialog extends AbstractCompileDialog {
 
   @Override
   public String getDefaultCompileCommands(String name) {
-    String defines = "";
-    if (((ContikiMoteType) moteType).getNetworkStack().getHeaderFile() != null) {
-      defines = " DEFINES=NETSTACK_CONF_H=" + ((ContikiMoteType) moteType).getNetworkStack().getHeaderFile();
-    }
-
-    return super.getDefaultCompileCommands(name) + defines;
+    var headerFile = ((ContikiMoteType) moteType).getNetworkStack().getHeaderFile();
+    return super.getDefaultCompileCommands(name) + (headerFile == null ? "" :  " DEFINES=NETSTACK_CONF_H=" + headerFile);
   }
 
 }

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -159,17 +159,6 @@ public abstract class BaseContikiMoteType implements MoteType {
             "/build/" + getMoteType() + "/" + sourceNoExtension + '.' + getMoteType());
   }
 
-  /**
-   * Returns make target based on source file name.
-   *
-   * @param name Name of source file.
-   * @return Make target based on source file
-   */
-  public String getMakeTargetName(String name) {
-    String sourceNoExtension = new File(name.substring(0, name.length() - 2)).getName();
-    return sourceNoExtension + "." + getMoteType();
-  }
-
   @Override
   public Class<? extends MoteInterface>[] getMoteInterfaceClasses() {
     if (moteInterfaceClasses.isEmpty()) {

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -306,7 +306,8 @@ public abstract class BaseContikiMoteType implements MoteType {
       String file = source != null ? source.getAbsolutePath() : firmware != null ? firmware.getAbsolutePath() : null;
       var moteClasses = getMoteInterfaceClasses();
       var interfaces = moteClasses == null ? getDefaultMoteInterfaceClasses() : moteClasses;
-      var cfg = showCompilationDialog(sim, new MoteTypeConfig(desc, file, getCompileCommands(), interfaces));
+      var cfg = showCompilationDialog(sim, new MoteTypeConfig(desc, getMoteType(), file,
+              getCompileCommands(), interfaces));
       if (cfg == null) {
         return false;
       }
@@ -340,7 +341,8 @@ public abstract class BaseContikiMoteType implements MoteType {
   }
 
   /** Compilation-relevant parts of mote type configuration. */
-  public record MoteTypeConfig(String desc, String file, String commands, Class<? extends MoteInterface>[] interfaces) {}
+  public record MoteTypeConfig(String desc, String targetName, String file, String commands,
+                               Class<? extends MoteInterface>[] interfaces) {}
 
   /** Create a compilation dialog for this mote type. */
   protected abstract AbstractCompileDialog createCompilationDialog(Simulation sim, MoteTypeConfig cfg);

--- a/java/org/contikios/cooja/mspmote/MspCompileDialog.java
+++ b/java/org/contikios/cooja/mspmote/MspCompileDialog.java
@@ -52,6 +52,6 @@ public class MspCompileDialog extends AbstractCompileDialog {
 
   @Override
   public boolean canLoadFirmware(String name) {
-    return name.endsWith("." + moteType.getMoteType()) || name.equals("main.exe");
+    return name.endsWith("." + targetName) || name.equals("main.exe");
   }
 }


### PR DESCRIPTION
This removes some of the code that pokes around in the internal state of the mote type.