### PR TITLE
GUI: construct plugins from AWT thread

### DIFF
--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -1794,11 +1794,9 @@ public class GUI {
     }
     @Override
     public void actionPerformed(final ActionEvent e) {
-      new Thread(() -> {
-        var pluginClass = (Class<Plugin>) ((JMenuItem) e.getSource()).getClientProperty("class");
-        Mote mote = (Mote) ((JMenuItem) e.getSource()).getClientProperty("mote");
-        cooja.tryStartPlugin(pluginClass, cooja.getSimulation(), mote);
-      }, "StartPluginGUIAction").start();
+      var pluginClass = (Class<Plugin>) ((JMenuItem) e.getSource()).getClientProperty("class");
+      Mote mote = (Mote) ((JMenuItem) e.getSource()).getClientProperty("mote");
+      cooja.tryStartPlugin(pluginClass, cooja.getSimulation(), mote);
     }
     @Override
     public boolean shouldBeEnabled() {


### PR DESCRIPTION
The plugin constructors contain Swing components
that need to be created in the AWT thread.