### PR TITLE
MoteType: add more constructors

### DIFF
--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -187,16 +187,10 @@ public abstract class CoreComm {
         return;
       }
     } catch (IOException | InterruptedException e) {
-      var exception = new MoteTypeCreationException(
-          "Could not compile corecomm source file: " + className + ".java", e);
-      exception.setCompilationOutput(compilationOutput);
-      throw exception;
+      throw new MoteTypeCreationException("Could not compile corecomm source file: " + className + ".java", e, compilationOutput);
     }
 
-    MoteTypeCreationException exception = new MoteTypeCreationException(
-        "Could not compile corecomm source file: " + className + ".java");
-    exception.setCompilationOutput(compilationOutput);
-    throw exception;
+    throw new MoteTypeCreationException("Could not compile corecomm source file: " + className + ".java", compilationOutput);
   }
 
   /**

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -1534,9 +1534,9 @@ public class GUI {
         }
         // Compilation output.
         MessageListUI compilationOutput = null;
-        if (e instanceof MoteType.MoteTypeCreationException ex && ex.hasCompilationOutput()) {
+        if (e instanceof MoteType.MoteTypeCreationException ex) {
           compilationOutput = (MessageListUI) ex.getCompilationOutput();
-        } else if (e != null && e.getCause() instanceof MoteType.MoteTypeCreationException ex && ex.hasCompilationOutput()) {
+        } else if (e != null && e.getCause() instanceof MoteType.MoteTypeCreationException ex) {
           compilationOutput = (MessageListUI) ex.getCompilationOutput();
         }
         if (compilationOutput != null) {

--- a/java/org/contikios/cooja/MoteType.java
+++ b/java/org/contikios/cooja/MoteType.java
@@ -222,8 +222,16 @@ public interface MoteType {
     public MoteTypeCreationException(String message) {
       super(message);
     }
+    public MoteTypeCreationException(String message, MessageList output) {
+      super(message);
+      compilationOutput = output;
+    }
     public MoteTypeCreationException(String message, Throwable cause) {
       super(message, cause);
+    }
+    public MoteTypeCreationException(String message, Throwable cause, MessageList output) {
+      super(message, cause);
+      compilationOutput = output;
     }
     public boolean hasCompilationOutput() {
       return compilationOutput != null;

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -752,10 +752,7 @@ public class ContikiMoteType extends BaseContikiMoteType {
   private static MoteTypeCreationException createException(String message, Throwable err,
                                                            String command, MessageList outputList) {
     outputList.addMessage("Failed to run command: " + command, MessageList.ERROR);
-
-    var e = new MoteTypeCreationException(message, err);
-    e.setCompilationOutput(outputList);
-    return e;
+    return new MoteTypeCreationException(message, err, outputList);
   }
 
   @Override


### PR DESCRIPTION
This removes the need for `setCompilationOutput` and `hasCompilationOutput` in the repository.