### PR TITLE
ScriptParser: stop copying messages

### DIFF
--- a/java/org/contikios/cooja/script/ScriptParser.java
+++ b/java/org/contikios/cooja/script/ScriptParser.java
@@ -147,7 +147,6 @@ public class ScriptParser {
          throw new TestFailed();
        }
        if (SHUTDOWN) { throw new Shutdown(); }
-       msg = new java.lang.String(msg);
        node.setMoteMsg(mote, msg);
      };
 


### PR DESCRIPTION
Strings are immutable so use the string
directly instead of making a copy.

This saves 1 Mb of allocations on
02-ringbufindex.csc.