### PR TITLE
CoreComm: remove offset computations

### DIFF
--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -85,7 +85,6 @@ import org.contikios.cooja.dialogs.MessageList;
 public abstract class CoreComm {
   private final static ArrayList<File> coreCommFiles = new ArrayList<>();
 
-  protected long offset = 0;
   private static int fileCounter = 1;
 
   /**
@@ -259,15 +258,6 @@ public abstract class CoreComm {
   public abstract long getReferenceAddress();
 
   /**
-   * Set the offset between absolute and relative memory addresses.
-   *
-   * @param offset Offset between absolute and relative addresses
-   */
-  public void setReferenceOffset(long offset) {
-    this.offset = offset;
-  }
-
-  /**
    * Fills a byte array with memory segment identified by start and length.
    *
    * @param relAddr Relative memory start address
@@ -275,7 +265,7 @@ public abstract class CoreComm {
    * @param mem Array to fill with memory segment
    */
   public void getMemory(long relAddr, int length, byte[] mem) {
-    final var addr = MemoryAddress.ofLong(relAddr + offset);
+    final var addr = MemoryAddress.ofLong(relAddr);
     addr.asSegment(length, ResourceScope.globalScope()).asByteBuffer().get(0, mem, 0, length);
   }
 
@@ -287,7 +277,7 @@ public abstract class CoreComm {
    * @param mem New memory segment data
    */
   public void setMemory(long relAddr, int length, byte[] mem) {
-    final var addr = MemoryAddress.ofLong(relAddr + offset);
+    final var addr = MemoryAddress.ofLong(relAddr);
     addr.asSegment(length, ResourceScope.globalScope()).asByteBuffer().put(0, mem, 0, length);
   }
 }

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -166,9 +166,6 @@ public class ContikiMoteType extends BaseContikiMoteType {
   // Initial memory for all motes of this type
   private SectionMoteMemory initialMemory = null;
 
-  /** Offset between native (cooja) and contiki address space */
-  long offset;
-
   /**
    * Creates a new uninitialized Cooja mote type. This mote type needs to load
    * a library file and parse a map file before it can be used.
@@ -330,6 +327,7 @@ public class ContikiMoteType extends BaseContikiMoteType {
      *
      * This offset will be used in Cooja in the memory abstraction to match
      * Contiki's and Cooja's address spaces */
+    long offset;
     HashMap<String, Symbol> variables = new HashMap<>();
     {
       SectionMoteMemory tmp = new SectionMoteMemory(variables);
@@ -342,7 +340,6 @@ public class ContikiMoteType extends BaseContikiMoteType {
       try {
         long referenceVar = tmp.getSymbolMap().get("referenceVar").addr;
         offset = myCoreComm.getReferenceAddress() - referenceVar;
-        myCoreComm.setReferenceOffset(offset);
       } catch (Exception e) {
         throw new MoteTypeCreationException("Error setting reference variable: " + e.getMessage(), e);
       }
@@ -664,7 +661,7 @@ public class ContikiMoteType extends BaseContikiMoteType {
    */
   protected void getCoreMemory(SectionMoteMemory mem) {
     for (var sec : mem.getSections().values()) {
-      myCoreComm.getMemory(sec.getStartAddr() - offset, sec.getTotalSize(), sec.getMemory());
+      myCoreComm.getMemory(sec.getStartAddr(), sec.getTotalSize(), sec.getMemory());
     }
   }
 
@@ -676,7 +673,7 @@ public class ContikiMoteType extends BaseContikiMoteType {
    */
   protected void setCoreMemory(SectionMoteMemory mem) {
     for (var sec : mem.getSections().values()) {
-      myCoreComm.setMemory(sec.getStartAddr() - offset, sec.getTotalSize(), sec.getMemory());
+      myCoreComm.setMemory(sec.getStartAddr(), sec.getTotalSize(), sec.getMemory());
     }
   }
 


### PR DESCRIPTION
Subtracting an offset at the caller and adding
it back in the callee just wastes cycles, remove
the offset calculations.