### PR TITLE
Cooja: separate sim config files from cfg

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1324,8 +1324,9 @@ public class Cooja extends Observable {
    * Load configurations and create a GUI.
    *
    * @param config Cooja configuration
+   * @param simConfigs Simulation configurations
    */
-  public static void go(Config config) {
+  public static void go(Config config, List<Simulation.SimConfig> simConfigs) {
     configuration = config;
     externalToolsUserSettingsFile = config.externalToolsConfig == null
             ? new File(System.getProperty("user.home"), ".cooja.user.properties")
@@ -1340,8 +1341,8 @@ public class Cooja extends Observable {
     }
     // Check if simulator should be quick-started.
     int rv = 0;
-    boolean autoQuit = !config.configs.isEmpty() && !config.vis;
-    for (var simConfig : config.configs) {
+    boolean autoQuit = !simConfigs.isEmpty() && !config.vis;
+    for (var simConfig : simConfigs) {
       Simulation sim = null;
       try {
         sim = config.vis
@@ -2042,6 +2043,5 @@ public class Cooja extends Observable {
    * values when creating a new simulation in the File menu.
    */
   public record Config(boolean vis, Long randomSeed, String externalToolsConfig,
-                       String logDir, String contikiPath, String coojaPath, String javac,
-                       List<Simulation.SimConfig> configs) {}
+                       String logDir, String contikiPath, String coojaPath, String javac) {}
 }

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -288,7 +288,7 @@ class Main {
 
     var vis = options.action == null || options.action.quickstart != null;
     var cfg = new Config(vis, options.randomSeed, options.externalToolsConfig,
-            options.logDir, options.contikiPath, options.coojaPath, options.javac, simConfigs);
+            options.logDir, options.contikiPath, options.coojaPath, options.javac);
     // Configure logger
     if (options.logConfigFile == null) {
       ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
@@ -328,10 +328,10 @@ class Main {
       //        but go immediately returns which causes the log file to be closed
       //        while the simulation is still running.
       Configurator.initialize(builder.build());
-      Cooja.go(cfg);
+      Cooja.go(cfg, simConfigs);
     } else {
       Configurator.initialize("ConfigFile", options.logConfigFile);
-      Cooja.go(cfg);
+      Cooja.go(cfg, simConfigs);
     }
   }
 }


### PR DESCRIPTION
The config is persistent during the lifetime
of Cooja, so do not store the -nogui/-quickstart
information inside that.