### PR TITLE
MoteType: remove Contiki-NG-specific methods

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -2,6 +2,26 @@
 
 ## Cooja API changes for plugins outside the main tree
 
+### Contiki-NG-specific moved from MoteType to BaseContikiMoteType
+
+Contiki-NG specific methods were moved from MoteType to BaseContikiMoteType
+([#857](https://github.com/contiki-ng/cooja/pull/857)).
+
+The following method implementations can safely be removed from mote other types:
+
+* `getContikiSourceFile`/`setContikiSourceFile`
+* `getContikiFirmwareFile`/`setContikiFirmwareFile`
+* `getCompileCommands`/`setCompileCommands`
+
+Plugins that need access to the getters can still access them through:
+
+```Java
+if (mote.getType() instanceof BaseContikiMoteType moteType) {
+   var sourceFile = moteType.getContikiSourceFile();
+   // ...
+}
+```
+
 ### Strongly typed PluginType Annotation
 
 The PluginType annotation was encapsulated in an enum to give Cooja exhaustiveness

--- a/java/org/contikios/cooja/MoteType.java
+++ b/java/org/contikios/cooja/MoteType.java
@@ -83,53 +83,6 @@ public interface MoteType {
   void setIdentifier(String identifier);
 
   /**
-   * Main Contiki source file of mote type.
-   * May be null.
-   *
-   * @return Contiki main process source file.
-   * @see #setContikiSourceFile(File)
-   */
-  File getContikiSourceFile();
-
-  /**
-   * @param file Contiki main process source file.
-   * @see #getContikiSourceFile()
-   */
-  void setContikiSourceFile(File file);
-
-  /**
-   * Compiled Contiki firmware file or library.
-   * May be null.
-   *
-   * @return Contiki firmware file or library.
-   * @see #setContikiFirmwareFile(File)
-   */
-  File getContikiFirmwareFile();
-
-  /**
-   * @param file Contiki firmware file or library.
-   * @see #getContikiFirmwareFile()
-   */
-  void setContikiFirmwareFile(File file);
-
-  /**
-   * Commands used to build the Contiki firmware from the Contiki source.
-   * May be null.
-   *
-   * @return Compile commands used to build firmware
-   * @see #setCompileCommands(String)
-   * @see #getContikiFirmwareFile()
-   * @see #getContikiSourceFile()
-   */
-  String getCompileCommands();
-
-  /**
-   * @param commands Compile commands
-   * @see #getCompileCommands()
-   */
-  void setCompileCommands(String commands);
-
-  /**
    * @return Mote interface classes of mote type.
    * @see #setMoteInterfaceClasses(Class[])
    */

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -143,34 +143,16 @@ public abstract class BaseContikiMoteType implements MoteType {
     return projectConfig;
   }
 
-  @Override
   public File getContikiSourceFile() {
     return fileSource;
   }
 
-  @Override
-  public void setContikiSourceFile(File file) {
-    fileSource = file;
-  }
-
-  @Override
   public String getCompileCommands() {
     return compileCommands;
   }
 
-  @Override
-  public void setCompileCommands(String commands) {
-    this.compileCommands = commands;
-  }
-
-  @Override
   public File getContikiFirmwareFile() {
     return fileFirmware;
-  }
-
-  @Override
-  public void setContikiFirmwareFile(File file) {
-    fileFirmware = file;
   }
 
   public File getExpectedFirmwareFile(String name) {
@@ -323,7 +305,7 @@ public abstract class BaseContikiMoteType implements MoteType {
       } else {
         fileFirmware = new File(cfg.file);
       }
-      setCompileCommands(cfg.commands);
+      compileCommands = cfg.commands;
       setMoteInterfaceClasses(cfg.interfaces);
     } else {
       // Handle multiple compilation commands one by one.

--- a/java/org/contikios/cooja/motes/AbstractApplicationMoteType.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMoteType.java
@@ -156,37 +156,6 @@ public abstract class AbstractApplicationMoteType implements MoteType {
   }
 
   @Override
-  public File getContikiSourceFile() {
-    return null; /* Contiki-independent */
-  }
-
-  @Override
-  public File getContikiFirmwareFile() {
-    return null; /* Contiki-independent */
-  }
-
-  @Override
-  public void setContikiSourceFile(File file) {
-    /* Contiki-independent */
-  }
-
-  @Override
-  public void setContikiFirmwareFile(File file) {
-    /* Contiki-independent */
-  }
-
-  @Override
-  public String getCompileCommands() {
-    /* Contiki-independent */
-    return null;
-  }
-
-  @Override
-  public void setCompileCommands(String commands) {
-    /* Contiki-independent */
-  }
-
-  @Override
   public ProjectConfig getConfig() {
     return myConfig;
   }

--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -472,7 +472,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
   private void tryMapDebugInfo() {
     /* called from AWT */
     int r = JOptionPane.showConfirmDialog(Cooja.getTopParentContainer(),
-        "The firmware file " + mspMote.getType().getContikiFirmwareFile().getName() + " references " + debugSourceFiles.length + " source files.\n" +
+        "The firmware file " + ((MspMoteType) mspMote.getType()).getContikiFirmwareFile().getName() + " references " + debugSourceFiles.length + " source files.\n" +
         "This function tries to locate these files on disk with a set of simple substitution rules.\n" +
         "\n" +
         "Right now " + getLocatedSourcesCount() + "/" + debugSourceFiles.length + " source files can be found.",

--- a/java/org/contikios/cooja/plugins/Visualizer.java
+++ b/java/org/contikios/cooja/plugins/Visualizer.java
@@ -92,6 +92,7 @@ import javax.swing.plaf.basic.BasicInternalFrameUI;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.contikios.cooja.mote.BaseContikiMoteType;
 import org.contikios.cooja.plugins.skins.DGRMVisualizerSkin;
 import org.contikios.cooja.plugins.skins.LogisticLossVisualizerSkin;
 import org.contikios.mrm.MRMVisualizerSkin;
@@ -397,15 +398,15 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
         if (motes == null) {
           return null;
         }
-        File file = motes[0].getType().getContikiSourceFile();
-        if (file == null) {
-          file = motes[0].getType().getContikiFirmwareFile();
-        }
         String fileName;
-        if (file == null) {
-          fileName = "<none>";
-        } else {
+        if (motes[0].getType() instanceof BaseContikiMoteType moteType) {
+          var file = moteType.getContikiSourceFile();
+          if (file == null) {
+            file = moteType.getContikiFirmwareFile();
+          }
           fileName = file.getName();
+        } else {
+          fileName = "<none>";
         }
         return "<html><table cellspacing=\"0\" cellpadding=\"1\">" +
                 "<tr><td>Type:</td><td>" +


### PR DESCRIPTION
Put the getters in BaseContikiMoteType instead,
and remove the setters completely.