### PR TITLE
Remove direct classloader access

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1326,9 +1326,7 @@ public class Cooja extends Observable {
         throw new ClassLoaderCreationException("Error when trying to read JAR-file in " + projectDir, e);
       }
     }
-
-    URL[] urlsArray = urls.toArray(new URL[0]);
-    return new URLClassLoader(urlsArray, parent);
+    return URLClassLoader.newInstance(urls.toArray(new URL[0]), parent);
   }
 
   /**

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -941,7 +941,7 @@ public class ContikiMoteType extends BaseContikiMoteType {
     // Loading a class might leave residue in the JVM so use a new name for the next call.
     fileCounter++;
     Class<?> newCoreCommClass;
-    try (var loader = new URLClassLoader(new URL[]{tempDir.toUri().toURL()}, ContikiMoteType.class.getClassLoader())) {
+    try (var loader = URLClassLoader.newInstance(new URL[]{tempDir.toUri().toURL()})) {
       newCoreCommClass = loader.loadClass("org.contikios.cooja.corecomm." + className);
     } catch (IOException | ClassNotFoundException e1) {
       throw new MoteTypeCreationException("Could not load corecomm class file: " + className + ".class", e1);

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -246,7 +246,7 @@ public abstract class BaseContikiMoteType implements MoteType {
     if (imageName == null) {
       return null;
     }
-    URL imageURL = this.getClass().getClassLoader().getResource(imageName);
+    URL imageURL = getClass().getResource(imageName);
     if (imageURL == null) {
       return null;
     }

--- a/java/org/contikios/cooja/motes/ImportAppMoteType.java
+++ b/java/org/contikios/cooja/motes/ImportAppMoteType.java
@@ -140,7 +140,7 @@ public class ImportAppMoteType extends AbstractApplicationMoteType {
     }
     ClassLoader parentLoader = getParentClassLoader(simulation);
     try (var loader = moteClassPath == null
-            ? null : new URLClassLoader(new java.net.URL[] { moteClassPath.toURI().toURL() }, parentLoader)) {
+            ? null : URLClassLoader.newInstance(new URL[] { moteClassPath.toURI().toURL() }, parentLoader)) {
       var moteClass = (loader == null ? parentLoader : loader).loadClass(moteClassName).asSubclass(AbstractApplicationMote.class);
       moteConstructor = moteClass.getConstructor(MoteType.class, Simulation.class);
     } catch (Exception | LinkageError e) {

--- a/java/org/contikios/cooja/mspmote/Exp5438MoteType.java
+++ b/java/org/contikios/cooja/mspmote/Exp5438MoteType.java
@@ -100,7 +100,7 @@ public class Exp5438MoteType extends MspMoteType {
 
   @Override
   protected String getMoteImage() {
-    return "images/exp5438.png";
+    return "/images/exp5438.png";
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/SkyMoteType.java
+++ b/java/org/contikios/cooja/mspmote/SkyMoteType.java
@@ -76,7 +76,7 @@ public class SkyMoteType extends MspMoteType {
 
   @Override
   protected String getMoteImage() {
-    return "images/sky.jpg";
+    return "/images/sky.jpg";
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/Z1MoteType.java
+++ b/java/org/contikios/cooja/mspmote/Z1MoteType.java
@@ -65,7 +65,7 @@ public class Z1MoteType extends MspMoteType {
 
     @Override
     protected String getMoteImage() {
-        return "images/z1.jpg";
+        return "/images/z1.jpg";
     }
 
     @Override

--- a/java/org/contikios/mrm/AreaViewer.java
+++ b/java/org/contikios/mrm/AreaViewer.java
@@ -56,7 +56,6 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Line2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.net.URL;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -176,7 +175,7 @@ public class AreaViewer extends VisPlugin {
   private final MRM currentRadioMedium;
   private final ChannelModel currentChannelModel;
 
-  private static final String antennaImageFilename = "images/antenna.png";
+  private static final String antennaImageFilename = "/images/antenna.png";
   private final Image antennaImage;
 
   private Radio selectedRadio = null;
@@ -714,9 +713,7 @@ public class AreaViewer extends VisPlugin {
     this.add(BorderLayout.EAST, scrollControlPanel);
 
     // Load external images (antenna)
-    Toolkit toolkit = Toolkit.getDefaultToolkit();
-    URL imageURL = this.getClass().getClassLoader().getResource(antennaImageFilename);
-    antennaImage = toolkit.getImage(imageURL);
+    antennaImage = Toolkit.getDefaultToolkit().getImage(getClass().getResource(antennaImageFilename));
 
     MediaTracker tracker = new MediaTracker(canvas);
     tracker.addImage(antennaImage, 1);


### PR DESCRIPTION
Use wrapper methods for creating URLClassLoader,
and get resources directly from the class. Getting resources from the class requires absolute paths,
so update the required image paths.