### PR TITLE
Cooja: use same javac as gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,11 @@ plugins {
     id 'application'
 }
 
+def javaVersion = 17
+
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(javaVersion)
   }
 }
 
@@ -101,7 +103,10 @@ tasks.register('fullJar', Jar) {
 run {
   // Bad Cooja location detected with gradle run, explicitly pass -cooja.
   doFirst {
-    args += ['-cooja', "$projectDir"]
+    args += ['-cooja', "$projectDir",
+             '-javac', javaToolchains.compilerFor {
+                         languageVersion = JavaLanguageVersion.of(javaVersion)
+                       }.get().executablePath]
   }
   // Pass all command line "-Dcooja.k=v" as "-Dk=v" to Cooja.
   System.properties.each { k,v ->

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -149,6 +149,7 @@ public class Cooja extends Observable {
   public static Properties defaultExternalToolsSettings;
   public static Properties currentExternalToolsSettings;
 
+  // FIXME: remove PATH_JAVAC.
   private static final String[] externalToolsSettingNames = new String[] {
     "PATH_COOJA",
     "PATH_CONTIKI", "PATH_APPS",
@@ -2234,6 +2235,6 @@ public class Cooja extends Observable {
 
   /** Structure to hold the Cooja startup configuration. */
   public record Config(Long randomSeed, String externalToolsConfig, boolean updateSim,
-                       String logDir, String contikiPath, String coojaPath,
+                       String logDir, String contikiPath, String coojaPath, String javac,
                        String[] quickstart, String[] noGui) {}
 }

--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -145,13 +145,14 @@ public abstract class CoreComm {
   /**
    * Compiles Java class.
    *
+   * @param cooja Cooja object
    * @param tempDir Directory for temporary files
    * @param className
    *          Java class name (without extension)
    * @throws MoteTypeCreationException
    *           If Java class compilation error occurs
    */
-  private static void compileSourceFile(Path tempDir, String className)
+  private static void compileSourceFile(Cooja cooja, Path tempDir, String className)
       throws MoteTypeCreationException {
       /* Try to create a message list with support for GUI - will give not UI if headless */
     MessageList compilationOutput = MessageContainer.createMessageList(true);
@@ -162,9 +163,8 @@ public abstract class CoreComm {
 
     try {
       int b;
-      String[] cmd = new String[] {
-          Cooja.getExternalToolsSetting("PATH_JAVAC"),
-          "-cp", System.getProperty("java.class.path"), "--release", "17",
+      String[] cmd = new String[] {cooja.configuration.javac(),
+          "-cp", System.getProperty("java.class.path"), "--release", String.valueOf(Runtime.version().feature()),
           // Disable warnings to avoid 3 lines of "warning: using incubating module(s): jdk.incubator.foreign".
           "-nowarn", "--add-modules", "jdk.incubator.foreign",
           tempDir + "/org/contikios/cooja/corecomm/" + className + ".java" };
@@ -201,6 +201,7 @@ public abstract class CoreComm {
    * Create and return an instance of the core communicator identified by
    * className. This core communicator will load the native library libFile.
    *
+   * @param cooja Cooja object
    * @param tempDir Directory for temporary files
    * @param className
    *          Class name of core communicator
@@ -208,10 +209,10 @@ public abstract class CoreComm {
    *          Native library file
    * @return Core Communicator
    */
-  public static CoreComm createCoreComm(Path tempDir, String className, File libFile)
+  public static CoreComm createCoreComm(Cooja cooja, Path tempDir, String className, File libFile)
       throws MoteTypeCreationException {
     generateLibSourceFile(tempDir, className);
-    compileSourceFile(tempDir, className);
+    compileSourceFile(cooja, tempDir, className);
 
     // Loading a class might leave residue in the JVM so use a new name for the next call.
     fileCounter++;

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -89,6 +89,12 @@ class Main {
   String coojaPath;
 
   /**
+   * Option for specifying javac path.
+   */
+  @Option(names = "-javac", paramLabel = "FILE", description = "the javac binary", required = true)
+  String javac;
+
+  /**
    * Option for specifying external config file of tools.
    */
   @Option(names = "-external_tools_config", paramLabel = "FILE", description = "the filename for external config")
@@ -238,6 +244,11 @@ class Main {
       System.exit(1);
     }
 
+    if (!Files.exists(Path.of(options.javac))) {
+      System.err.println("Java compiler '" + options.javac + "' does not exist");
+      System.exit(1);
+    }
+
     if (options.logName != null && !options.logName.endsWith(".log")) {
       options.logName += ".log";
     }
@@ -253,7 +264,7 @@ class Main {
     }
 
     var cfg = new Config(options.randomSeed, options.externalToolsConfig, options.updateSimulation,
-            options.logDir, options.contikiPath, options.coojaPath,
+            options.logDir, options.contikiPath, options.coojaPath, options.javac,
             options.action == null ? null : options.action.quickstart,
             options.action == null ? null : options.action.nogui);
     // Configure logger

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -272,7 +272,7 @@ public class ContikiMoteType extends BaseContikiMoteType {
     // Allocate core communicator class
     final var firmwareFile = getContikiFirmwareFile();
     logger.debug("Creating core communicator between Java class " + javaClassName + " and Contiki library '" + firmwareFile.getPath() + "'");
-    myCoreComm = CoreComm.createCoreComm(tmpDir, javaClassName, firmwareFile);
+    myCoreComm = CoreComm.createCoreComm(gui, tmpDir, javaClassName, firmwareFile);
 
     /* Parse addresses using map file
      * or output of command specified in external tools settings (e.g. nm -a )


### PR DESCRIPTION
Pass in the javac to use as a parameter
to ensure the intended compiler is used.
Also use the feature release of the JDK
as target when compiling CoreCommTemplate.java
instead of having a hardcoded version in
the source code.