### PR TITLE
Consolidate sim config

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1550,7 +1550,7 @@ public class Cooja extends Observable {
     }
     Simulation sim;
     try {
-      sim = new Simulation(cfg, this, title, configuration.logDir, generatedSeed, seed, medium, delay, quick, root);
+      sim = new Simulation(cfg, this, title, generatedSeed, seed, medium, delay, quick, root);
     } catch (MoteTypeCreationException e) {
       throw new SimulationCreationException("Unknown error: " + e.getMessage(), e);
     }
@@ -2078,7 +2078,11 @@ public class Cooja extends Observable {
     }
   }
 
-  /** Structure to hold the Cooja startup configuration. */
+  /** Structure to hold the Cooja startup configuration.
+   * <p>
+   * When SimConfig contains an identical field, these values are the default
+   * values when creating a new simulation in the File menu.
+   */
   public record Config(boolean vis, Long randomSeed, String externalToolsConfig,
                        String logDir, String contikiPath, String coojaPath, String javac,
                        List<Simulation.SimConfig> configs) {}

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1387,8 +1387,8 @@ public class Cooja extends Observable {
       Simulation sim = null;
       try {
         sim = config.vis
-                ? Cooja.gui.doLoadConfig(simConfig, simConfig.updateSim(), config.randomSeed)
-                : gui.loadSimulationConfig(simConfig, true, false, config.randomSeed);
+                ? Cooja.gui.doLoadConfig(simConfig, config.randomSeed)
+                : gui.loadSimulationConfig(simConfig, true, config.randomSeed);
       } catch (Exception e) {
         logger.fatal("Exception when loading simulation: ", e);
       }
@@ -1424,13 +1424,12 @@ public class Cooja extends Observable {
    * change mote type settings at this point.
    *
    * @param cfg Configuration to load
-   * @param rewriteCsc Should Cooja update the .csc file.
    * @param manualRandomSeed The random seed.
    * @return New simulation or null if recompiling failed or aborted
    * @throws SimulationCreationException If loading fails.
    * @see #saveSimulationConfig(File)
    */
-  Simulation loadSimulationConfig(Simulation.SimConfig cfg, boolean quick, boolean rewriteCsc, Long manualRandomSeed)
+  Simulation loadSimulationConfig(Simulation.SimConfig cfg, boolean quick, Long manualRandomSeed)
   throws SimulationCreationException {
     var file = new File(cfg.file());
     this.currentConfigFile = file; /* Used to generate config relative paths */
@@ -1449,7 +1448,7 @@ public class Cooja extends Observable {
         logger.fatal("Not a valid Cooja simulation config.");
         return null;
       }
-      sim = createSimulation(cfg, root, quick, rewriteCsc, manualRandomSeed);
+      sim = createSimulation(cfg, root, quick, manualRandomSeed);
     } catch (JDOMException e) {
       throw new SimulationCreationException("Config not well-formed", e);
     } catch (IOException e) {
@@ -1464,12 +1463,11 @@ public class Cooja extends Observable {
    * @param cfg Configuration to use
    * @param root The XML config.
    * @param quick Do a quickstart.
-   * @param rewriteCsc Should Cooja update the .csc file.
    * @param manualRandomSeed The random seed.
    * @throws SimulationCreationException If creation fails.
    * @return Simulation object.
    */
-  Simulation createSimulation(Simulation.SimConfig cfg, Element root, boolean quick, boolean rewriteCsc, Long manualRandomSeed)
+  Simulation createSimulation(Simulation.SimConfig cfg, Element root, boolean quick, Long manualRandomSeed)
   throws SimulationCreationException {
     boolean projectsOk = verifyProjects(root);
 
@@ -1485,7 +1483,7 @@ public class Cooja extends Observable {
       }
     }
     // Only renumber motes if their names can collide with existing motes.
-    if (!rewriteCsc) {
+    if (!cfg.updateSim()) {
       // Create old to new identifier mappings.
       var moteTypeIDMappings = new HashMap<String, String>();
       var reserved = new HashSet<>(readNames);
@@ -1561,12 +1559,9 @@ public class Cooja extends Observable {
   }
 
   /**
-   * Saves current simulation configuration to given file and notifies
-   * observers.
+   * Saves current simulation configuration to given file and notifies observers.
    *
-   * @see #loadSimulationConfig(Simulation.SimConfig, boolean, boolean, Long)
-   * @param file
-   *          File to write
+   * @param file File to write
    */
    void saveSimulationConfig(File file) {
     this.currentConfigFile = file; /* Used to generate config relative paths */

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1383,7 +1383,6 @@ public class Cooja extends Observable {
     int rv = 0;
     boolean autoQuit = !config.configs.isEmpty() && !config.vis;
     for (var simConfig : config.configs) {
-      var file = new File(simConfig.file());
       Simulation sim = null;
       try {
         sim = config.vis
@@ -1397,7 +1396,7 @@ public class Cooja extends Observable {
         rv = Math.max(rv, 1);
       } else if (simConfig.updateSim()) {
         autoQuit = true;
-        gui.saveSimulationConfig(file);
+        gui.saveSimulationConfig(new File(simConfig.file()));
       } else if (simConfig.autoStart()) {
         autoQuit = true;
         if (!config.vis) {

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -48,7 +48,6 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Properties;
@@ -1384,7 +1383,7 @@ public class Cooja extends Observable {
     int rv = 0;
     boolean autoQuit = !config.configs.isEmpty() && (!config.vis || config.updateSim);
     for (var simConfig : config.configs) {
-      var file = new File(simConfig.file);
+      var file = new File(simConfig.file());
       Simulation sim = null;
       try {
         sim = config.vis
@@ -1398,7 +1397,7 @@ public class Cooja extends Observable {
         rv = Math.max(rv, 1);
       } else if (config.updateSim) {
         gui.saveSimulationConfig(file);
-      } else if (simConfig.autoStart) {
+      } else if (simConfig.autoStart()) {
         autoQuit = true;
         if (!config.vis) {
           sim.setSpeedLimit(null);
@@ -2079,11 +2078,8 @@ public class Cooja extends Observable {
     }
   }
 
-  /** Structure to hold the simulation parameters. */
-  public record SimConfig(Map<String, String> opts, boolean autoStart, String file) {}
-
   /** Structure to hold the Cooja startup configuration. */
   public record Config(boolean vis, Long randomSeed, String externalToolsConfig, boolean updateSim,
                        String logDir, String contikiPath, String coojaPath, String javac,
-                       List<SimConfig> configs) {}
+                       List<Simulation.SimConfig> configs) {}
 }

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1381,13 +1381,13 @@ public class Cooja extends Observable {
     }
     // Check if simulator should be quick-started.
     int rv = 0;
-    boolean autoQuit = !config.configs.isEmpty() && (!config.vis || config.updateSim);
+    boolean autoQuit = !config.configs.isEmpty() && !config.vis;
     for (var simConfig : config.configs) {
       var file = new File(simConfig.file());
       Simulation sim = null;
       try {
         sim = config.vis
-                ? Cooja.gui.doLoadConfig(simConfig, config.updateSim, config.randomSeed)
+                ? Cooja.gui.doLoadConfig(simConfig, simConfig.updateSim(), config.randomSeed)
                 : gui.loadSimulationConfig(simConfig, true, false, config.randomSeed);
       } catch (Exception e) {
         logger.fatal("Exception when loading simulation: ", e);
@@ -1395,7 +1395,8 @@ public class Cooja extends Observable {
       if (sim == null) {
         autoQuit = true;
         rv = Math.max(rv, 1);
-      } else if (config.updateSim) {
+      } else if (simConfig.updateSim()) {
+        autoQuit = true;
         gui.saveSimulationConfig(file);
       } else if (simConfig.autoStart()) {
         autoQuit = true;
@@ -2083,7 +2084,7 @@ public class Cooja extends Observable {
   }
 
   /** Structure to hold the Cooja startup configuration. */
-  public record Config(boolean vis, Long randomSeed, String externalToolsConfig, boolean updateSim,
+  public record Config(boolean vis, Long randomSeed, String externalToolsConfig,
                        String logDir, String contikiPath, String coojaPath, String javac,
                        List<Simulation.SimConfig> configs) {}
 }

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -1119,7 +1119,7 @@ public class GUI {
     if (warnMemory()) {
       return;
     }
-    var worker = createLoadSimWorker(null, true, false, seed);
+    var worker = createLoadSimWorker(null, true, seed);
     if (worker == null) return;
     worker.execute();
   }
@@ -1139,7 +1139,7 @@ public class GUI {
     final var cfgFile = validateFileOrSelectNew(file);
     if (cfgFile == null) return;
     var cfg = new Simulation.SimConfig(cfgFile.getAbsolutePath(), false, false, new HashMap<>());
-    var worker = createLoadSimWorker(cfg, quick, false, null);
+    var worker = createLoadSimWorker(cfg, quick, null);
     if (worker == null) return;
     worker.execute();
   }
@@ -1148,15 +1148,14 @@ public class GUI {
    * Load a simulation configuration file from disk and return the simulation.
    *
    * @param cfg Configuration to load, reloads current sim if null
-   * @param rewriteCsc Rewrite simulation config
    * @param manualRandomSeed The random seed to use for the simulation
    * @return The simulation
    */
-  Simulation doLoadConfig(Simulation.SimConfig cfg, boolean rewriteCsc, Long manualRandomSeed) {
+  Simulation doLoadConfig(Simulation.SimConfig cfg, Long manualRandomSeed) {
     final var worker = new Cooja.RunnableInEDT<SwingWorker<Simulation, Cooja.SimulationCreationException>>() {
       @Override
       public SwingWorker<Simulation, Cooja.SimulationCreationException> work() {
-        return createLoadSimWorker(cfg, true, rewriteCsc, manualRandomSeed);
+        return createLoadSimWorker(cfg, true, manualRandomSeed);
       }
     }.invokeAndWait();
     worker.execute();
@@ -1231,12 +1230,11 @@ public class GUI {
    *
    * @param cfg        Configuration to load, reloads current sim if null
    * @param quick      Quick-load simulation
-   * @param rewriteCsc Rewrite simulation config
    * @param manualRandomSeed The random seed to use for the simulation
    * @return The worker that will load the simulation.
    */
   public SwingWorker<Simulation, Cooja.SimulationCreationException> createLoadSimWorker(Simulation.SimConfig cfg, final boolean quick,
-                                                                                         boolean rewriteCsc, Long manualRandomSeed) {
+                                                                                         Long manualRandomSeed) {
     assert java.awt.EventQueue.isDispatchThread() : "Call from AWT thread";
     final var configFile = cfg == null ? null : new File(cfg.file());
     final var autoStart = configFile == null && cooja.getSimulation().isRunning();
@@ -1292,8 +1290,8 @@ public class GUI {
             shouldRetry = false;
             PROGRESS_WARNINGS.clear();
             newSim = configFile == null
-                    ? cooja.createSimulation(cooja.getSimulation().getCfg(), root, quick, rewriteCsc, manualRandomSeed)
-                    : cooja.loadSimulationConfig(cfg, quick, rewriteCsc, manualRandomSeed);
+                    ? cooja.createSimulation(cooja.getSimulation().getCfg(), root, quick, manualRandomSeed)
+                    : cooja.loadSimulationConfig(cfg, quick, manualRandomSeed);
             if (newSim != null && autoStart) {
               newSim.startSimulation();
             }

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -411,10 +411,11 @@ public class GUI {
         var cfg = CreateSimDialog.showDialog(cooja, new CreateSimDialog.SimConfig(null, null,
                 false, 123456, 1000 * Simulation.MILLISECOND));
         if (cfg == null) return;
-        var config = new Simulation.SimConfig(null, false, false, new HashMap<>());
+        var config = new Simulation.SimConfig(null, false, false, cooja.configuration.logDir(),
+                new HashMap<>());
         Simulation sim;
         try {
-          sim = new Simulation(config, cooja, cfg.title(), cooja.configuration.logDir(), cfg.generatedSeed(),
+          sim = new Simulation(config, cooja, cfg.title(), cfg.generatedSeed(),
                   cfg.randomSeed(), cfg.radioMedium(), cfg.moteStartDelay(), false, null);
         } catch (MoteType.MoteTypeCreationException | Cooja.SimulationCreationException ex) {
           return;
@@ -1138,7 +1139,8 @@ public class GUI {
 
     final var cfgFile = validateFileOrSelectNew(file);
     if (cfgFile == null) return;
-    var cfg = new Simulation.SimConfig(cfgFile.getAbsolutePath(), false, false, new HashMap<>());
+    var cfg = new Simulation.SimConfig(cfgFile.getAbsolutePath(), false, false,
+            cooja.configuration.logDir(), new HashMap<>());
     var worker = createLoadSimWorker(cfg, quick, null);
     if (worker == null) return;
     worker.execute();

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -53,6 +53,7 @@ import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -410,10 +411,11 @@ public class GUI {
         var cfg = CreateSimDialog.showDialog(cooja, new CreateSimDialog.SimConfig(null, null,
                 false, 123456, 1000 * Simulation.MILLISECOND));
         if (cfg == null) return;
+        var config = new Simulation.SimConfig(null, false, new HashMap<>());
         Simulation sim;
         try {
-          sim = new Simulation(cooja, cfg.title(), cooja.configuration.logDir(), cfg.generatedSeed(), cfg.randomSeed(),
-                  cfg.radioMedium(), cfg.moteStartDelay(), false, null);
+          sim = new Simulation(config, cooja, cfg.title(), cooja.configuration.logDir(), cfg.generatedSeed(),
+                  cfg.randomSeed(), cfg.radioMedium(), cfg.moteStartDelay(), false, null);
         } catch (MoteType.MoteTypeCreationException | Cooja.SimulationCreationException ex) {
           return;
         }
@@ -1136,8 +1138,8 @@ public class GUI {
 
     final var cfgFile = validateFileOrSelectNew(file);
     if (cfgFile == null) return;
-
-    var worker = createLoadSimWorker(cfgFile, quick, false, null);
+    var cfg = new Simulation.SimConfig(cfgFile.getAbsolutePath(), false, new HashMap<>());
+    var worker = createLoadSimWorker(cfg, quick, false, null);
     if (worker == null) return;
     worker.execute();
   }
@@ -1145,16 +1147,16 @@ public class GUI {
   /**
    * Load a simulation configuration file from disk and return the simulation.
    *
-   * @param configFile Configuration file to load, reloads current sim if null
+   * @param cfg Configuration to load, reloads current sim if null
    * @param rewriteCsc Rewrite simulation config
    * @param manualRandomSeed The random seed to use for the simulation
    * @return The simulation
    */
-  Simulation doLoadConfig(File configFile, boolean rewriteCsc, Long manualRandomSeed) {
+  Simulation doLoadConfig(Simulation.SimConfig cfg, boolean rewriteCsc, Long manualRandomSeed) {
     final var worker = new Cooja.RunnableInEDT<SwingWorker<Simulation, Cooja.SimulationCreationException>>() {
       @Override
       public SwingWorker<Simulation, Cooja.SimulationCreationException> work() {
-        return createLoadSimWorker(configFile, true, rewriteCsc, manualRandomSeed);
+        return createLoadSimWorker(cfg, true, rewriteCsc, manualRandomSeed);
       }
     }.invokeAndWait();
     worker.execute();
@@ -1227,15 +1229,16 @@ public class GUI {
    * Create a worker that will load the simulation in the background, displaying
    * a progress dialog if it is a quick-load.
    *
-   * @param configFile Configuration file to load, reloads current sim if null
+   * @param cfg        Configuration to load, reloads current sim if null
    * @param quick      Quick-load simulation
    * @param rewriteCsc Rewrite simulation config
    * @param manualRandomSeed The random seed to use for the simulation
    * @return The worker that will load the simulation.
    */
-  public SwingWorker<Simulation, Cooja.SimulationCreationException> createLoadSimWorker(File configFile, final boolean quick,
+  public SwingWorker<Simulation, Cooja.SimulationCreationException> createLoadSimWorker(Simulation.SimConfig cfg, final boolean quick,
                                                                                          boolean rewriteCsc, Long manualRandomSeed) {
     assert java.awt.EventQueue.isDispatchThread() : "Call from AWT thread";
+    final var configFile = cfg == null ? null : new File(cfg.file());
     final var autoStart = configFile == null && cooja.getSimulation().isRunning();
     if (configFile != null && !cooja.doRemoveSimulation(!cooja.configuration.updateSim())) {
       return null;
@@ -1275,23 +1278,22 @@ public class GUI {
       progressDialog = null;
     }
 
-    final var cfgFile = configFile;
     // SwingWorker can pass information from worker to process() through publish().
     // Communicate information the other way through this shared queue.
     final var channel = new SynchronousQueue<Integer>(true);
     var worker = new SwingWorker<Simulation, Cooja.SimulationCreationException>() {
       @Override
       public Simulation doInBackground() {
-        Element root = cfgFile == null ? cooja.extractSimulationConfig() : null;
+        Element root = configFile == null ? cooja.extractSimulationConfig() : null;
         boolean shouldRetry;
         Simulation newSim = null;
         do {
           try {
             shouldRetry = false;
             PROGRESS_WARNINGS.clear();
-            newSim = cfgFile == null
-                    ? cooja.createSimulation(root, quick, rewriteCsc, manualRandomSeed)
-                    : cooja.loadSimulationConfig(cfgFile, quick, rewriteCsc, manualRandomSeed);
+            newSim = configFile == null
+                    ? cooja.createSimulation(cooja.getSimulation().getCfg(), root, quick, rewriteCsc, manualRandomSeed)
+                    : cooja.loadSimulationConfig(cfg, quick, rewriteCsc, manualRandomSeed);
             if (newSim != null && autoStart) {
               newSim.startSimulation();
             }

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -411,7 +411,7 @@ public class GUI {
         var cfg = CreateSimDialog.showDialog(cooja, new CreateSimDialog.SimConfig(null, null,
                 false, 123456, 1000 * Simulation.MILLISECOND));
         if (cfg == null) return;
-        var config = new Simulation.SimConfig(null, false, new HashMap<>());
+        var config = new Simulation.SimConfig(null, false, false, new HashMap<>());
         Simulation sim;
         try {
           sim = new Simulation(config, cooja, cfg.title(), cooja.configuration.logDir(), cfg.generatedSeed(),
@@ -1138,7 +1138,7 @@ public class GUI {
 
     final var cfgFile = validateFileOrSelectNew(file);
     if (cfgFile == null) return;
-    var cfg = new Simulation.SimConfig(cfgFile.getAbsolutePath(), false, new HashMap<>());
+    var cfg = new Simulation.SimConfig(cfgFile.getAbsolutePath(), false, false, new HashMap<>());
     var worker = createLoadSimWorker(cfg, quick, false, null);
     if (worker == null) return;
     worker.execute();
@@ -1240,7 +1240,7 @@ public class GUI {
     assert java.awt.EventQueue.isDispatchThread() : "Call from AWT thread";
     final var configFile = cfg == null ? null : new File(cfg.file());
     final var autoStart = configFile == null && cooja.getSimulation().isRunning();
-    if (configFile != null && !cooja.doRemoveSimulation(!cooja.configuration.updateSim())) {
+    if (configFile != null && !cooja.doRemoveSimulation(!cfg.updateSim())) {
       return null;
     }
 

--- a/java/org/contikios/cooja/LogScriptEngine.java
+++ b/java/org/contikios/cooja/LogScriptEngine.java
@@ -121,11 +121,11 @@ public class LogScriptEngine {
   private long startTime;
   private long startRealTime;
 
-  protected LogScriptEngine(Simulation simulation, String logDir, int logNumber, JTextArea logTextArea) {
+  protected LogScriptEngine(Simulation simulation, int logNumber, JTextArea logTextArea) {
     this.simulation = simulation;
     if (!Cooja.isVisualized()) {
       var logName = logNumber == 0 ? "COOJA.testlog" : String.format("COOJA-%02d.testlog", logNumber);
-      var logFile = Paths.get(logDir, logName);
+      var logFile = Paths.get(simulation.getCfg().logDir(), logName);
       try {
         logWriter = Files.newBufferedWriter(logFile, UTF_8);
         logWriter.write("Random seed: " + simulation.getRandomSeed() + "\n");

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -227,7 +227,9 @@ class Main {
           System.exit(1);
         }
         var autoStart = map.getOrDefault("autostart", Boolean.toString(options.autoStart || options.action.nogui != null));
-        simConfigs.add(new Simulation.SimConfig(file, Boolean.parseBoolean(autoStart), map));
+        var updateSim = map.getOrDefault("update-simulation", Boolean.toString(options.updateSimulation));
+        simConfigs.add(new Simulation.SimConfig(file, Boolean.parseBoolean(autoStart), Boolean.parseBoolean(updateSim),
+                map));
       }
     }
 
@@ -284,7 +286,7 @@ class Main {
     }
 
     var vis = options.action == null || options.action.quickstart != null;
-    var cfg = new Config(vis, options.randomSeed, options.externalToolsConfig, options.updateSimulation,
+    var cfg = new Config(vis, options.randomSeed, options.externalToolsConfig,
             options.logDir, options.contikiPath, options.coojaPath, options.javac, simConfigs);
     // Configure logger
     if (options.logConfigFile == null) {

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -228,8 +228,9 @@ class Main {
         }
         var autoStart = map.getOrDefault("autostart", Boolean.toString(options.autoStart || options.action.nogui != null));
         var updateSim = map.getOrDefault("update-simulation", Boolean.toString(options.updateSimulation));
+        var logDir = map.getOrDefault("logdir", options.logDir);
         simConfigs.add(new Simulation.SimConfig(file, Boolean.parseBoolean(autoStart), Boolean.parseBoolean(updateSim),
-                map));
+                logDir, map));
       }
     }
 

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -195,7 +195,7 @@ class Main {
     }
 
     // Parse and verify soundness of -nogui/-quickstart argument.
-    ArrayList<Cooja.SimConfig> simConfigs = new ArrayList<>();
+    ArrayList<Simulation.SimConfig> simConfigs = new ArrayList<>();
     if (options.action != null) {
       for (String arg : options.action.nogui == null ? options.action.quickstart : options.action.nogui) {
         // Argument on the form "file.csc[,key1=value1,key2=value2, ..]"
@@ -227,7 +227,7 @@ class Main {
           System.exit(1);
         }
         var autoStart = map.getOrDefault("autostart", Boolean.toString(options.autoStart || options.action.nogui != null));
-        simConfigs.add(new Cooja.SimConfig(map, Boolean.parseBoolean(autoStart), file));
+        simConfigs.add(new Simulation.SimConfig(file, Boolean.parseBoolean(autoStart), map));
       }
     }
 

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -64,9 +64,6 @@ public final class Simulation extends Observable {
   public static final long MICROSECOND = 1L;
   public static final long MILLISECOND = 1000*MICROSECOND;
 
-  /** The name of the directory to output logs to. */
-  private final String logDir;
-
   /** Lock used to wait for simulation state changes */
   private final Object stateLock = new Object();
 
@@ -167,14 +164,13 @@ public final class Simulation extends Observable {
   /**
    * Creates a new simulation
    */
-  public Simulation(SimConfig cfg, Cooja cooja, String title, String logDir, boolean generateSeed, long seed,
+  public Simulation(SimConfig cfg, Cooja cooja, String title, boolean generateSeed, long seed,
                     String radioMediumClass, long moteStartDelay, boolean quick, Element root)
           throws MoteType.MoteTypeCreationException, SimulationCreationException {
     this.cfg = cfg;
     logger.info("Simulation " + (cfg.file == null ? "(unnamed)" : cfg.file) + " random seed: " + seed);
     this.cooja = cooja;
     this.title = title;
-    this.logDir = logDir;
     randomSeed = seed;
     randomSeedGenerated = generateSeed;
     randomGenerator = new SafeRandom(this);
@@ -505,7 +501,7 @@ public final class Simulation extends Observable {
   /** Create a new script engine that logs to the logTextArea and add it to the list
    *  of active script engines. */
   public LogScriptEngine newScriptEngine(JTextArea logTextArea) {
-    var engine = new LogScriptEngine(this, logDir, scriptEngines.size(), logTextArea);
+    var engine = new LogScriptEngine(this, scriptEngines.size(), logTextArea);
     scriptEngines.add(engine);
     return engine;
   }
@@ -1049,5 +1045,6 @@ public final class Simulation extends Observable {
 
   /** Structure to hold the simulation parameters. */
   public record SimConfig(String file, boolean autoStart, boolean updateSim,
+                          String logDir,
                           Map<String, String> opts) {}
 }

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -124,6 +124,8 @@ public final class Simulation extends Observable {
   public record MoteRelation(Mote source, Mote dest, Color color) {}
   private final ArrayList<MoteRelation> moteRelations = new ArrayList<>();
 
+  private final SimConfig cfg;
+
   private final TimeEvent delayEvent = new TimeEvent() {
     @Override
     public void execute(long t) {
@@ -165,11 +167,11 @@ public final class Simulation extends Observable {
   /**
    * Creates a new simulation
    */
-  public Simulation(Cooja cooja, String title, String logDir, boolean generateSeed, long seed, String radioMediumClass,
-                    long moteStartDelay, boolean quick, Element root)
+  public Simulation(SimConfig cfg, Cooja cooja, String title, String logDir, boolean generateSeed, long seed,
+                    String radioMediumClass, long moteStartDelay, boolean quick, Element root)
           throws MoteType.MoteTypeCreationException, SimulationCreationException {
-    String name = cooja.currentConfigFile == null ? "(unnamed)" : cooja.currentConfigFile.toString();
-    logger.info("Simulation " + name + " random seed: " + seed);
+    this.cfg = cfg;
+    logger.info("Simulation " + (cfg.file == null ? "(unnamed)" : cfg.file) + " random seed: " + seed);
     this.cooja = cooja;
     this.title = title;
     this.logDir = logDir;
@@ -1038,6 +1040,11 @@ public final class Simulation extends Observable {
    */
   public void setTitle(String title) {
     this.title = title;
+  }
+
+  /** Returns the simulation configuration. */
+  public SimConfig getCfg() {
+    return cfg;
   }
 
   /** Structure to hold the simulation parameters. */

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -1048,6 +1048,6 @@ public final class Simulation extends Observable {
   }
 
   /** Structure to hold the simulation parameters. */
-  public record SimConfig(String file, boolean autoStart,
+  public record SimConfig(String file, boolean autoStart, boolean updateSim,
                           Map<String, String> opts) {}
 }

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -30,6 +30,7 @@ package org.contikios.cooja;
 import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Observable;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -1038,4 +1039,8 @@ public final class Simulation extends Observable {
   public void setTitle(String title) {
     this.title = title;
   }
+
+  /** Structure to hold the simulation parameters. */
+  public record SimConfig(String file, boolean autoStart,
+                          Map<String, String> opts) {}
 }

--- a/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
+++ b/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
@@ -446,8 +446,7 @@ public class SerialSocketServer implements Plugin, MotePlugin {
       }
     }, "SerialSocketServer").start();
 
-    final var cooja = simulation.getCooja();
-    if (commands != null && !cooja.configuration.updateSim()) {
+    if (commands != null && !simulation.getCfg().updateSim()) {
       // Run commands in a separate thread since Cooja cannot start the simulation before this method returns.
       // The simulation is required to run before tunslip6 can be started.
       new Thread(() -> {
@@ -458,7 +457,7 @@ public class SerialSocketServer implements Plugin, MotePlugin {
           }
           try {
             // Must not be synchronous, tunslip6 hangs in 17-tun-rpl-br because SerialSocket does not disconnect.
-            CmdUtils.run(cmd, cooja, false);
+            CmdUtils.run(cmd, simulation.getCooja(), false);
           } catch (Exception e) {
             rv = 1;
             break;


### PR DESCRIPTION
Add a SimConfig parameter to the load/create simulation functions that contains the information that is passed in separate parameters right now.

This does not make a huge difference right now, but it will simplify the handling of per-simulation configuration.