### PR TITLE
Move logDir field to Simulation

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -180,6 +180,8 @@ public class Cooja extends Observable {
 
   private static GUI gui = null;
 
+  /** The Cooja startup configuration. */
+  private final Config configuration;
   private Simulation mySimulation;
 
   private final ArrayList<Class<? extends Plugin>> menuMotePluginClasses = new ArrayList<>();
@@ -210,17 +212,16 @@ public class Cooja extends Observable {
   /**
    * Creates a new Cooja Simulator GUI and ensures Swing initialization is done in the right thread.
    *
-   * @param logDirectory Directory for log files
-   * @param vis          True if running in visual mode
+   * @param cfg Cooja configuration
    */
-  public static Cooja makeCooja(final String logDirectory, final boolean vis) throws ParseProjectsException {
-    if (vis) {
+  public static Cooja makeCooja(Config cfg) throws ParseProjectsException {
+    if (cfg.noGui == null) {
       assert !java.awt.EventQueue.isDispatchThread() : "Call from regular context";
       return new RunnableInEDT<Cooja>() {
         @Override
         public Cooja work() {
           try {
-            return new Cooja(logDirectory, vis);
+            return new Cooja(cfg);
           } catch (ParseProjectsException e) {
             throw new RuntimeException("Could not parse projects", e);
           }
@@ -228,17 +229,17 @@ public class Cooja extends Observable {
       }.invokeAndWait();
     }
 
-    return new Cooja(logDirectory, vis);
+    return new Cooja(cfg);
   }
 
   /**
    * Internal constructor for Cooja.
    *
-   * @param logDirectory Directory for log files
-   * @param vis          True if running in visual mode
+   * @param cfg Cooja configuration
    */
-  private Cooja(String logDirectory, boolean vis) throws ParseProjectsException {
-    this.logDirectory = logDirectory;
+  private Cooja(Config cfg) throws ParseProjectsException {
+    logDirectory = cfg.logDir;
+    configuration = cfg;
     mySimulation = null;
     // Load default and overwrite with user settings (if any).
     loadExternalToolsDefaultSettings();
@@ -278,7 +279,7 @@ public class Cooja extends Observable {
       }
     }
 
-    if (vis) {
+    if (cfg.noGui == null) {
       gui = new GUI(this);
     } else {
       parseProjectConfig();
@@ -1392,7 +1393,7 @@ public class Cooja extends Observable {
 
     Cooja gui = null;
     try {
-      gui = makeCooja(config.logDir, vis);
+      gui = makeCooja(config);
     } catch (Exception e) {
       logger.error(e.getMessage());
       System.exit(1);

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -149,11 +149,6 @@ public class Cooja extends Observable {
   public static Properties defaultExternalToolsSettings;
   public static Properties currentExternalToolsSettings;
 
-  /**
-   * The name of the directory to output logs to.
-   */
-  public final String logDirectory;
-
   private static final String[] externalToolsSettingNames = new String[] {
     "PATH_COOJA",
     "PATH_CONTIKI", "PATH_APPS",
@@ -181,7 +176,7 @@ public class Cooja extends Observable {
   private static GUI gui = null;
 
   /** The Cooja startup configuration. */
-  private final Config configuration;
+  final Config configuration;
   private Simulation mySimulation;
 
   private final ArrayList<Class<? extends Plugin>> menuMotePluginClasses = new ArrayList<>();
@@ -238,7 +233,6 @@ public class Cooja extends Observable {
    * @param cfg Cooja configuration
    */
   private Cooja(Config cfg) throws ParseProjectsException {
-    logDirectory = cfg.logDir;
     configuration = cfg;
     mySimulation = null;
     // Load default and overwrite with user settings (if any).
@@ -1548,7 +1542,7 @@ public class Cooja extends Observable {
     var cfgSeed = root.getChild("simulation").getChild("randomseed").getText();
     long seed = manualRandomSeed != null ? manualRandomSeed
             : "generated".equals(cfgSeed) ? new Random().nextLong() : Long.parseLong(cfgSeed);
-    var newSim = new Simulation(this, seed);
+    var newSim = new Simulation(this, configuration.logDir, seed);
     try {
       if (!newSim.setConfigXML(root.getChild("simulation"), quick)) {
         logger.info("Simulation not loaded");

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1374,39 +1374,39 @@ public class Cooja extends Observable {
   /**
    * Load configurations and create a GUI.
    *
-   * @param options Parsed command line options
+   * @param config Cooja configuration
    */
-  public static void go(Main options) {
-    externalToolsUserSettingsFileReadOnly = options.externalToolsConfig != null;
-    if (options.externalToolsConfig == null) {
+  public static void go(Config config) {
+    externalToolsUserSettingsFileReadOnly = config.externalToolsConfig != null;
+    if (config.externalToolsConfig == null) {
       externalToolsUserSettingsFile = new File(System.getProperty("user.home"), ".cooja.user.properties");
     } else {
-      externalToolsUserSettingsFile = new File(options.externalToolsConfig);
+      externalToolsUserSettingsFile = new File(config.externalToolsConfig);
     }
 
-    specifiedContikiPath = options.contikiPath;
-    specifiedCoojaPath = options.coojaPath;
+    specifiedContikiPath = config.contikiPath;
+    specifiedCoojaPath = config.coojaPath;
 
     // Is Cooja started in GUI mode?
-    var vis = options.action == null || options.action.quickstart != null;
+    var vis = config.noGui == null;
 
     Cooja gui = null;
     try {
-      gui = makeCooja(options.logDir, vis);
+      gui = makeCooja(config.logDir, vis);
     } catch (Exception e) {
       logger.error(e.getMessage());
       System.exit(1);
     }
     // Check if simulator should be quick-started.
-    if (options.action != null) {
+    if (config.quickstart != null || config.noGui != null) {
       int rv = 0;
-      for (var cfg : vis ? new String[]{options.action.quickstart} : options.action.nogui) {
-        var config = new File(cfg);
+      for (var cfg : vis ? new String[]{config.quickstart} : config.noGui) {
+        var file = new File(cfg);
         Simulation sim = null;
         try {
           sim = vis
-                  ? Cooja.gui.doLoadConfig(config, options.updateSimulation, options.randomSeed)
-                  : gui.loadSimulationConfig(config, true, false, options.randomSeed);
+                  ? Cooja.gui.doLoadConfig(file, config.updateSim, config.randomSeed)
+                  : gui.loadSimulationConfig(file, true, false, config.randomSeed);
         } catch (Exception e) {
           logger.fatal("Exception when loading simulation: ", e);
         }
@@ -2238,4 +2238,9 @@ public class Cooja extends Observable {
       }
     }
   }
+
+  /** Structure to hold the Cooja startup configuration. */
+  public record Config(Long randomSeed, String externalToolsConfig, boolean updateSim,
+                       String logDir, String contikiPath, String coojaPath,
+                       String quickstart, String[] noGui) {}
 }

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -404,7 +404,7 @@ public class GUI {
           return;
         }
 
-        var sim = new Simulation(cooja, 123456);
+        var sim = new Simulation(cooja, cooja.configuration.logDir(), 123456);
         boolean ok;
         try {
           ok = sim.setSimConfig(CreateSimDialog.showDialog(cooja, sim.getSimConfig()));

--- a/java/org/contikios/cooja/LogScriptEngine.java
+++ b/java/org/contikios/cooja/LogScriptEngine.java
@@ -121,11 +121,11 @@ public class LogScriptEngine {
   private long startTime;
   private long startRealTime;
 
-  protected LogScriptEngine(Simulation simulation, int logNumber, JTextArea logTextArea) {
+  protected LogScriptEngine(Simulation simulation, String logDir, int logNumber, JTextArea logTextArea) {
     this.simulation = simulation;
     if (!Cooja.isVisualized()) {
       var logName = logNumber == 0 ? "COOJA.testlog" : String.format("COOJA-%02d.testlog", logNumber);
-      var logFile = Paths.get(simulation.getCooja().logDirectory, logName);
+      var logFile = Paths.get(logDir, logName);
       try {
         logWriter = Files.newBufferedWriter(logFile, UTF_8);
         logWriter.write("Random seed: " + simulation.getRandomSeed() + "\n");

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
 import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.contikios.cooja.Cooja.Config;
 import picocli.CommandLine;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
@@ -251,6 +252,10 @@ class Main {
       }
     }
 
+    var cfg = new Config(options.randomSeed, options.externalToolsConfig, options.updateSimulation,
+            options.logDir, options.contikiPath, options.coojaPath,
+            options.action == null ? null : options.action.quickstart,
+            options.action == null ? null : options.action.nogui);
     // Configure logger
     if (options.logConfigFile == null) {
       ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
@@ -290,10 +295,10 @@ class Main {
       //        but go immediately returns which causes the log file to be closed
       //        while the simulation is still running.
       Configurator.initialize(builder.build());
-      Cooja.go(options);
+      Cooja.go(cfg);
     } else {
       Configurator.initialize("ConfigFile", options.logConfigFile);
-      Cooja.go(options);
+      Cooja.go(cfg);
     }
   }
 }

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -61,6 +61,9 @@ public class Simulation extends Observable {
   public static final long MICROSECOND = 1L;
   public static final long MILLISECOND = 1000*MICROSECOND;
 
+  /** The name of the directory to output logs to. */
+  private final String logDir;
+
   /** Lock used to wait for simulation state changes */
   private final Object stateLock = new Object();
 
@@ -152,8 +155,9 @@ public class Simulation extends Observable {
   /**
    * Creates a new simulation
    */
-  public Simulation(Cooja cooja, long seed) {
+  public Simulation(Cooja cooja, String logDir, long seed) {
     this.cooja = cooja;
+    this.logDir = logDir;
     randomGenerator = new SafeRandom(this);
     randomSeed = seed;
     simulationThread = new Thread(() -> {
@@ -328,7 +332,7 @@ public class Simulation extends Observable {
   /** Create a new script engine that logs to the logTextArea and add it to the list
    *  of active script engines. */
   public LogScriptEngine newScriptEngine(JTextArea logTextArea) {
-    var engine = new LogScriptEngine(this, scriptEngines.size(), logTextArea);
+    var engine = new LogScriptEngine(this, logDir, scriptEngines.size(), logTextArea);
     scriptEngines.add(engine);
     return engine;
   }


### PR DESCRIPTION
This field is only used by the LogScriptEngine
in headless mode, so move the field from Cooja
to Simulation.

The reason the field was put in the Cooja class
in the first place was because of how the
initialization of Cooja looked at the time.