### PR TITLE
GUI: remove save settings call

### DIFF
--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -1506,7 +1506,6 @@ public class GUI {
       }
     }
     Cooja.setExternalToolsSetting("SIMCFG_HISTORY", newHistory.toString());
-    Cooja.saveExternalToolsUserSettings();
     hasFileHistoryChanged = true;
   }
 


### PR DESCRIPTION
No reason to write the user settings file
repeatedly, the settings are automatically
saved upon exit.