### PR TITLE
MspMote: add a stop exception type

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -38,6 +38,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JTextArea;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.contikios.cooja.mspmote.MspMote.MSPSimStop;
 import org.jdom2.Element;
 
 /**
@@ -309,21 +310,19 @@ public class Simulation extends Observable {
               nextEvent.event.execute(currentSimulationTime);
             }
           }
+        } catch (MSPSimStop e) {
+          logger.info("Simulation stopped due to MSPSim breakpoint");
         } catch (RuntimeException e) {
-          if ("MSPSim requested simulation stop".equals(e.getMessage())) {
-            logger.info("Simulation stopped due to MSPSim breakpoint");
-          } else {
-            logger.fatal("Simulation stopped due to error: " + e.getMessage(), e);
-            if (!Cooja.isVisualized()) {
-              /* Quit simulator if in test mode */
-              System.exit(1);
-            }
-            String errorTitle = "Simulation error";
-            if (nextEvent != null && nextEvent.event instanceof MoteTimeEvent moteTimeEvent) {
-              errorTitle += ": " + moteTimeEvent.getMote();
-            }
-            Cooja.showErrorDialog(errorTitle, e, false);
+          logger.fatal("Simulation stopped due to error: " + e.getMessage(), e);
+          if (!Cooja.isVisualized()) {
+            /* Quit simulator if in test mode */
+            System.exit(1);
           }
+          String errorTitle = "Simulation error";
+          if (nextEvent != null && nextEvent.event instanceof MoteTimeEvent moteTimeEvent) {
+            errorTitle += ": " + moteTimeEvent.getMote();
+          }
+          Cooja.showErrorDialog(errorTitle, e, false);
         } catch (InterruptedException e) {
           // Simulation thread interrupted - quit
           logger.warn("simulation thread interrupted");

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -261,7 +261,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     if (stopNextInstruction) {
       stopNextInstruction = false;
       scheduleNextWakeup(t);
-      throw new RuntimeException("MSPSim requested simulation stop");
+      throw new MSPSimStop();
     }
 
     if (lastExecute < 0) {
@@ -282,7 +282,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
 
     if (stopNextInstruction) {
       stopNextInstruction = false;
-      throw new RuntimeException("MSPSim requested simulation stop");
+      throw new MSPSimStop();
     }
 
     // TODO: Reimplement stack monitoring using MSPSim internals.
@@ -610,5 +610,12 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     }
 
     return config;
+  }
+
+  /** Exception for signaling the simulation that MSPSim has stopped. */
+  public static class MSPSimStop extends RuntimeException {
+    public MSPSimStop() {
+      super("MSPSim requested simulation stop");
+    }
   }
 }


### PR DESCRIPTION
Use types instead of string comparisons
to decide what happened in MSPSim.