### PR TITLE
Always log test status in headless mode

### DIFF
--- a/java/org/contikios/cooja/LogScriptEngine.java
+++ b/java/org/contikios/cooja/LogScriptEngine.java
@@ -274,11 +274,9 @@ public class LogScriptEngine {
               // Something else is shutting down Cooja, for example the SerialSocket commands in 17-tun-rpl-br.
               break;
             case 0:
-              logger.info("TEST OK\n");
               scriptLogObserver.update(null, "TEST OK\n");
               break;
             default:
-              logger.warn("TEST FAILED\n");
               scriptLogObserver.update(null, "TEST FAILED\n");
               break;
           }

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -228,6 +228,15 @@ public class Simulation extends Observable {
       for (Mote m: motes) {
         doRemoveMote(m);
       }
+
+      // Log test status to console in headless mode, ScriptRunner shows status in GUI mode.
+      if (!Cooja.isVisualized()) {
+        if (returnValue == null) {
+          logger.info("TEST OK\n");
+        } else {
+          logger.warn("TEST FAILED\n");
+        }
+      }
     }, "sim");
     simulationThread.start();
   }


### PR DESCRIPTION
Move the log statements to the removal of
the simulation. This avoids noise on the console
in GUI mode, and makes 17-tun-rpl-br print
the test status when shutting down.