### PR TITLE
gradle: update to JDOM 2.0.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ dependencies {
   implementation 'info.picocli:picocli:4.7.0'
   // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
   implementation 'org.apache.logging.log4j:log4j-core:2.19.0'
-  // https://mvnrepository.com/artifact/org.jdom/jdom-legacy
-  implementation 'org.jdom:jdom-legacy:1.1.3'
+  // https://mvnrepository.com/artifact/org.jdom/jdom2
+  implementation 'org.jdom:jdom2:2.0.6.1'
   // https://mvnrepository.com/artifact/org.jfree/jfreechart
   implementation 'org.jfree:jfreechart:1.5.3'
   // https://mvnrepository.com/artifact/org.openjdk.nashorn/nashorn-core

--- a/examples/project_new_interface/java/DummyInterface.java
+++ b/examples/project_new_interface/java/DummyInterface.java
@@ -32,7 +32,7 @@ import java.util.*;
 import javax.swing.*;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.*;
 import org.contikios.cooja.contikimote.ContikiMoteInterface;

--- a/examples/project_new_plugin/java/MyDummyPlugin.java
+++ b/examples/project_new_plugin/java/MyDummyPlugin.java
@@ -42,7 +42,7 @@ import javax.swing.SwingUtilities;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;

--- a/examples/project_new_radiomedium/java/DummyRadioMedium.java
+++ b/examples/project_new_radiomedium/java/DummyRadioMedium.java
@@ -31,7 +31,7 @@
 import java.util.Collection;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.*;
 import org.contikios.cooja.interfaces.*;

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -108,13 +108,13 @@ import org.contikios.cooja.radiomediums.UDGMConstantLoss;
 import org.contikios.cooja.serialsocket.SerialSocketClient;
 import org.contikios.cooja.serialsocket.SerialSocketServer;
 import org.contikios.mrm.MRM;
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.JDOMException;
-import org.jdom.filter.ElementFilter;
-import org.jdom.input.SAXBuilder;
-import org.jdom.output.Format;
-import org.jdom.output.XMLOutputter;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.filter.ElementFilter;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
 
 /**
  * Main file of COOJA Simulator. Typically, contains a visualizer for the

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -109,7 +109,7 @@ import org.contikios.cooja.dialogs.ProjectDirectoriesDialog;
 import org.contikios.cooja.plugins.MoteTypeInformation;
 import org.contikios.cooja.plugins.SimInformation;
 import org.contikios.cooja.util.ScnObservable;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /** The graphical user interface for Cooja. */
 public class GUI {

--- a/java/org/contikios/cooja/Mote.java
+++ b/java/org/contikios/cooja/Mote.java
@@ -29,7 +29,7 @@ package org.contikios.cooja;
 
 import java.util.Collection;
 import org.contikios.cooja.mote.memory.MemoryInterface;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /**
  * A simulated mote.

--- a/java/org/contikios/cooja/MoteInterface.java
+++ b/java/org/contikios/cooja/MoteInterface.java
@@ -33,7 +33,7 @@ package org.contikios.cooja;
 import java.util.Collection;
 import java.util.Observable;
 import javax.swing.JPanel;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.interfaces.PolledAfterActiveTicks;
 import org.contikios.cooja.interfaces.PolledAfterAllTicks;

--- a/java/org/contikios/cooja/MoteType.java
+++ b/java/org/contikios/cooja/MoteType.java
@@ -33,7 +33,7 @@ import java.util.Collection;
 
 import javax.swing.JComponent;
 
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.contikimote.ContikiMoteType;
 import org.contikios.cooja.dialogs.MessageList;

--- a/java/org/contikios/cooja/Plugin.java
+++ b/java/org/contikios/cooja/Plugin.java
@@ -34,7 +34,7 @@ import java.util.Collection;
 
 import javax.swing.JInternalFrame;
 
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /**
  * COOJA plugin. For graphical plugins, extend abstract class VisPlugin.

--- a/java/org/contikios/cooja/RadioMedium.java
+++ b/java/org/contikios/cooja/RadioMedium.java
@@ -33,7 +33,7 @@ package org.contikios.cooja;
 import java.util.Collection;
 import java.util.Observable;
 import java.util.Observer;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.interfaces.Radio;
 

--- a/java/org/contikios/cooja/SimEventCentral.java
+++ b/java/org/contikios/cooja/SimEventCentral.java
@@ -34,7 +34,7 @@ import java.util.Collection;
 import java.util.Observable;
 import java.util.Observer;
 
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.interfaces.Log;
 import org.contikios.cooja.util.ArrayUtils;

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -39,7 +39,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JTextArea;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /**
  * A simulation consists of a number of motes and mote types.

--- a/java/org/contikios/cooja/VisPlugin.java
+++ b/java/org/contikios/cooja/VisPlugin.java
@@ -36,7 +36,7 @@ import javax.swing.JInternalFrame;
 import javax.swing.event.InternalFrameAdapter;
 import javax.swing.event.InternalFrameEvent;
 
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /**
  * Visualized plugins can extend VisPlugin for basic visualization functionality.

--- a/java/org/contikios/cooja/contikimote/ContikiMote.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMote.java
@@ -39,7 +39,7 @@ import org.contikios.cooja.interfaces.PolledAfterActiveTicks;
 import org.contikios.cooja.interfaces.PolledAfterAllTicks;
 import org.contikios.cooja.interfaces.PolledBeforeActiveTicks;
 import org.contikios.cooja.interfaces.PolledBeforeAllTicks;
-import org.jdom.Element;
+import org.jdom2.Element;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.MoteInterfaceHandler;

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -82,7 +82,7 @@ import org.contikios.cooja.mote.memory.MemoryInterface;
 import org.contikios.cooja.mote.memory.MemoryInterface.Symbol;
 import org.contikios.cooja.mote.memory.MemoryLayout;
 import org.contikios.cooja.mote.memory.SectionMoteMemory;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /**
  * The Cooja mote type holds the native library used to communicate with an

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiEEPROM.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiEEPROM.java
@@ -56,7 +56,7 @@ import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterface;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.interfaces.PolledAfterActiveTicks;
 import org.contikios.cooja.mote.memory.VarMemory;

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiRadio.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiRadio.java
@@ -35,7 +35,7 @@ import java.util.Collection;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.COOJARadioPacket;
 import org.contikios.cooja.Mote;

--- a/java/org/contikios/cooja/dialogs/SerialUI.java
+++ b/java/org/contikios/cooja/dialogs/SerialUI.java
@@ -54,7 +54,7 @@ import javax.swing.JTextField;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.interfaces.Log;

--- a/java/org/contikios/cooja/interfaces/Clock.java
+++ b/java/org/contikios/cooja/interfaces/Clock.java
@@ -44,7 +44,7 @@ import javax.swing.JTextField;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.Simulation;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /**
  * Represents a mote's internal clock. Notice that the overall

--- a/java/org/contikios/cooja/interfaces/MoteID.java
+++ b/java/org/contikios/cooja/interfaces/MoteID.java
@@ -33,7 +33,7 @@ package org.contikios.cooja.interfaces;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.MoteInterface;

--- a/java/org/contikios/cooja/interfaces/Position.java
+++ b/java/org/contikios/cooja/interfaces/Position.java
@@ -42,7 +42,7 @@ import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterface;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /**
  * Mote 3D position.

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -66,7 +66,7 @@ import org.contikios.cooja.dialogs.AbstractCompileDialog;
 import org.contikios.cooja.dialogs.MessageContainer;
 import org.contikios.cooja.dialogs.MessageList;
 import org.contikios.cooja.util.StringUtils;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /**
  * The common parts of mote types based on compiled Contiki-NG targets.

--- a/java/org/contikios/cooja/motes/AbstractApplicationMote.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMote.java
@@ -35,7 +35,7 @@ import java.util.Observer;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.MoteInterfaceHandler;

--- a/java/org/contikios/cooja/motes/AbstractApplicationMoteType.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMoteType.java
@@ -36,7 +36,7 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;

--- a/java/org/contikios/cooja/motes/ImportAppMoteType.java
+++ b/java/org/contikios/cooja/motes/ImportAppMoteType.java
@@ -43,7 +43,7 @@ import java.util.Collection;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.AbstractionLevelDescription;
 import org.contikios.cooja.ClassDescription;

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -40,7 +40,7 @@ import java.util.HashMap;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 import org.contikios.cooja.ContikiError;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.Mote;

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -40,7 +40,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.dialogs.AbstractCompileDialog;
 import org.contikios.cooja.mote.BaseContikiMoteType;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;

--- a/java/org/contikios/cooja/mspmote/plugins/MspBreakpoint.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspBreakpoint.java
@@ -38,7 +38,7 @@ import java.util.Collection;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.Watchpoint;
 import org.contikios.cooja.mspmote.MspMote;

--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -61,7 +61,7 @@ import javax.swing.table.AbstractTableModel;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.HasQuickHelp;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;

--- a/java/org/contikios/cooja/mspmote/plugins/MspStackWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspStackWatcher.java
@@ -45,7 +45,7 @@ import javax.swing.SwingUtilities;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;

--- a/java/org/contikios/cooja/plugins/BufferListener.java
+++ b/java/org/contikios/cooja/plugins/BufferListener.java
@@ -104,7 +104,7 @@ import org.contikios.cooja.motes.AbstractEmulatedMote;
 import org.contikios.cooja.util.ArrayQueue;
 import org.contikios.cooja.util.IPUtils;
 import org.contikios.cooja.util.StringUtils;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /**
  * @author Fredrik Osterlind, Niclas Finne

--- a/java/org/contikios/cooja/plugins/EventListener.java
+++ b/java/org/contikios/cooja/plugins/EventListener.java
@@ -48,7 +48,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;

--- a/java/org/contikios/cooja/plugins/LogListener.java
+++ b/java/org/contikios/cooja/plugins/LogListener.java
@@ -96,7 +96,7 @@ import org.contikios.cooja.VisPlugin;
 import org.contikios.cooja.dialogs.TableColumnAdjuster;
 import org.contikios.cooja.dialogs.UpdateAggregator;
 import org.contikios.cooja.util.ArrayQueue;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /**
  * A simple mote log listener.

--- a/java/org/contikios/cooja/plugins/Mobility.java
+++ b/java/org/contikios/cooja/plugins/Mobility.java
@@ -50,8 +50,7 @@ import org.contikios.cooja.VisPlugin;
 import org.contikios.cooja.dialogs.MessageListUI;
 import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.util.StringUtils;
-
-import org.jdom.Element;
+import org.jdom2.Element;
 
 
 @ClassDescription("Mobility")

--- a/java/org/contikios/cooja/plugins/MoteInterfaceViewer.java
+++ b/java/org/contikios/cooja/plugins/MoteInterfaceViewer.java
@@ -46,7 +46,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSeparator;
 
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;

--- a/java/org/contikios/cooja/plugins/Notes.java
+++ b/java/org/contikios/cooja/plugins/Notes.java
@@ -44,7 +44,7 @@ import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
 import javax.swing.plaf.basic.BasicInternalFrameUI;
 
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;

--- a/java/org/contikios/cooja/plugins/PowerTracker.java
+++ b/java/org/contikios/cooja/plugins/PowerTracker.java
@@ -55,7 +55,7 @@ import javax.swing.table.DefaultTableCellRenderer;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;

--- a/java/org/contikios/cooja/plugins/RadioLogger.java
+++ b/java/org/contikios/cooja/plugins/RadioLogger.java
@@ -102,7 +102,7 @@ import org.contikios.cooja.plugins.analyzers.IPv6PacketAnalyzer;
 import org.contikios.cooja.plugins.analyzers.PacketAnalyzer;
 import org.contikios.cooja.plugins.analyzers.RadioLoggerAnalyzerSuite;
 import org.contikios.cooja.util.StringUtils;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /**
  * Radio logger listens to the simulation radio medium and lists all transmitted

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -73,7 +73,7 @@ import org.contikios.cooja.PluginType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.VisPlugin;
 import org.contikios.cooja.util.StringUtils;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 @ClassDescription("Simulation script editor")
 @PluginType(PluginType.SIM_CONTROL_PLUGIN)

--- a/java/org/contikios/cooja/plugins/TimeLine.java
+++ b/java/org/contikios/cooja/plugins/TimeLine.java
@@ -99,7 +99,7 @@ import org.contikios.cooja.interfaces.LED;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.interfaces.Radio.RadioEvent;
 import org.contikios.cooja.motes.AbstractEmulatedMote;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /**
  * Shows events such as mote logs, LEDs, and radio transmissions, in a timeline.

--- a/java/org/contikios/cooja/plugins/VariableWatcher.java
+++ b/java/org/contikios/cooja/plugins/VariableWatcher.java
@@ -80,7 +80,7 @@ import org.contikios.cooja.mote.memory.MemoryInterface;
 import org.contikios.cooja.mote.memory.UnknownVariableException;
 import org.contikios.cooja.mote.memory.VarMemory;
 import org.jdesktop.swingx.autocomplete.AutoCompleteDecorator;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /**
  * Variable Watcher enables a user to watch mote variables during a simulation.

--- a/java/org/contikios/cooja/plugins/Visualizer.java
+++ b/java/org/contikios/cooja/plugins/Visualizer.java
@@ -99,7 +99,7 @@ import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.plugins.skins.DGRMVisualizerSkin;
 import org.contikios.cooja.plugins.skins.LogisticLossVisualizerSkin;
 import org.contikios.mrm.MRMVisualizerSkin;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;

--- a/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
+++ b/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
@@ -50,7 +50,7 @@ import org.contikios.cooja.TimeEvent;
 import org.contikios.cooja.interfaces.CustomDataRadio;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.util.ScnObservable;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 
 /**

--- a/java/org/contikios/cooja/radiomediums/DGRMDestinationRadio.java
+++ b/java/org/contikios/cooja/radiomediums/DGRMDestinationRadio.java
@@ -32,7 +32,7 @@ package org.contikios.cooja.radiomediums;
 
 import java.util.Collection;
 
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.interfaces.Radio;

--- a/java/org/contikios/cooja/radiomediums/DestinationRadio.java
+++ b/java/org/contikios/cooja/radiomediums/DestinationRadio.java
@@ -33,7 +33,7 @@ package org.contikios.cooja.radiomediums;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.interfaces.Radio;

--- a/java/org/contikios/cooja/radiomediums/DirectedGraphMedium.java
+++ b/java/org/contikios/cooja/radiomediums/DirectedGraphMedium.java
@@ -38,7 +38,7 @@ import java.util.Random;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;

--- a/java/org/contikios/cooja/radiomediums/LogisticLoss.java
+++ b/java/org/contikios/cooja/radiomediums/LogisticLoss.java
@@ -38,7 +38,7 @@ import java.util.Map;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;

--- a/java/org/contikios/cooja/radiomediums/SilentRadioMedium.java
+++ b/java/org/contikios/cooja/radiomediums/SilentRadioMedium.java
@@ -35,7 +35,7 @@ import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.RadioConnection;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.interfaces.Radio;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /**
  * Silent radio. No data is ever transferred through this medium.

--- a/java/org/contikios/cooja/radiomediums/UDGM.java
+++ b/java/org/contikios/cooja/radiomediums/UDGM.java
@@ -37,7 +37,7 @@ import java.util.Random;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;

--- a/java/org/contikios/cooja/serialsocket/SerialSocketClient.java
+++ b/java/org/contikios/cooja/serialsocket/SerialSocketClient.java
@@ -67,7 +67,7 @@ import javax.swing.text.NumberFormatter;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;

--- a/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
+++ b/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
@@ -68,7 +68,7 @@ import javax.swing.text.NumberFormatter;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;

--- a/java/org/contikios/mrm/AreaViewer.java
+++ b/java/org/contikios/mrm/AreaViewer.java
@@ -93,7 +93,7 @@ import javax.swing.filechooser.FileFilter;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;

--- a/java/org/contikios/mrm/ChannelModel.java
+++ b/java/org/contikios/mrm/ChannelModel.java
@@ -46,7 +46,7 @@ import javax.swing.tree.DefaultMutableTreeNode;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.interfaces.DirectionalAntennaRadio;

--- a/java/org/contikios/mrm/FormulaViewer.java
+++ b/java/org/contikios/mrm/FormulaViewer.java
@@ -54,7 +54,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;

--- a/java/org/contikios/mrm/MRM.java
+++ b/java/org/contikios/mrm/MRM.java
@@ -36,7 +36,7 @@ import java.util.Observable;
 import java.util.Observer;
 import java.util.Random;
 
-import org.jdom.Element;
+import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.RadioConnection;

--- a/java/org/contikios/mrm/ObstacleWorld.java
+++ b/java/org/contikios/mrm/ObstacleWorld.java
@@ -39,7 +39,7 @@ import java.util.Enumeration;
 import java.util.Vector;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.jdom.Element;
+import org.jdom2.Element;
 
 /**
  * This class represents an area with obstacles.


### PR DESCRIPTION
This version of JDOM supports generics.
Cooja only uses a small part of JDOM, so existing
code can be kept, only import statements
needd to be updated from importing org.jdom
to instead import org.jdom2.

The required code updates can be done with
the following one-liner:

find <directory> -name \*.java -exec perl -pi -e 's#import org\.jdom\.#import org\.jdom2\.#g' {} \;