### PR TITLE
Simulation: stop properly for headless mode

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -264,11 +264,6 @@ public class Simulation extends Observable {
     cooja.updateProgress(!isRunning);
     setChanged();
     notifyObservers(this);
-
-    if (!Cooja.isVisualized() && !isRunning) {
-      // Remove simulation when it stopped without GUI
-      cooja.doRemoveSimulation(false);
-    }
   }
 
   /**
@@ -343,7 +338,6 @@ public class Simulation extends Observable {
   /** Remove a script engine from the list of active script engines. */
   public void removeScriptEngine(LogScriptEngine engine) {
     engine.deactivateScript();
-    engine.closeLog();
     scriptEngines.remove(engine);
   }
 
@@ -392,7 +386,7 @@ public class Simulation extends Observable {
       returnValue = rv;
     }
 
-    commandQueue.add(Command.STOP);
+    commandQueue.add(Cooja.isVisualized() ? Command.STOP : Command.QUIT);
 
     if (block) {
       waitFor(false, 250);


### PR DESCRIPTION
The call to stopSimulation when headless means
kill the simulation thread which corresponds
to what QUIT does.