### PR TITLE
Push setSimulation to inner scope

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1464,9 +1464,7 @@ public class Cooja extends Observable {
         logger.fatal("Not a valid Cooja simulation config.");
         return null;
       }
-      doRemoveSimulation(false);
       sim = createSimulation(root, quick, rewriteCsc, manualRandomSeed);
-      setSimulation(sim);
     } catch (JDOMException e) {
       throw new SimulationCreationException("Config not well-formed", e);
     } catch (IOException e) {
@@ -1545,6 +1543,7 @@ public class Cooja extends Observable {
         }
       }
     }
+    doRemoveSimulation(false);
     System.gc();
     var simCfg = root.getChild("simulation");
     var title = simCfg.getChild("title").getText();
@@ -1567,11 +1566,14 @@ public class Cooja extends Observable {
       medium = cfg.radioMedium();
       delay = cfg.moteStartDelay();
     }
+    Simulation sim;
     try {
-      return new Simulation(this, title, configuration.logDir, generatedSeed, seed, medium, delay, quick, root);
+      sim = new Simulation(this, title, configuration.logDir, generatedSeed, seed, medium, delay, quick, root);
     } catch (MoteTypeCreationException e) {
       throw new SimulationCreationException("Unknown error: " + e.getMessage(), e);
     }
+    setSimulation(sim);
+    return sim;
   }
 
   /**

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -1293,13 +1293,9 @@ public class GUI {
           try {
             shouldRetry = false;
             PROGRESS_WARNINGS.clear();
-            if (cfgFile == null) {
-              cooja.doRemoveSimulation(false);
-              newSim = cooja.createSimulation(root, quick, rewriteCsc, manualRandomSeed);
-              cooja.setSimulation(newSim);
-            } else {
-              newSim = cooja.loadSimulationConfig(cfgFile, quick, rewriteCsc, manualRandomSeed);
-            }
+            newSim = cfgFile == null
+                    ? cooja.createSimulation(root, quick, rewriteCsc, manualRandomSeed)
+                    : cooja.loadSimulationConfig(cfgFile, quick, rewriteCsc, manualRandomSeed);
             if (newSim != null && autoStart) {
               newSim.startSimulation();
             }


### PR DESCRIPTION
The recent changes that pushed more work
into the Simulation constructor enabled
pushing this to a place where it makes
sense to have the functionality.