### PR TITLE
picocli: disable closures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,7 @@ run {
       systemProperty k - "cooja.", v
     }
   }
+  systemProperty 'picocli.disable.closures', "true"
   // Enable assertions with "-Passertions".
   enableAssertions = project.hasProperty('assertions')
 }


### PR DESCRIPTION
According to https://picocli.info/#_closures_in_annotations, this can improve application startup time.