### PR TITLE
Move status printout to Cooja

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -3013,7 +3013,10 @@ public class Cooja extends Observable {
         if (!vis) {
           sim.setSpeedLimit(null);
           var ret = sim.startSimulation(true);
-          if (ret != null) {
+          if (ret == null) {
+            logger.info("TEST OK\n");
+          } else {
+            logger.warn("TEST FAILED\n");
             rv = Math.max(rv, ret);
           }
         }

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -228,15 +228,6 @@ public class Simulation extends Observable {
       for (Mote m: motes) {
         doRemoveMote(m);
       }
-
-      // Log test status to console in headless mode, ScriptRunner shows status in GUI mode.
-      if (!Cooja.isVisualized()) {
-        if (returnValue == null) {
-          logger.info("TEST OK\n");
-        } else {
-          logger.warn("TEST FAILED\n");
-        }
-      }
     }, "sim");
     simulationThread.start();
   }


### PR DESCRIPTION
This is a more natural place for the
test printout, and the placement
ensures this is the last thing
printed for each simulation.