### PR TITLE
Make @PluginType() strongly typed

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -1,0 +1,27 @@
+# Cooja v4.9
+
+## Cooja API changes for plugins outside the main tree
+
+### Update from JDOM 1 to JDOM 2
+
+JDOM was upgraded from version 1 to version 2 ([#784](https://github.com/contiki-ng/cooja/pull/784)).
+This requires some source code updates, but since Cooja uses such a small subset
+of the JDOM API, the update can be done automatically with the command:
+
+```bash
+find <directory> -name \*.java -exec perl -pi -e 's#import org.jdom.#import org.jdom2.#g' {} \;
+```
+
+### Avoid starting the AWT thread in headless mode
+
+Cooja will no longer start plugins that extend `VisPlugin` in headless mode
+to avoid starting the AWT thread. Plugins that should run in both GUI mode
+and headless mode need to be updated to keep the JInternalFrame internal.
+Examples for PowerTracker and other plugins can be found in the PR
+([#261](https://github.com/contiki-ng/cooja/pull/261)).
+
+## Changelog
+
+* Mobility plugin added to Cooja ([#768](https://github.com/contiki-ng/cooja/pull/768))
+
+All [commits](https://github.com/contiki-ng/cooja/compare/630e719d01d3...master) since v4.8.

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -2,6 +2,22 @@
 
 ## Cooja API changes for plugins outside the main tree
 
+### Strongly typed PluginType Annotation
+
+The PluginType annotation was encapsulated in an enum to give Cooja exhaustiveness
+checking in switch-expressions ([#848](https://github.com/contiki-ng/cooja/pull/848)).
+Plugins need to be updated by adding `.PType` in the PluginType annotation in plugins,
+so change from
+```Java
+@PluginType(PluginType.X)
+public class Y { /* ... */ }
+```
+into
+```Java
+@PluginType(PluginType.PType.X)
+public class Y { /* ... */ }
+```
+
 ### Update from JDOM 1 to JDOM 2
 
 JDOM was upgraded from version 1 to version 2 ([#784](https://github.com/contiki-ng/cooja/pull/784)).

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -681,11 +681,11 @@ public class Cooja extends Observable {
       throw new PluginConstructionException("Tool class not registered: " + pluginClass.getName());
     }
 
-    int pluginType = pluginClass.getAnnotation(PluginType.class).value();
-    if (pluginType != PluginType.COOJA_PLUGIN && pluginType != PluginType.COOJA_STANDARD_PLUGIN && sim == null) {
+    var pluginType = pluginClass.getAnnotation(PluginType.class).value();
+    if (pluginType != PluginType.PType.COOJA_PLUGIN && pluginType != PluginType.PType.COOJA_STANDARD_PLUGIN && sim == null) {
       throw new PluginConstructionException("No simulation argument for plugin: " + pluginClass.getName());
     }
-    if (pluginType == PluginType.MOTE_PLUGIN && argMote == null) {
+    if (pluginType == PluginType.PType.MOTE_PLUGIN && argMote == null) {
       throw new PluginConstructionException("No mote argument for mote plugin: " + pluginClass.getName());
     }
     if (!isVisualized() && VisPlugin.class.isAssignableFrom(pluginClass)) {
@@ -696,13 +696,12 @@ public class Cooja extends Observable {
     Plugin plugin;
     try {
       plugin = switch (pluginType) {
-        case PluginType.MOTE_PLUGIN -> pluginClass.getConstructor(Mote.class, Simulation.class, Cooja.class)
+        case MOTE_PLUGIN -> pluginClass.getConstructor(Mote.class, Simulation.class, Cooja.class)
                 .newInstance(argMote, sim, this);
-        case PluginType.SIM_PLUGIN, PluginType.SIM_STANDARD_PLUGIN, PluginType.SIM_CONTROL_PLUGIN ->
+        case SIM_PLUGIN, SIM_STANDARD_PLUGIN, SIM_CONTROL_PLUGIN ->
                 pluginClass.getConstructor(Simulation.class, Cooja.class).newInstance(sim, this);
-        case PluginType.COOJA_PLUGIN, PluginType.COOJA_STANDARD_PLUGIN ->
+        case COOJA_PLUGIN, COOJA_STANDARD_PLUGIN ->
                 pluginClass.getConstructor(Cooja.class).newInstance(this);
-        default -> throw new PluginConstructionException("Bad plugin type: " + pluginType);
       };
     } catch (PluginRequiresVisualizationException e) {
       throw new PluginConstructionException("Tool class requires visualization: " + pluginClass.getName(), e);
@@ -831,13 +830,13 @@ public class Cooja extends Observable {
     }
 
     switch (annotation.value()) {
-      case PluginType.MOTE_PLUGIN:
+      case MOTE_PLUGIN:
         menuMotePluginClasses.add(pluginClass);
-      case PluginType.COOJA_PLUGIN:
-      case PluginType.COOJA_STANDARD_PLUGIN:
-      case PluginType.SIM_PLUGIN:
-      case PluginType.SIM_STANDARD_PLUGIN:
-      case PluginType.SIM_CONTROL_PLUGIN:
+      case COOJA_PLUGIN:
+      case COOJA_STANDARD_PLUGIN:
+      case SIM_PLUGIN:
+      case SIM_STANDARD_PLUGIN:
+      case SIM_CONTROL_PLUGIN:
         pluginClasses.add(pluginClass);
         return true;
     }
@@ -958,8 +957,8 @@ public class Cooja extends Observable {
 
     // Close all started non-GUI plugins
     for (var startedPlugin : startedPlugins.toArray(new Plugin[0])) {
-      int pluginType = startedPlugin.getClass().getAnnotation(PluginType.class).value();
-      if (pluginType != PluginType.COOJA_PLUGIN && pluginType != PluginType.COOJA_STANDARD_PLUGIN) {
+      var pluginType = startedPlugin.getClass().getAnnotation(PluginType.class).value();
+      if (pluginType != PluginType.PType.COOJA_PLUGIN && pluginType != PluginType.PType.COOJA_STANDARD_PLUGIN) {
         removePlugin(startedPlugin);
       }
     }
@@ -1622,10 +1621,9 @@ public class Cooja extends Observable {
     // Create started plugins config
     ArrayList<Element> config = new ArrayList<>();
     for (Plugin startedPlugin : startedPlugins) {
-      int pluginType = startedPlugin.getClass().getAnnotation(PluginType.class).value();
-
+      var pluginType = startedPlugin.getClass().getAnnotation(PluginType.class).value();
       // Ignore GUI plugins
-      if (pluginType == PluginType.COOJA_PLUGIN || pluginType == PluginType.COOJA_STANDARD_PLUGIN) {
+      if (pluginType == PluginType.PType.COOJA_PLUGIN || pluginType == PluginType.PType.COOJA_STANDARD_PLUGIN) {
         continue;
       }
 
@@ -1633,7 +1631,7 @@ public class Cooja extends Observable {
       pluginElement.setText(startedPlugin.getClass().getName());
 
       // Create mote argument config (if mote plugin)
-      if (pluginType == PluginType.MOTE_PLUGIN) {
+      if (pluginType == PluginType.PType.MOTE_PLUGIN) {
         var pluginSubElement = new Element("mote_arg");
         Mote taggedMote = ((MotePlugin) startedPlugin).getMote();
         for (int moteNr = 0; moteNr < mySimulation.getMotesCount(); moteNr++) {

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -208,8 +208,8 @@ public class GUI {
 
     // Start all standard GUI plugins
     for (var pluginClass : cooja.getRegisteredPlugins()) {
-      int pluginType = pluginClass.getAnnotation(PluginType.class).value();
-      if (pluginType == PluginType.COOJA_STANDARD_PLUGIN) {
+      var pluginType = pluginClass.getAnnotation(PluginType.class).value();
+      if (pluginType == PluginType.PType.COOJA_STANDARD_PLUGIN) {
         cooja.tryStartPlugin(pluginClass, null, null);
       }
     }
@@ -793,8 +793,8 @@ public class GUI {
         // Cooja plugins.
         boolean hasCoojaPlugins = false;
         for (Class<? extends Plugin> pluginClass : cooja.getRegisteredPlugins()) {
-          int pluginType = pluginClass.getAnnotation(PluginType.class).value();
-          if (pluginType != PluginType.COOJA_PLUGIN && pluginType != PluginType.COOJA_STANDARD_PLUGIN) {
+          var pluginType = pluginClass.getAnnotation(PluginType.class).value();
+          if (pluginType != PluginType.PType.COOJA_PLUGIN && pluginType != PluginType.PType.COOJA_STANDARD_PLUGIN) {
             continue;
           }
           toolsMenu.add(createMenuItem(pluginClass));
@@ -808,9 +808,9 @@ public class GUI {
             continue; // Ignore.
           }
 
-          int pluginType = pluginClass.getAnnotation(PluginType.class).value();
-          if (pluginType != PluginType.SIM_PLUGIN && pluginType != PluginType.SIM_STANDARD_PLUGIN
-                  && pluginType != PluginType.SIM_CONTROL_PLUGIN) {
+          var pluginType = pluginClass.getAnnotation(PluginType.class).value();
+          if (pluginType != PluginType.PType.SIM_PLUGIN && pluginType != PluginType.PType.SIM_STANDARD_PLUGIN
+                  && pluginType != PluginType.PType.SIM_CONTROL_PLUGIN) {
             continue;
           }
 
@@ -824,8 +824,8 @@ public class GUI {
         }
 
         for (Class<? extends Plugin> pluginClass : cooja.getRegisteredPlugins()) {
-          int pluginType = pluginClass.getAnnotation(PluginType.class).value();
-          if (pluginType != PluginType.MOTE_PLUGIN) {
+          var pluginType = pluginClass.getAnnotation(PluginType.class).value();
+          if (pluginType != PluginType.PType.MOTE_PLUGIN) {
             continue;
           }
 

--- a/java/org/contikios/cooja/PluginType.java
+++ b/java/org/contikios/cooja/PluginType.java
@@ -38,89 +38,84 @@ import java.lang.annotation.RetentionPolicy;
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PluginType {
-  int UNDEFINED_PLUGIN = 0;
+  enum PType {
+    /**
+     * Mote Plugin
+     * <p>
+     * A mote plugin concerns one specific mote.
+     * <p>
+     * An example of such a plugin may be to display some mote information in a
+     * frame.
+     * <p>
+     * Mote plugins can not be instantiated from the regular menu bar, but are
+     * instead started from other plugins, for example a visualizer that lets a
+     * user select a mote.
+     * <p>
+     * When constructed, a mote plugin is given a mote, the current active
+     * simulation and the GUI object.
+     * <p>
+     * If the current simulation is removed, so are all instances of this plugin.
+     */
+    MOTE_PLUGIN,
 
-  /**
-   * Mote Plugin
-   * <p>
-   * A mote plugin concerns one specific mote.
-   * <p>
-   * An example of such a plugin may be to display some mote information in a
-   * frame.
-   * <p>
-   * Mote plugins can not be instantiated from the regular menu bar, but are
-   * instead started from other plugins, for example a visualizer that lets a
-   * user select a mote.
-   * <p>
-   * When constructed, a mote plugin is given a mote, the current active
-   * simulation and the GUI object.
-   * <p>
-   * If the current simulation is removed, so are all instances of this plugin.
-   */
-  int MOTE_PLUGIN = 1;
+    /**
+     * Simulation Plugin
+     * <p>
+     * A simulation plugin concerns one specific simulation.
+     * <p>
+     * An example of such a plugin may be to display number of motes and current
+     * simulation time in a window.
+     * <p>
+     * Simulation plugins are available via the plugin menubar.
+     * <p>
+     * When constructed, a simulation plugin is given the current active
+     * simulation and the GUI object.
+     * <p>
+     * If the current simulation is removed, so are all instances of this plugin.
+     */
+    SIM_PLUGIN,
 
-  /**
-   * Simulation Plugin
-   * <p>
-   * A simulation plugin concerns one specific simulation.
-   * <p>
-   * An example of such a plugin may be to display number of motes and current
-   * simulation time in a window.
-   * <p>
-   * Simulation plugins are available via the plugins menubar.
-   * <p>
-   * When constructed, a simulation plugin is given the current active
-   * simulation and the GUI object.
-   * <p>
-   * If the current simulation is removed, so are all instances of this plugin.
-   */
-  int SIM_PLUGIN = 2;
+    /**
+     * COOJA Plugin
+     * <p>
+     * A COOJA plugin does not depend on the current simulation (if any).
+     * <p>
+     * An example of such a plugin may be a control panel where a user can save
+     * and load different simulations.
+     * <p>
+     * COOJA plugins are available via the plugin menubar.
+     * <p>
+     * When constructed, a COOJA plugin is given the current GUI.
+     */
+    COOJA_PLUGIN,
 
-  /**
-   * COOJA Plugin
-   * <p>
-   * A COOJA plugin does not depend on the current simulation (if any).
-   * <p>
-   * An example of such a plugin may be a control panel where a user can save
-   * and load different simulations.
-   * <p>
-   * COOJA plugins are available via the plugins menubar.
-   * <p>
-   * When constructed, a COOJA plugin is given the current GUI.
-   */
-  int COOJA_PLUGIN = 3;
+    /**
+     * Simulation Standard Plugin
+     * <p>
+     * This is treated exactly like a Simulation Plugin, with the only difference
+     * that this will automatically be opened when a new simulation is created.
+     *
+     * @see #SIM_PLUGIN
+     */
+    SIM_STANDARD_PLUGIN,
 
-  /**
-   * Simulation Standard Plugin
-   * <p>
-   * This is treated exactly like a Simulation Plugin, with the only difference
-   * that this will automatically be opened when a new simulation is created.
-   * 
-   * @see #SIM_PLUGIN
-   */
-  int SIM_STANDARD_PLUGIN = 4;
+    /**
+     * COOJA Standard Plugin
+     * <p>
+     * This is treated exactly like a COOJA Plugin, with the only difference that
+     * this will automatically be opened when the simulator is started.
+     *
+     * @see #COOJA_PLUGIN
+     */
+    COOJA_STANDARD_PLUGIN,
 
-  /**
-   * COOJA Standard Plugin
-   * <p>
-   * This is treated exactly like a COOJA Plugin, with the only difference that
-   * this will automatically be opened when the simulator is started.
-   * 
-   * @see #COOJA_PLUGIN
-   */
-  int COOJA_STANDARD_PLUGIN = 5;
-  
-  /**
-   * Simulation Control Plugin
-   * <p>
-   * A Simulation Control Plugin indicates control over the simulation. If COOJA
-   * is loaded in nogui mode, it will terminate if no controll plugin is present.
-   * <p>
-   * COOJA plugins are available via the plugins menubar.
-   * <p>
-   * When constructed, a COOJA plugin is given the current GUI.  
-   */
-  int SIM_CONTROL_PLUGIN = 6;
-
-  int value();
+    /**
+     * Simulation Control Plugin
+     * <p>
+     * A Simulation Control Plugin indicates control over the simulation. If COOJA
+     * is loaded in headless mode, it will terminate if no control plugin is present.
+     */
+    SIM_CONTROL_PLUGIN,
+  }
+  PType value();
 }

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -330,7 +330,7 @@ public final class Simulation extends Observable {
       // Keep track of started plugins, so they can be removed on failure.
       var startedPlugins = new ArrayList<Plugin>();
       for (var pluginClass : cooja.getRegisteredPlugins()) {
-        if (pluginClass.getAnnotation(PluginType.class).value() == PluginType.SIM_STANDARD_PLUGIN) {
+        if (pluginClass.getAnnotation(PluginType.class).value() == PluginType.PType.SIM_STANDARD_PLUGIN) {
           try {
             startedPlugins.add(cooja.startPlugin(pluginClass, this, null, null));
           } catch (PluginConstructionException e) {
@@ -399,7 +399,7 @@ public final class Simulation extends Observable {
       if (!Cooja.isVisualized() && VisPlugin.class.isAssignableFrom(pluginClass)) {
         continue;
       }
-      if (pluginClass.getAnnotation(PluginType.class).value() == PluginType.SIM_CONTROL_PLUGIN) {
+      if (pluginClass.getAnnotation(PluginType.class).value() == PluginType.PType.SIM_CONTROL_PLUGIN) {
         hasController = true;
       }
       // Parse plugin mote argument (if any).

--- a/java/org/contikios/cooja/mspmote/plugins/MspCLI.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCLI.java
@@ -61,7 +61,7 @@ import se.sics.mspsim.cli.LineListener;
 import se.sics.mspsim.cli.LineOutputStream;
 
 @ClassDescription("Msp CLI")
-@PluginType(PluginType.MOTE_PLUGIN)
+@PluginType(PluginType.PType.MOTE_PLUGIN)
 @SupportedArguments(motes = {MspMote.class})
 public class MspCLI extends VisPlugin implements MotePlugin, HasQuickHelp {
   private final MspMote mspMote;

--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -84,7 +84,7 @@ import se.sics.mspsim.util.DebugInfo;
 import se.sics.mspsim.util.ELFDebug;
 
 @ClassDescription("Msp Code Watcher")
-@PluginType(PluginType.MOTE_PLUGIN)
+@PluginType(PluginType.PType.MOTE_PLUGIN)
 @SupportedArguments(motes = {MspMote.class})
 public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHelp {
   private static final int SOURCECODE = 0;

--- a/java/org/contikios/cooja/mspmote/plugins/MspCycleWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCycleWatcher.java
@@ -55,7 +55,7 @@ import org.contikios.cooja.mspmote.MspMote;
 import se.sics.mspsim.core.MSP430;
 
 @ClassDescription("Msp Cycle Watcher")
-@PluginType(PluginType.MOTE_PLUGIN)
+@PluginType(PluginType.PType.MOTE_PLUGIN)
 @SupportedArguments(motes = {MspMote.class})
 public class MspCycleWatcher extends VisPlugin implements MotePlugin {
   private final MspMote mspMote;

--- a/java/org/contikios/cooja/mspmote/plugins/MspStackWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspStackWatcher.java
@@ -64,7 +64,7 @@ import se.sics.mspsim.core.RegisterMonitor;
 import se.sics.mspsim.ui.StackUI;
 
 @ClassDescription("Msp Stack Watcher")
-@PluginType(PluginType.MOTE_PLUGIN)
+@PluginType(PluginType.PType.MOTE_PLUGIN)
 @SupportedArguments(motes = { MspMote.class })
 public class MspStackWatcher extends VisPlugin implements MotePlugin {
   private static final Logger logger = LogManager.getLogger(MspStackWatcher.class);

--- a/java/org/contikios/cooja/plugins/BaseRSSIconf.java
+++ b/java/org/contikios/cooja/plugins/BaseRSSIconf.java
@@ -60,7 +60,7 @@ import org.contikios.cooja.radiomediums.DirectedGraphMedium;
  * @author Sebastian Schinabeck
  */
 @ClassDescription("Base RSSI")
-@PluginType(PluginType.SIM_PLUGIN)
+@PluginType(PluginType.PType.SIM_PLUGIN)
 @SupportedArguments(radioMediums = { AbstractRadioMedium.class })
 
 public class BaseRSSIconf extends VisPlugin {

--- a/java/org/contikios/cooja/plugins/BufferListener.java
+++ b/java/org/contikios/cooja/plugins/BufferListener.java
@@ -110,7 +110,7 @@ import org.jdom2.Element;
  * @author Fredrik Osterlind, Niclas Finne
  */
 @ClassDescription("Buffer view")
-@PluginType(PluginType.SIM_PLUGIN)
+@PluginType(PluginType.PType.SIM_PLUGIN)
 public class BufferListener extends VisPlugin {
   private static final Logger logger = LogManager.getLogger(BufferListener.class);
 

--- a/java/org/contikios/cooja/plugins/DGRMConfigurator.java
+++ b/java/org/contikios/cooja/plugins/DGRMConfigurator.java
@@ -80,7 +80,7 @@ import org.contikios.cooja.util.StringUtils;
  * @author Fredrik Osterlind
  */
 @ClassDescription("DGRM Links")
-@PluginType(PluginType.SIM_PLUGIN)
+@PluginType(PluginType.PType.SIM_PLUGIN)
 @SupportedArguments(radioMediums = {DirectedGraphMedium.class})
 public class DGRMConfigurator extends VisPlugin {
 	private static final Logger logger = LogManager.getLogger(DGRMConfigurator.class);

--- a/java/org/contikios/cooja/plugins/EventListener.java
+++ b/java/org/contikios/cooja/plugins/EventListener.java
@@ -73,7 +73,7 @@ import org.contikios.cooja.interfaces.Radio;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Breakpoints")
-@PluginType(PluginType.SIM_PLUGIN)
+@PluginType(PluginType.PType.SIM_PLUGIN)
 public class EventListener extends VisPlugin {
   private final Simulation mySimulation;
 

--- a/java/org/contikios/cooja/plugins/LogListener.java
+++ b/java/org/contikios/cooja/plugins/LogListener.java
@@ -104,7 +104,7 @@ import org.jdom2.Element;
  * @author Fredrik Osterlind, Niclas Finne
  */
 @ClassDescription("Mote output")
-@PluginType(PluginType.SIM_STANDARD_PLUGIN)
+@PluginType(PluginType.PType.SIM_STANDARD_PLUGIN)
 public class LogListener extends VisPlugin implements HasQuickHelp {
   private static final Logger logger = LogManager.getLogger(LogListener.class);
 

--- a/java/org/contikios/cooja/plugins/Mobility.java
+++ b/java/org/contikios/cooja/plugins/Mobility.java
@@ -52,7 +52,7 @@ import org.jdom2.Element;
 
 
 @ClassDescription("Mobility")
-@PluginType(PluginType.SIM_PLUGIN)
+@PluginType(PluginType.PType.SIM_PLUGIN)
 public class Mobility implements Plugin {
   private static final boolean WRAP_MOVES = true; /* Wrap around loaded moves forever */
 

--- a/java/org/contikios/cooja/plugins/MoteInformation.java
+++ b/java/org/contikios/cooja/plugins/MoteInformation.java
@@ -55,7 +55,7 @@ import org.contikios.cooja.motes.AbstractEmulatedMote;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Mote Information")
-@PluginType(PluginType.MOTE_PLUGIN)
+@PluginType(PluginType.PType.MOTE_PLUGIN)
 public class MoteInformation extends VisPlugin implements MotePlugin {
   private final Mote mote;
 

--- a/java/org/contikios/cooja/plugins/MoteInterfaceViewer.java
+++ b/java/org/contikios/cooja/plugins/MoteInterfaceViewer.java
@@ -64,7 +64,7 @@ import org.contikios.cooja.VisPlugin;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Mote Interface Viewer")
-@PluginType(PluginType.MOTE_PLUGIN)
+@PluginType(PluginType.PType.MOTE_PLUGIN)
 public class MoteInterfaceViewer extends VisPlugin implements HasQuickHelp, MotePlugin {
   private final Mote mote;
   private MoteInterface selectedMoteInterface = null;

--- a/java/org/contikios/cooja/plugins/MoteTypeInformation.java
+++ b/java/org/contikios/cooja/plugins/MoteTypeInformation.java
@@ -52,7 +52,7 @@ import org.contikios.cooja.VisPlugin;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Mote Type Information")
-@PluginType(PluginType.SIM_PLUGIN)
+@PluginType(PluginType.PType.SIM_PLUGIN)
 public class MoteTypeInformation extends VisPlugin {
   private final Simulation simulation;
   private final Observer simObserver;

--- a/java/org/contikios/cooja/plugins/Notes.java
+++ b/java/org/contikios/cooja/plugins/Notes.java
@@ -53,7 +53,7 @@ import org.contikios.cooja.Simulation;
 import org.contikios.cooja.VisPlugin;
 
 @ClassDescription("Notes")
-@PluginType(PluginType.SIM_STANDARD_PLUGIN)
+@PluginType(PluginType.PType.SIM_STANDARD_PLUGIN)
 public class Notes extends VisPlugin {
   private final JTextArea notes = new JTextArea("Enter notes here");
   private boolean decorationsVisible = true;

--- a/java/org/contikios/cooja/plugins/PowerTracker.java
+++ b/java/org/contikios/cooja/plugins/PowerTracker.java
@@ -74,7 +74,7 @@ import org.contikios.cooja.interfaces.Radio;
  * @author Fredrik Osterlind, Adam Dunkels
  */
 @ClassDescription("Mote radio duty cycle")
-@PluginType(PluginType.SIM_PLUGIN)
+@PluginType(PluginType.PType.SIM_PLUGIN)
 public class PowerTracker implements Plugin {
   private static final Logger logger = LogManager.getLogger(PowerTracker.class);
 

--- a/java/org/contikios/cooja/plugins/RadioLogger.java
+++ b/java/org/contikios/cooja/plugins/RadioLogger.java
@@ -111,7 +111,7 @@ import org.jdom2.Element;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Radio messages")
-@PluginType(PluginType.SIM_PLUGIN)
+@PluginType(PluginType.PType.SIM_PLUGIN)
 public class RadioLogger extends VisPlugin {
 
   private static final Logger logger = LogManager.getLogger(RadioLogger.class);

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -76,7 +76,7 @@ import org.contikios.cooja.util.StringUtils;
 import org.jdom2.Element;
 
 @ClassDescription("Simulation script editor")
-@PluginType(PluginType.SIM_CONTROL_PLUGIN)
+@PluginType(PluginType.PType.SIM_CONTROL_PLUGIN)
 public class ScriptRunner implements Plugin, HasQuickHelp {
   private static final Logger logger = LogManager.getLogger(ScriptRunner.class);
 

--- a/java/org/contikios/cooja/plugins/SimInformation.java
+++ b/java/org/contikios/cooja/plugins/SimInformation.java
@@ -55,7 +55,7 @@ import org.contikios.cooja.VisPlugin;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Simulation Information")
-@PluginType(PluginType.SIM_PLUGIN)
+@PluginType(PluginType.PType.SIM_PLUGIN)
 public class SimInformation extends VisPlugin {
   private final Simulation simulation;
 

--- a/java/org/contikios/cooja/plugins/TimeLine.java
+++ b/java/org/contikios/cooja/plugins/TimeLine.java
@@ -104,7 +104,7 @@ import org.jdom2.Element;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Timeline")
-@PluginType(PluginType.SIM_STANDARD_PLUGIN)
+@PluginType(PluginType.PType.SIM_STANDARD_PLUGIN)
 public class TimeLine extends VisPlugin implements HasQuickHelp {
   public static final int LED_PIXEL_HEIGHT = 2;
   public static final int EVENT_PIXEL_HEIGHT = 4;

--- a/java/org/contikios/cooja/plugins/VariableWatcher.java
+++ b/java/org/contikios/cooja/plugins/VariableWatcher.java
@@ -92,7 +92,7 @@ import org.jdom2.Element;
  * @author Enrico Jorns
  */
 @ClassDescription("Variable Watcher")
-@PluginType(PluginType.MOTE_PLUGIN)
+@PluginType(PluginType.PType.MOTE_PLUGIN)
 public class VariableWatcher extends VisPlugin implements MotePlugin, HasQuickHelp {
   private static final Logger logger = LogManager.getLogger(VariableWatcher.class.getName());
 

--- a/java/org/contikios/cooja/plugins/Visualizer.java
+++ b/java/org/contikios/cooja/plugins/Visualizer.java
@@ -138,7 +138,7 @@ import org.contikios.cooja.plugins.skins.UDGMVisualizerSkin;
  * @author Enrico Jorns
  */
 @ClassDescription("Network")
-@PluginType(PluginType.SIM_STANDARD_PLUGIN)
+@PluginType(PluginType.PType.SIM_STANDARD_PLUGIN)
 public class Visualizer extends VisPlugin implements HasQuickHelp {
   private static final Logger logger = LogManager.getLogger(Visualizer.class);
 

--- a/java/org/contikios/cooja/serialsocket/SerialSocketClient.java
+++ b/java/org/contikios/cooja/serialsocket/SerialSocketClient.java
@@ -86,7 +86,7 @@ import org.contikios.cooja.interfaces.SerialPort;
  * @author Enrico Jorns
  */
 @ClassDescription("Serial Socket (CLIENT)")
-@PluginType(PluginType.MOTE_PLUGIN)
+@PluginType(PluginType.PType.MOTE_PLUGIN)
 public class SerialSocketClient implements Plugin, MotePlugin {
   private static final Logger logger = LogManager.getLogger(SerialSocketClient.class);
 

--- a/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
+++ b/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
@@ -88,7 +88,7 @@ import org.contikios.cooja.util.CmdUtils;
  * @author Enrico Jorns
  */
 @ClassDescription("Serial Socket (SERVER)")
-@PluginType(PluginType.MOTE_PLUGIN)
+@PluginType(PluginType.PType.MOTE_PLUGIN)
 public class SerialSocketServer implements Plugin, MotePlugin {
   private static final Logger logger = LogManager.getLogger(SerialSocketServer.class);
 

--- a/java/org/contikios/mrm/AreaViewer.java
+++ b/java/org/contikios/mrm/AreaViewer.java
@@ -118,7 +118,7 @@ import org.contikios.mrm.ChannelModel.TxPair;
  * @author Fredrik Osterlind
  */
 @ClassDescription("MRM Radio environment")
-@PluginType(PluginType.SIM_PLUGIN)
+@PluginType(PluginType.PType.SIM_PLUGIN)
 @SupportedArguments(radioMediums = {MRM.class})
 public class AreaViewer extends VisPlugin {
   private static final Logger logger = LogManager.getLogger(AreaViewer.class);

--- a/java/org/contikios/mrm/FormulaViewer.java
+++ b/java/org/contikios/mrm/FormulaViewer.java
@@ -69,7 +69,7 @@ import org.contikios.mrm.ChannelModel.Parameter;
  * @author Fredrik Osterlind
  */
 @ClassDescription("MRM Settings")
-@PluginType(PluginType.SIM_PLUGIN)
+@PluginType(PluginType.PType.SIM_PLUGIN)
 @SupportedArguments(radioMediums = {MRM.class})
 public class FormulaViewer extends org.contikios.cooja.VisPlugin {
   private final ChannelModel channelModel;


### PR DESCRIPTION
Put the plugin type in an enum inside the PluginType interface. This ensures that plugin type annotations do not cause runtime exceptions.