### PR TITLE
Visualizer: fix startup race condition

### DIFF
--- a/java/org/contikios/cooja/plugins/Visualizer.java
+++ b/java/org/contikios/cooja/plugins/Visualizer.java
@@ -1488,7 +1488,7 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
           }
           for (final var skinClass : visualizerSkins) {
             if (wanted.equals(skinClass.getName()) || wanted.equals(Cooja.getDescriptionOf(skinClass))) {
-              SwingUtilities.invokeLater(() -> generateAndActivateSkin(skinClass));
+              generateAndActivateSkin(skinClass);
               wanted = null;
               break;
             }

--- a/java/org/contikios/cooja/plugins/Visualizer.java
+++ b/java/org/contikios/cooja/plugins/Visualizer.java
@@ -1485,18 +1485,18 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
           /* Backwards compatibility: se.sics -> org.contikios */
           if (wanted.startsWith("se.sics")) {
             wanted = wanted.replaceFirst("se\\.sics", "org.contikios");
-          } for (Class<? extends VisualizerSkin> skinClass : visualizerSkins) {
-          if (wanted.equals(skinClass.getName())
-                  /* Backwards compatibility */
-                  || wanted.equals(Cooja.getDescriptionOf(skinClass))) {
-            final Class<? extends VisualizerSkin> skin = skinClass;
-            SwingUtilities.invokeLater(() -> generateAndActivateSkin(skin));
-            wanted = null;
-            break;
           }
-        } if (wanted != null) {
-          logger.warn("Could not load visualizer: " + element.getText());
-        } break;
+          for (final var skinClass : visualizerSkins) {
+            if (wanted.equals(skinClass.getName()) || wanted.equals(Cooja.getDescriptionOf(skinClass))) {
+              SwingUtilities.invokeLater(() -> generateAndActivateSkin(skinClass));
+              wanted = null;
+              break;
+            }
+          }
+          if (wanted != null) {
+            logger.warn("Could not load visualizer: " + element.getText());
+          }
+          break;
         case "moterelations":
           showMoteToMoteRelations = true;
           break;


### PR DESCRIPTION
Calling invokeLater() in setConfigXML
makes it possible for Cooja to close
the simulation before the visualizer
has been loaded. This becomes a problem
with -update-simulation, that might drop
some visualizers along the way.

Plugins are now created from the AWT
thread, so remove the invokeLater call.