### PR TITLE
GUI: remove EventQueue.invokeLater wrapping

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -305,7 +305,7 @@ public class Cooja extends Observable {
    */
   public static void updateProgress(boolean stoppedSimulation) {
     if (gui != null) {
-      gui.updateProgress(stoppedSimulation);
+      java.awt.EventQueue.invokeLater(() -> gui.updateProgress(stoppedSimulation));
     }
   }
 
@@ -314,7 +314,7 @@ public class Cooja extends Observable {
    */
   static void updateGUIComponentState() {
     if (gui != null) {
-      gui.updateGUIComponentState();
+      java.awt.EventQueue.invokeLater(() -> gui.updateGUIComponentState());
     }
   }
 

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -377,7 +377,7 @@ public class GUI {
         } else if (source == reloadButton) {
           reloadCurrentSimulation(cooja.getSimulation().getRandomSeed());
         }
-        java.awt.EventQueue.invokeLater(() -> toolbarListener.updateToolbar(source == reloadButton));
+        toolbarListener.updateToolbar(source == reloadButton);
       }
     };
     stepButton.addActionListener(buttonAction);
@@ -1440,21 +1440,19 @@ public class GUI {
   }
 
   public void updateProgress(boolean stoppedSimulation) {
-    java.awt.EventQueue.invokeLater(() -> toolbarListener.updateToolbar(stoppedSimulation));
+    toolbarListener.updateToolbar(stoppedSimulation);
   }
 
   public void updateGUIComponentState() {
-    java.awt.EventQueue.invokeLater(() -> {
-      // Update action state.
-      for (var a : guiActions) {
-        a.setEnabled(a.shouldBeEnabled());
-      }
+    // Update action state.
+    for (var a : guiActions) {
+      a.setEnabled(a.shouldBeEnabled());
+    }
 
-      // Mote and mote type menus.
-      menuMoteTypeClasses.setEnabled(cooja.getSimulation() != null);
-      menuMoteTypes.setEnabled(cooja.getSimulation() != null);
-      updateProgress(false);
-    });
+    // Mote and mote type menus.
+    menuMoteTypeClasses.setEnabled(cooja.getSimulation() != null);
+    menuMoteTypes.setEnabled(cooja.getSimulation() != null);
+    updateProgress(false);
   }
 
   private static void updateDesktopSize(final JDesktopPane desktop) {


### PR DESCRIPTION
The GUI methods are called from the AWT thread,
so move the EventQueue.invokeLater into Cooja
instead.