### PR TITLE
Make some classes final

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -52,7 +52,7 @@ import org.jdom2.Element;
  *
  * @author Fredrik Osterlind
  */
-public class Simulation extends Observable {
+public final class Simulation extends Observable {
 
   /** Commands sent to the simulation thread to start, stop, or shutdown the simulation */
   private enum Command {

--- a/java/se/sics/mspsim/util/GDBStubs.java
+++ b/java/se/sics/mspsim/util/GDBStubs.java
@@ -50,7 +50,7 @@ import se.sics.mspsim.core.EmulationException;
 import se.sics.mspsim.core.MSP430Core;
 import se.sics.mspsim.core.Memory;
 
-public class GDBStubs implements Runnable {
+public final class GDBStubs implements Runnable {
 
     private final static String OK = "OK";
 

--- a/java/se/sics/mspsim/util/NetworkConnection.java
+++ b/java/se/sics/mspsim/util/NetworkConnection.java
@@ -151,7 +151,7 @@ public class NetworkConnection implements Runnable {
 
   private record SendEvent(byte[] data, ConnectionThread source) {}
 
-  class SendThread implements Runnable {
+  final class SendThread implements Runnable {
 
     private final ArrayList<SendEvent> queue = new ArrayList<>();
 
@@ -211,7 +211,7 @@ public class NetworkConnection implements Runnable {
     }
   }
 
-  class ConnectionThread implements Runnable {
+  final class ConnectionThread implements Runnable {
     Socket socket;
     DataInputStream input;
     OutputStream output;


### PR DESCRIPTION
These classes are not treated as an API that will be extended by a third-party so make the classes final to silence the IntelliJ warning about starting threads in the constructor. If someone wants to extend these classes in the future, they can remove the final.