### PR TITLE
LogScriptEngine: remove busy-wait loop

### DIFF
--- a/java/org/contikios/cooja/script/ScriptParser.java
+++ b/java/org/contikios/cooja/script/ScriptParser.java
@@ -233,6 +233,7 @@ public class ScriptParser {
     "timeout_function = null; " +
     "function run() { try {" +
     "SEMAPHORE_SIM.acquire(); " +
+    "BARRIER.countDown(); " +
     "SEMAPHORE_SCRIPT.acquire(); " + /* STARTUP BLOCKS HERE! */
     "if (TIMEOUT) { SCRIPT_TIMEOUT(); } " +
     "if (SHUTDOWN) { throw new Shutdown(); } " +


### PR DESCRIPTION
This simplifies the code, removes an IntelliJ
warning, and reduces the sys time slightly
on 07-simulation-base.

Before:

real 115.30
user 24.61
sys 3.35

After:

real 114.34
user 24.98
sys 2.81