### PR TITLE
ContikiMoteType: handle mixed readelf output

### DIFF
--- a/config/external_tools.config
+++ b/config/external_tools.config
@@ -11,7 +11,7 @@ MAPFILE_DATA_START = ^.data[ \t]*0x([0-9A-Fa-f]*)[ \t]*0x[0-9A-Fa-f]*[ \t]*$
 MAPFILE_DATA_SIZE = ^.data[ \t]*0x[0-9A-Fa-f]*[ \t]*0x([0-9A-Fa-f]*)[ \t]*$
 MAPFILE_BSS_START = ^.bss[ \t]*0x([0-9A-Fa-f]*)[ \t]*0x[0-9A-Fa-f]*[ \t]*$
 MAPFILE_BSS_SIZE = ^.bss[ \t]*0x[0-9A-Fa-f]*[ \t]*0x([0-9A-Fa-f]*)[ \t]*$
-READELF_COMMAND = readelf -W --sym-base=10 --symbols $(LIBFILE)
+READELF_COMMAND = readelf -W --symbols $(LIBFILE)
 
 PARSE_COMMAND=nm -aP $(LIBFILE)
 COMMAND_VAR_NAME_ADDRESS_SIZE = ^(?<symbol>[^.].*?) <SECTION> (?<address>[0-9a-fA-F]+) (?<size>[0-9a-fA-F])*

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -582,7 +582,11 @@ public class ContikiMoteType extends BaseContikiMoteType {
           continue;
         }
         var addr = s.nextLong(16);
-        var size = s.nextInt();
+        // Size is output in decimal if below 100000, hex otherwise. The command line option --sym-base=10 gives
+        // a decimal output, but readelf 2.34 does not have the option.
+        var sizeString = s.next();
+        var hex = sizeString.startsWith("0x");
+        var size = Integer.parseInt(hex ? sizeString.substring(2) : sizeString, hex ? 16 : 10);
         var type = s.next();
         if (!"OBJECT".equals(type)) {
           s.nextLine(); // Skip lines that do not define variables.


### PR DESCRIPTION
Older versions of readelf do not have the --sym-base option, so deal with the mixed output format.