### PR TITLE
Set look and feel in Main

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -116,10 +116,6 @@ import javax.swing.RepaintManager;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
 import javax.swing.Timer;
-import javax.swing.ToolTipManager;
-import javax.swing.UIManager;
-import javax.swing.UIManager.LookAndFeelInfo;
-import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 import javax.swing.filechooser.FileFilter;
@@ -1480,42 +1476,6 @@ public class Cooja extends Observable {
    */
   public JDesktopPane getDesktopPane() {
     return myDesktopPane;
-  }
-
-  private static void setLookAndFeel() throws InterruptedException, InvocationTargetException {
-    javax.swing.SwingUtilities.invokeAndWait(() -> {
-      JFrame.setDefaultLookAndFeelDecorated(true);
-      JDialog.setDefaultLookAndFeelDecorated(true);
-
-      ToolTipManager.sharedInstance().setDismissDelay(60000);
-
-      /* Nimbus */
-      try {
-        String osName = System.getProperty("os.name").toLowerCase();
-        if (osName.startsWith("linux")) {
-          try {
-            for (LookAndFeelInfo info : UIManager.getInstalledLookAndFeels()) {
-              if ("Nimbus".equals(info.getName())) {
-                UIManager.setLookAndFeel(info.getClassName());
-                break;
-              }
-            }
-          } catch (UnsupportedLookAndFeelException e) {
-            UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
-          }
-        } else {
-          UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
-        }
-        return;
-      } catch (Exception e) {
-      }
-
-      /* System */
-      try {
-        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-      } catch (Exception e) {
-      }
-    });
   }
 
   private static void updateDesktopSize(final JDesktopPane desktop) {
@@ -2975,17 +2935,6 @@ public class Cooja extends Observable {
 
     // Is Cooja started in GUI mode?
     var vis = options.action == null || options.action.quickstart != null;
-
-    if (vis) {
-      try {
-        setLookAndFeel();
-      } catch (InterruptedException e) {
-        logger.fatal("Thread interrupted: " + e.getMessage());
-        return;
-      } catch (InvocationTargetException e) {
-        throw new RuntimeException(e);
-      }
-    }
 
     Cooja gui = null;
     try {

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -29,6 +29,11 @@
 package org.contikios.cooja;
 
 import java.io.IOException;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.ToolTipManager;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
@@ -239,6 +244,46 @@ class Main {
 
     if (options.logName != null && !options.logName.endsWith(".log")) {
       options.logName += ".log";
+    }
+
+    var vis = options.action == null || options.action.quickstart != null;
+    if (vis) {
+      try {
+        java.awt.EventQueue.invokeAndWait(() -> {
+          JFrame.setDefaultLookAndFeelDecorated(true);
+          JDialog.setDefaultLookAndFeelDecorated(true);
+          ToolTipManager.sharedInstance().setDismissDelay(60000);
+          // Nimbus.
+          try {
+            String osName = System.getProperty("os.name").toLowerCase();
+            if (osName.startsWith("linux")) {
+              try {
+                for (UIManager.LookAndFeelInfo info : UIManager.getInstalledLookAndFeels()) {
+                  if ("Nimbus".equals(info.getName())) {
+                    UIManager.setLookAndFeel(info.getClassName());
+                    break;
+                  }
+                }
+              } catch (UnsupportedLookAndFeelException e) {
+                UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
+              }
+            } else {
+              UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+            }
+            return;
+          } catch (Exception e) {
+          }
+
+          // System.
+          try {
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+          } catch (Exception e) {
+          }
+        });
+      } catch (Exception e) {
+        System.err.println("Could not set look and feel: " + e.getMessage());
+        System.exit(1);
+      }
     }
 
     // Configure logger


### PR DESCRIPTION
The Cooja class does too many things,
so move the setting of look and feel
into the Main class.

This is also preparation for making
the -logname parameter more flexible
with multiple -nogui parameters.