### PR TITLE
Simulation: load without searching for motes

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -685,11 +685,7 @@ public class Simulation extends Observable {
             logger.fatal("Mote was not created: " + element.getText().trim());
             throw new Exception("All motes were not recreated");
           }
-          if (getMoteWithID(mote.getID()) != null) {
-            logger.warn("Ignoring duplicate mote ID: " + mote.getID());
-          } else {
-            addMote(mote);
-          }
+          addMote(mote);
           break;
         }
       }


### PR DESCRIPTION
The config files are not supposed to contain
duplicate IDs, so stop validating IDs and just
add to the container.

This reduces the risk of the concurrent modification exception seen in the Contiki-NG CI.