### PR TITLE
GUI: prevent right-alignment of time-label

### DIFF
--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -263,6 +263,9 @@ public class GUI {
     superSpeedButton.setToolTipText("Unlimited");
     pane.add(unlimitedSpeedButton, radioConstraints);
     group.add(unlimitedSpeedButton);
+    // The system and Nimbus look and feels size the pane differently. Clamp the size
+    // to prevent the time label to end up to the far right on the toolbar.
+    pane.setMaximumSize(pane.getPreferredSize());
     toolBar.add(pane);
     toolBar.addSeparator();
     final var simulationTime = new JLabel("Time:");


### PR DESCRIPTION
Clamp the size of the pane to prevent the time label to end up to the far right. Nimbus already behaves this way, but the system look and feel does not.