### PR TITLE
Add an -autostart option

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1405,6 +1405,7 @@ public class Cooja extends Observable {
     }
     // Check if simulator should be quick-started.
     int rv = 0;
+    boolean autoQuit = !config.configs.isEmpty() && (!config.vis || config.updateSim);
     for (var simConfig : config.configs) {
       var file = new File(simConfig.file);
       Simulation sim = null;
@@ -1418,8 +1419,11 @@ public class Cooja extends Observable {
       if (sim == null) {
         System.exit(1);
       }
-      if (!config.vis) {
-        sim.setSpeedLimit(null);
+      if (simConfig.autoStart) {
+        autoQuit = true;
+        if (!config.vis) {
+          sim.setSpeedLimit(null);
+        }
         var ret = sim.startSimulation(true);
         if (ret == null) {
           logger.info("TEST OK\n");
@@ -1429,7 +1433,7 @@ public class Cooja extends Observable {
         }
       }
     }
-    if (!config.configs.isEmpty() && (!config.vis || config.updateSim)) {
+    if (autoQuit) {
       gui.doQuit(rv);
     }
   }
@@ -2235,7 +2239,7 @@ public class Cooja extends Observable {
   }
 
   /** Structure to hold the simulation parameters. */
-  public record SimConfig(Map<String, String> opts, String file) {}
+  public record SimConfig(Map<String, String> opts, boolean autoStart, String file) {}
 
   /** Structure to hold the Cooja startup configuration. */
   public record Config(boolean vis, Long randomSeed, String externalToolsConfig, boolean updateSim,

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -109,6 +109,12 @@ class Main {
   Long randomSeed;
 
   /**
+   * Automatically start simulations.
+   */
+  @Option(names = "-autostart", description = "automatically start -nogui/-quickstart simulations")
+  boolean autoStart;
+
+  /**
    * The action to take after starting. No action means start GUI.
    */
   @ArgGroup(exclusive = true)
@@ -220,7 +226,8 @@ class Main {
           System.err.println("File '" + file + "' does not exist");
           System.exit(1);
         }
-        simConfigs.add(new Cooja.SimConfig(map, file));
+        var autoStart = map.getOrDefault("autostart", Boolean.toString(options.autoStart || options.action.nogui != null));
+        simConfigs.add(new Cooja.SimConfig(map, Boolean.parseBoolean(autoStart), file));
       }
     }
 


### PR DESCRIPTION
This option enables the user to automatically
start simulations loaded with -quickstart.

There is also a per-simulation option called
autostart, so

cooja --args="-quickstart=file1.csc -quickstart=file2.csc,autostart=true"

will first load file1.csc, and then load file2.csc and run the simulation.

Fixes #59.