### PR TITLE
ScriptParser: release semaphore on exit

### DIFF
--- a/java/org/contikios/cooja/script/ScriptParser.java
+++ b/java/org/contikios/cooja/script/ScriptParser.java
@@ -244,6 +244,7 @@ public class ScriptParser {
     "\n" +
     "while (true) { YIELD(); } " /* SCRIPT ENDED */+
     "} catch (error) { " +
+    "SEMAPHORE_SCRIPT.release(); " +
     "if (error instanceof TestOK) return 0; " +
     "if (error instanceof TestFailed) return 1; " +
     "if (error instanceof Shutdown) return -1; " +


### PR DESCRIPTION
This makes the SEMAPHORE_SCRIPT into 1 when
exiting the script.