### PR TITLE
Set look and feel in Cooja again

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -216,6 +216,7 @@ public class Cooja extends Observable {
       return new RunnableInEDT<Cooja>() {
         @Override
         public Cooja work() {
+          GUI.setLookAndFeel();
           try {
             return new Cooja(cfg);
           } catch (ParseProjectsException e) {

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -50,7 +50,6 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1610,39 +1609,37 @@ public class GUI {
     return n != JOptionPane.YES_OPTION;
   }
 
-  public static void setLookAndFeel() throws InterruptedException, InvocationTargetException {
-    java.awt.EventQueue.invokeAndWait(() -> {
-      JFrame.setDefaultLookAndFeelDecorated(true);
-      JDialog.setDefaultLookAndFeelDecorated(true);
-      ToolTipManager.sharedInstance().setDismissDelay(60000);
-      // Nimbus.
-      try {
-        String osName = System.getProperty("os.name").toLowerCase();
-        if (osName.startsWith("linux")) {
-          try {
-            for (var info : UIManager.getInstalledLookAndFeels()) {
-              if ("Nimbus".equals(info.getName())) {
-                UIManager.setLookAndFeel(info.getClassName());
-                break;
-              }
+  public static void setLookAndFeel() {
+    JFrame.setDefaultLookAndFeelDecorated(true);
+    JDialog.setDefaultLookAndFeelDecorated(true);
+    ToolTipManager.sharedInstance().setDismissDelay(60000);
+    // Nimbus.
+    try {
+      String osName = System.getProperty("os.name").toLowerCase();
+      if (osName.startsWith("linux")) {
+        try {
+          for (var info : UIManager.getInstalledLookAndFeels()) {
+            if ("Nimbus".equals(info.getName())) {
+              UIManager.setLookAndFeel(info.getClassName());
+              break;
             }
-          } catch (UnsupportedLookAndFeelException e) {
-            UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
           }
-        } else {
-          UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
+        } catch (UnsupportedLookAndFeelException e) {
+          UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
         }
-        return;
-      } catch (Exception e) {
+      } else {
+        UIManager.setLookAndFeel("javax.swing.plaf.nimbus.NimbusLookAndFeel");
       }
+      return;
+    } catch (Exception e) {
+    }
 
-      // System.
-      try {
-        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-      } catch (Exception e) {
-        System.err.println("Could not set any look and feel");
-      }
-    });
+    // System.
+    try {
+      UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to set look and feel", e);
+    }
   }
 
   /** GUI event handler */

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -284,15 +284,6 @@ class Main {
     }
 
     var vis = options.action == null || options.action.quickstart != null;
-    if (vis) {
-      try {
-        GUI.setLookAndFeel();
-      } catch (Exception e) {
-        System.err.println("Could not set look and feel: " + e.getMessage());
-        System.exit(1);
-      }
-    }
-
     var cfg = new Config(vis, options.randomSeed, options.externalToolsConfig, options.updateSimulation,
             options.logDir, options.contikiPath, options.coojaPath, options.javac, simConfigs);
     // Configure logger


### PR DESCRIPTION
Calling a method in GUI before log4j
is initialized makes info messages inside
the Cooja class to not appear. Curiously,
error messages still work.

Rather than investigating the exact
conditions, just put the look and feel
setup in Cooja again,