### PR TITLE
Fixes error "No line found"

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -591,7 +591,6 @@ public class ContikiMoteType extends BaseContikiMoteType {
         s.next();
         var name = s.next();
         varNames.put(name, new Symbol(Symbol.Type.VARIABLE, name, addr + offset, size));
-        s.nextLine(); // Skip rest of line.
       }
       return varNames;
     }


### PR DESCRIPTION
This PR fixes the following error I encountered when adding a Cooja mote to a simulation.

```
org.contikios.cooja.Cooja$SimulationCreationException: Unknown error: No line found
	at org.contikios.cooja.Cooja.createSimulation(Cooja.java:3207)
	at org.contikios.cooja.Cooja.loadSimulationConfig(Cooja.java:3109)
	at org.contikios.cooja.Cooja$37.doInBackground(Cooja.java:2419)
	at org.contikios.cooja.Cooja$37.doInBackground(Cooja.java:2404)
	at java.desktop/javax.swing.SwingWorker$1.call(SwingWorker.java:304)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.desktop/javax.swing.SwingWorker.run(SwingWorker.java:343)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.util.NoSuchElementException: No line found
	at java.base/java.util.Scanner.nextLine(Scanner.java:1651)
	at org.contikios.cooja.contikimote.ContikiMoteType$MapSectionParser.parseSymbols(ContikiMoteType.java:597)
	at org.contikios.cooja.contikimote.ContikiMoteType$SectionParser.parse(ContikiMoteType.java:509)
	at org.contikios.cooja.contikimote.ContikiMoteType.loadMoteFirmware(ContikiMoteType.java:400)
	at org.contikios.cooja.mote.BaseContikiMoteType.configureAndInit(BaseContikiMoteType.java:334)
	at org.contikios.cooja.contikimote.ContikiMoteType.setConfigXML(ContikiMoteType.java:948)
	at org.contikios.cooja.Simulation.setConfigXML(Simulation.java:632)
	at org.contikios.cooja.Cooja.createSimulation(Cooja.java:3196)
	... 9 more
```