### PR TITLE
ScriptParser: call YIELD() on startup

### DIFF
--- a/java/org/contikios/cooja/script/ScriptParser.java
+++ b/java/org/contikios/cooja/script/ScriptParser.java
@@ -232,12 +232,7 @@ public class ScriptParser {
     """ +
     "timeout_function = null; " +
     "function run() { try {" +
-    "SEMAPHORE_SIM.release(); " +
-    "SEMAPHORE_SCRIPT.acquire(); " + /* STARTUP BLOCKS HERE! */
-    "if (TIMEOUT) { SCRIPT_TIMEOUT(); } " +
-    "if (SHUTDOWN) { throw new Shutdown(); } " +
-    "msg = new java.lang.String(msg); " +
-    "node.setMoteMsg(mote, msg); " +
+    "YIELD(); " +
     code + 
     "\n" +
     "\n" +


### PR DESCRIPTION
Remove the special startup-prelude and just
call YIELD() instead.