### PR TITLE
Move externalToolsSettingsName to ExternalToolsDialog

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -143,29 +143,6 @@ public class Cooja extends Observable {
   public static Properties defaultExternalToolsSettings;
   public static Properties currentExternalToolsSettings;
 
-  private static final String[] externalToolsSettingNames = new String[] {
-    "PATH_COOJA",
-    "PATH_CONTIKI", "PATH_APPS",
-    "PATH_APPSEARCH",
-
-    "PATH_MAKE",
-    "PATH_C_COMPILER", "COMPILER_ARGS",
-
-    "DEFAULT_PROJECTDIRS",
-
-    "PARSE_WITH_COMMAND",
-
-    "READELF_COMMAND",
-
-    "PARSE_COMMAND",
-    "COMMAND_VAR_NAME_ADDRESS_SIZE",
-    "COMMAND_DATA_START", "COMMAND_DATA_END",
-    "COMMAND_BSS_START", "COMMAND_BSS_END",
-    "COMMAND_COMMON_START", "COMMAND_COMMON_END",
-
-    "HIDE_WARNINGS"
-  };
-
   static GUI gui = null;
 
   /** The Cooja startup configuration. */
@@ -1000,24 +977,6 @@ public class Cooja extends Observable {
     }
 
   // // EXTERNAL TOOLS SETTINGS METHODS ////
-
-  /**
-   * @return Number of external tools settings
-   */
-  public static int getExternalToolsSettingsCount() {
-    return externalToolsSettingNames.length;
-  }
-
-  /**
-   * Get name of external tools setting at given index.
-   *
-   * @param index
-   *          Setting index
-   * @return Name
-   */
-  public static String getExternalToolsSettingName(int index) {
-    return externalToolsSettingNames[index];
-  }
 
   /**
    * @param name

--- a/java/org/contikios/cooja/dialogs/ExternalToolsDialog.java
+++ b/java/org/contikios/cooja/dialogs/ExternalToolsDialog.java
@@ -57,8 +57,30 @@ import org.contikios.cooja.Cooja;
 public class ExternalToolsDialog extends JDialog {
   private final static int LABEL_WIDTH = 220;
   private final static int LABEL_HEIGHT = 15;
+  private static final String[] settingsNames = new String[] {
+    "PATH_COOJA",
+    "PATH_CONTIKI", "PATH_APPS",
+    "PATH_APPSEARCH",
 
-  private final JTextField[] textFields = new JTextField[Cooja.getExternalToolsSettingsCount()];
+    "PATH_MAKE",
+    "PATH_C_COMPILER", "COMPILER_ARGS",
+
+    "DEFAULT_PROJECTDIRS",
+
+    "PARSE_WITH_COMMAND",
+
+    "READELF_COMMAND",
+
+    "PARSE_COMMAND",
+    "COMMAND_VAR_NAME_ADDRESS_SIZE",
+    "COMMAND_DATA_START", "COMMAND_DATA_END",
+    "COMMAND_BSS_START", "COMMAND_BSS_END",
+    "COMMAND_COMMON_START", "COMMAND_COMMON_END",
+
+    "HIDE_WARNINGS"
+  };
+
+  private final JTextField[] textFields = new JTextField[settingsNames.length];
 
   /** Creates a dialog for viewing/editing external tools settings. */
   public static void showDialog() {
@@ -92,7 +114,7 @@ public class ExternalToolsDialog extends JDialog {
     button = new JButton("Save");
     button.addActionListener(e -> {
       for (int i = 0; i < textFields.length; i++) {
-        Cooja.setExternalToolsSetting(Cooja.getExternalToolsSettingName(i), textFields[i].getText().trim());
+        Cooja.setExternalToolsSetting(settingsNames[i], textFields[i].getText().trim());
       }
       Cooja.saveExternalToolsUserSettings();
       dispose();
@@ -115,7 +137,7 @@ public class ExternalToolsDialog extends JDialog {
       var smallPane = new JPanel();
       smallPane.setAlignmentX(Component.LEFT_ALIGNMENT);
       smallPane.setLayout(new BoxLayout(smallPane, BoxLayout.X_AXIS));
-      var label = new JLabel(Cooja.getExternalToolsSettingName(i));
+      var label = new JLabel(settingsNames[i]);
       label.setPreferredSize(new Dimension(LABEL_WIDTH, LABEL_HEIGHT));
 
       var textField = new JTextField(35);
@@ -148,7 +170,7 @@ public class ExternalToolsDialog extends JDialog {
 
   private void updateTextFields() {
     for (int i = 0; i < textFields.length; i++) {
-      textFields[i].setText(Cooja.getExternalToolsSetting(Cooja.getExternalToolsSettingName(i), ""));
+      textFields[i].setText(Cooja.getExternalToolsSetting(settingsNames[i], ""));
     }
     compareWithDefaults();
   }
@@ -158,7 +180,7 @@ public class ExternalToolsDialog extends JDialog {
       String currentValue = textFields[i].getText();
 
       // Compare with default value
-      String defaultValue = Cooja.getExternalToolsDefaultSetting(Cooja.getExternalToolsSettingName(i), "");
+      var defaultValue = Cooja.getExternalToolsDefaultSetting(settingsNames[i], "");
       if (currentValue.equals(defaultValue)) {
         textFields[i].setBackground(Color.WHITE);
         textFields[i].setToolTipText("");


### PR DESCRIPTION
This array is only used in ExternalToolsDialog, so move it there.