### PR TITLE
Simulation: move blocking to first method

### DIFF
--- a/java/org/contikios/cooja/LogScriptEngine.java
+++ b/java/org/contikios/cooja/LogScriptEngine.java
@@ -103,7 +103,7 @@ public class LogScriptEngine {
           Cooja.showErrorDialog(e.getMessage(), e, false);
         }
         deactivateScript();
-        simulation.stopSimulation(false, 1);
+        simulation.stopSimulation(1);
       }
     }
     @Override
@@ -290,7 +290,7 @@ public class LogScriptEngine {
           }
         }
         deactivateScript();
-        simulation.stopSimulation(false, rv > 0 ? rv : null);
+        simulation.stopSimulation(rv > 0 ? rv : null);
       }
     }, "script");
     scriptThread.start();

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -363,32 +363,30 @@ public class Simulation extends Observable {
   }
 
   /**
-   * Stop simulation (blocks) by calling stopSimulation(true, null).
+   * Stop simulation and block until it has stopped.
    */
   public void stopSimulation() {
-    stopSimulation(true, null);
+    if (stopSimulation(null)) {
+      waitFor(false, 250);
+    }
   }
 
   /**
    * Stop simulation
    *
-   * @param block Block until simulation has stopped, with timeout (100ms)
    * @param rv Return value from startSimulation, should be null unless > 0
+   * @return True if action was taken
    */
-  public void stopSimulation(boolean block, Integer rv) {
+  public boolean stopSimulation(Integer rv) {
     if (!isRunning() || isShutdown) {
-      return;
+      return false;
     }
     assert rv == null || rv > 0 : "Pass in rv = null or rv > 0";
     if (rv != null) {
       returnValue = rv;
     }
-
     commandQueue.add(Cooja.isVisualized() ? Command.STOP : Command.QUIT);
-
-    if (block) {
-      waitFor(false, 250);
-    }
+    return true;
   }
 
   private void waitFor(boolean isRunning, long timeout) {

--- a/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
+++ b/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
@@ -465,7 +465,7 @@ public class SerialSocketServer implements Plugin, MotePlugin {
             break;
           }
         }
-        simulation.stopSimulation(false, rv > 0 ? rv : null);
+        simulation.stopSimulation(rv > 0 ? rv : null);
         stopServer();
       }, "SerialSocketServer commands").start();
     }


### PR DESCRIPTION
The second method is only called with false
as argument, so move the blocking to the
only caller that needs it.