### PR TITLE
ScriptLog: pass in mote as parameter

### DIFF
--- a/java/org/contikios/cooja/LogScriptEngine.java
+++ b/java/org/contikios/cooja/LogScriptEngine.java
@@ -356,8 +356,7 @@ public class LogScriptEngine {
     }
 
     @Override
-    public void generateMessage(final long delay, final String msg) {
-      final Mote currentMote = (Mote) engine.get("mote");
+    public void generateMsg(final Mote currentMote, final long delay, final String msg) {
       final TimeEvent generateEvent = new TimeEvent() {
         @Override
         public void execute(long t) {

--- a/java/org/contikios/cooja/script/ScriptLog.java
+++ b/java/org/contikios/cooja/script/ScriptLog.java
@@ -33,9 +33,11 @@ package org.contikios.cooja.script;
 
 /* Morty: This interface must be public, otherwise openjdk will fail */
 
+import org.contikios.cooja.Mote;
+
 public interface ScriptLog {
     void log(String log);
-    void generateMessage(long delay, String msg);
+    void generateMsg(Mote mote, long delay, String msg);
     void append(String filename, String msg);
     void writeFile(String filename, String msg);
 }

--- a/java/org/contikios/cooja/script/ScriptParser.java
+++ b/java/org/contikios/cooja/script/ScriptParser.java
@@ -61,6 +61,8 @@ public class ScriptParser {
 
     code = replaceTestStatus(code);
 
+    code = replaceGenerateMessage(code);
+
     this.code = code;
   }
 
@@ -194,6 +196,10 @@ public class ScriptParser {
     return Pattern.compile("log\\.testFailed\\(\\)").matcher(code).replaceAll("throw new TestFailed()");
   }
 
+  private static String replaceGenerateMessage(String code) {
+    return Pattern.compile("log\\.generateMessage\\(").matcher(code).replaceAll("log.generateMsg(mote, ");
+  }
+
   public String getJSCode() {
     return getJSCode(code, timeoutCode);
   }
@@ -246,7 +252,7 @@ public class ScriptParser {
     "};" +
     "\n" +
     "function GENERATE_MSG(time, msg) { " +
-    " log.generateMessage(time, msg); " +
+    " log.generateMsg(mote, time, msg); " +
     "};\n" +
     "\n" +
     "function SCRIPT_TIMEOUT() { " +


### PR DESCRIPTION
The mote is available in the JavaScript code
so pass it as a parameter instead of digging
it out of the engine inside the called method.