### PR TITLE
CreateSimDialog: restore delay startup divisor

### DIFF
--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -406,7 +406,7 @@ public class GUI {
         }
 
         var cfg = CreateSimDialog.showDialog(cooja, new Simulation.SimConfig(null, null,
-                false, 123456, 1000));
+                false, 123456, 1000 * Simulation.MILLISECOND));
         if (cfg == null) return;
         Simulation sim;
         try {

--- a/java/org/contikios/cooja/dialogs/CreateSimDialog.java
+++ b/java/org/contikios/cooja/dialogs/CreateSimDialog.java
@@ -162,7 +162,6 @@ public class CreateSimDialog extends JDialog {
     label.setPreferredSize(new Dimension(LABEL_WIDTH,LABEL_HEIGHT));
 
     final var delayedStartup = new JFormattedTextField(integerFormat);
-    delayedStartup.setValue(10000);
     delayedStartup.setColumns(4);
 
     horizBox.add(label);
@@ -260,7 +259,7 @@ public class CreateSimDialog extends JDialog {
     }
 
     // Set delayed mote startup time (ms)
-    delayedStartup.setValue(cfg.moteStartDelay());
+    delayedStartup.setValue(cfg.moteStartDelay() / Simulation.MILLISECOND);
 
     createButton.addActionListener(e -> {
       config = new Simulation.SimConfig(title.getText(),


### PR DESCRIPTION
The divisor got lost when moving the configuration around. Put back the divisor and the previous default values.