### PR TITLE
Allow multiple -quickstart

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1394,7 +1394,7 @@ public class Cooja extends Observable {
     // Check if simulator should be quick-started.
     if (config.quickstart != null || config.noGui != null) {
       int rv = 0;
-      for (var cfg : vis ? new String[]{config.quickstart} : config.noGui) {
+      for (var cfg : vis ? config.quickstart : config.noGui) {
         var file = new File(cfg);
         Simulation sim = null;
         try {
@@ -1418,7 +1418,7 @@ public class Cooja extends Observable {
           }
         }
       }
-      if (!vis) {
+      if (!vis || config.updateSim) {
         gui.doQuit(rv);
       }
     }
@@ -1466,7 +1466,6 @@ public class Cooja extends Observable {
     // Rewrite simulation config after the InputStream is closed.
     if (rewriteCsc) {
       saveSimulationConfig(file);
-      System.exit(0);
     }
     return sim;
   }
@@ -2236,5 +2235,5 @@ public class Cooja extends Observable {
   /** Structure to hold the Cooja startup configuration. */
   public record Config(Long randomSeed, String externalToolsConfig, boolean updateSim,
                        String logDir, String contikiPath, String coojaPath,
-                       String quickstart, String[] noGui) {}
+                       String[] quickstart, String[] noGui) {}
 }

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -1246,7 +1246,7 @@ public class GUI {
                                                                                          boolean rewriteCsc, Long manualRandomSeed) {
     assert java.awt.EventQueue.isDispatchThread() : "Call from AWT thread";
     final var autoStart = configFile == null && cooja.getSimulation().isRunning();
-    if (configFile != null && !cooja.doRemoveSimulation(true)) {
+    if (configFile != null && !cooja.doRemoveSimulation(!cooja.configuration.updateSim())) {
       return null;
     }
 

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -114,7 +114,7 @@ class Main {
      * Option for specifying file to start the simulation with.
      */
     @Option(names = "-quickstart", paramLabel = "FILE", description = "start simulation with file")
-    String quickstart;
+    String[] quickstart;
 
     /**
      * Option for specifying file to start the simulation with.
@@ -182,7 +182,7 @@ class Main {
 
     // Verify soundness of -nogui/-quickstart argument.
     if (options.action != null) {
-      for (var file : options.action.nogui == null ? new String[] {options.action.quickstart} : options.action.nogui) {
+      for (var file : options.action.nogui == null ? options.action.quickstart : options.action.nogui) {
         if (!file.endsWith(".csc") && !file.endsWith(".csc.gz")) {
           String option = options.action.nogui == null ? "-quickstart" : "-nogui";
           System.err.println("Cooja " + option + " expects a filename extension of '.csc'");


### PR DESCRIPTION
This aligns the behavior of -quickstart
with -nogui. This also makes -update-simulation
work with the current test makefiles in Contiki-NG.