### PR TITLE
Support for Mobility plugin.

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -83,6 +83,7 @@ import org.contikios.cooja.plugins.BufferListener;
 import org.contikios.cooja.plugins.DGRMConfigurator;
 import org.contikios.cooja.plugins.EventListener;
 import org.contikios.cooja.plugins.LogListener;
+import org.contikios.cooja.plugins.Mobility;
 import org.contikios.cooja.plugins.MoteInformation;
 import org.contikios.cooja.plugins.MoteInterfaceViewer;
 import org.contikios.cooja.plugins.MoteTypeInformation;
@@ -472,6 +473,7 @@ public class Cooja extends Observable {
     registerPlugin(Visualizer.class);
     registerPlugin(LogListener.class);
     registerPlugin(TimeLine.class);
+    registerPlugin(Mobility.class);
     registerPlugin(MoteInformation.class);
     registerPlugin(MoteInterfaceViewer.class);
     registerPlugin(VariableWatcher.class);

--- a/java/org/contikios/cooja/plugins/Mobility.java
+++ b/java/org/contikios/cooja/plugins/Mobility.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2009, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+package org.contikios.cooja.plugins;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import javax.swing.JFileChooser;
+import javax.swing.JScrollPane;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+import org.contikios.cooja.ClassDescription;
+import org.contikios.cooja.Cooja;
+import org.contikios.cooja.Mote;
+import org.contikios.cooja.PluginType;
+import org.contikios.cooja.Simulation;
+import org.contikios.cooja.TimeEvent;
+import org.contikios.cooja.VisPlugin;
+import org.contikios.cooja.dialogs.MessageListUI;
+import org.contikios.cooja.interfaces.Position;
+import org.contikios.cooja.util.StringUtils;
+
+import org.jdom.Element;
+
+
+@ClassDescription("Mobility")
+@PluginType(PluginType.SIM_PLUGIN)
+public class Mobility extends VisPlugin {
+  private static Logger logger = LogManager.getLogger(Mobility.class);
+
+  private static final boolean QUIET = false;
+
+  private final boolean WRAP_MOVES = true; /* Wrap around loaded moves forever */
+
+  private Move[] entries; /* All mote moves */
+  private Simulation simulation;
+  private long periodStart; /* us */
+  private int currentMove;
+
+  private File filePositions = null;
+
+  private MessageListUI log = new MessageListUI();
+
+  public Mobility(Simulation simulation, final Cooja gui) {
+    super("Mobility", gui);
+    this.simulation = simulation;
+
+    log.addPopupMenuItem(null, true); /* Create message list popup */
+    add(new JScrollPane(log));
+
+    if (!QUIET) {
+      log.addMessage("Mobility plugin started at (ms): " + simulation.getSimulationTimeMillis());
+      logger.info("Mobility plugin started at (ms): " + simulation.getSimulationTimeMillis());
+    }
+    setSize(500,200);
+  }
+
+  @Override
+  public void startPlugin() {
+    super.startPlugin();
+
+    if (filePositions != null) {
+      /* Positions were already loaded */
+      return;
+    }
+
+    JFileChooser fileChooser = new JFileChooser();
+    File suggest = new File(Cooja.getExternalToolsSetting("MOBILITY_LAST", "positions.dat"));
+    fileChooser.setSelectedFile(suggest);
+    fileChooser.setDialogTitle("Select positions file");
+    int reply = fileChooser.showOpenDialog(Cooja.getTopParentContainer());
+    if (reply == JFileChooser.APPROVE_OPTION) {
+      filePositions = fileChooser.getSelectedFile();
+      Cooja.setExternalToolsSetting("MOBILITY_LAST", filePositions.getAbsolutePath());
+    }
+    if (filePositions == null) {
+      throw new RuntimeException("No positions file");
+    }
+    loadPositions();
+  }
+
+  private void loadPositions() {
+    try {
+      if (!QUIET) {
+        log.addMessage("Parsing position file: " + filePositions);
+        logger.info("Parsing position file: " + filePositions);
+      }
+
+      String data = StringUtils.loadFromFile(filePositions);
+
+      /* Load move by move */
+      ArrayList<Move> entriesList = new ArrayList<Move>();
+      for (String line: data.split("\n")) {
+        if (line.trim().isEmpty() || line.startsWith("#")) {
+          /* Skip header/metadata */
+          continue;
+        }
+
+        String[] args = line.split(" ");
+        Move e = new Move();
+        e.moteIndex = Integer.parseInt(args[0]); /* XXX Mote index. Not ID */
+        e.time = (long) (Double.parseDouble(args[1])*1000.0*Simulation.MILLISECOND); /* s -> us */
+        e.posX = Double.parseDouble(args[2]);
+        e.posY = Double.parseDouble(args[3]);
+
+        entriesList.add(e);
+      }
+      entries = entriesList.toArray(new Move[0]);
+      if (!QUIET) {
+        log.addMessage("Loaded " + entries.length + " positions");
+        logger.info("Loaded " + entries.length + " positions");
+      }
+
+      setTitle("Mobility: " + filePositions.getName());
+
+      /* Execute first event - it will reschedule itself */
+      simulation.invokeSimulationThread(new Runnable() {
+        public void run() {
+          currentMove = 0;
+          periodStart = simulation.getSimulationTime();
+          moveNextMoteEvent.execute(Mobility.this.simulation.getSimulationTime());
+        }
+      });
+
+    } catch (Exception e) {
+      log.addMessage("Error when loading positions: " + e.getMessage());
+      logger.info("Error when loading positions:", e);
+      entries = new Move[0];
+    }
+  }
+
+  private TimeEvent moveNextMoteEvent = new TimeEvent() {
+    @Override
+    public void execute(long t) {
+
+      /* Detect early events: reschedule for later */
+      if (simulation.getSimulationTime() < entries[currentMove].time + periodStart) {
+        simulation.scheduleEvent(this, entries[currentMove].time + periodStart);
+        return;
+      }
+
+      /* Perform a single move */
+      Move move = entries[currentMove];
+      if (move.moteIndex < simulation.getMotesCount()) {
+        Mote mote = simulation.getMote(move.moteIndex);
+        Position pos = mote.getInterfaces().getPosition();
+        pos.setCoordinates(move.posX, move.posY, pos.getZCoordinate());
+      }
+
+      currentMove++;
+      if (currentMove >= entries.length) {
+        if (!WRAP_MOVES) {
+          return;
+        }
+        periodStart = simulation.getSimulationTime();
+        currentMove = 0;
+      }
+
+      /* Reschedule future events */
+      simulation.scheduleEvent(this, entries[currentMove].time + periodStart);
+    }
+  };
+
+  @Override
+  public void closePlugin() {
+    moveNextMoteEvent.remove();
+  }
+
+  class Move {
+    long time;
+    int moteIndex;
+    double posX, posY;
+
+    public String toString() {
+      return "MOVE: mote " + moteIndex + " -> [" + posX + "," + posY + "] @ " + time/Simulation.MILLISECOND;
+    }
+  }
+
+  @Override
+  public Collection<Element> getConfigXML() {
+    ArrayList<Element> config = new ArrayList<Element>();
+
+    if (filePositions != null) {
+      var element = new Element("positions");
+      File file = gui.createPortablePath(filePositions);
+      element.setText(file.getPath().replaceAll("\\\\", "/"));
+      element.setAttribute("EXPORT", "copy");
+      config.add(element);
+    }
+
+    return config;
+  }
+
+  @Override
+  public boolean setConfigXML(Collection<Element> configXML, boolean visAvailable) {
+    for (Element element : configXML) {
+      String name = element.getName();
+
+      if (name.equals("positions")) {
+        filePositions = gui.restorePortablePath(new File(element.getText()));
+        loadPositions();
+      }
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
This PR adds support for the [Mobility Cooja plugin](https://sourceforge.net/p/contikiprojects/code/HEAD/tree/sics.se/mobility/) (see https://github.com/contiki-ng/cooja/issues/763).

How does it work?

The mobility plugin should be in the Tools menu. Click on it and load your positions.dat file. 

An example of the positions of a network with two mobile sensor nodes is shown below:

The format of the file is:
| Node ID      | Time (s) | x pos (m) | y pos (m)|
| ----------- | ----------- |---|---|

_**positions.dat:**_
0 0.0 0 0
1 0.0 30 30
0 1.0 0 10
1 1.0 30 20
0 2.0 10 10
1 2.0 20 20
0 3.0 10 0
1 3.0 20 30
0 4.0 0 0
1 4.0 30 30

The node IDs 0 and 1 correspond to node 1.0 and node 2.0 in Cooja, respectively.

The mobility plugin is from https://github.com/anilprajapati88/Mobility-Plugin-for-Contiki-NG/tree/main/mobility