### PR TITLE
Use a single thread for the simulation

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -2219,7 +2219,7 @@ public class Cooja extends Observable {
    *          Should we ask for confirmation if a simulation is already active?
    * @return True if no simulation exists when method returns
    */
-  private boolean doRemoveSimulation(boolean askForConfirmation) {
+  boolean doRemoveSimulation(boolean askForConfirmation) {
 
     if (mySimulation == null) {
       return true;


### PR DESCRIPTION
Use a single thread instead of creating a new thread each time a simulation is started or stopped. This simplifies simulation control and avoids some issues when simulations are repetitively started and stopped very quickly.