### PR TITLE
Use double dash in command line options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,8 +110,8 @@ tasks.register('fullJar', Jar) {
 run {
   // Bad Cooja location detected with gradle run, explicitly pass -cooja.
   doFirst {
-    args += ['-cooja', "$projectDir",
-             '-javac', javaToolchains.compilerFor {
+    args += ['--cooja', "$projectDir",
+             '--javac', javaToolchains.compilerFor {
                          languageVersion = JavaLanguageVersion.of(javaVersion)
                        }.get().executablePath]
   }

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -1,5 +1,19 @@
 # Cooja v4.9
 
+## Cooja User Interface Changes
+
+### Deprecated `-nogui` parameter
+
+Graphical/headless mode is now controlled by separate parameter (`--[no-]gui`),
+so `-nogui` has been deprecated. The old behavior for `-nogui=file.csc` is now
+accomplished with `--quickstart=file.csc --no-gui`.
+
+### Double dash before long command line options
+
+The implementation of the command line option `--[no-]gui` was required to use
+a double dash, so the other command line options have been converted to also
+use a double dash for consistency.
+
 ## Cooja API changes for plugins outside the main tree
 
 ### Contiki-NG-specific moved from MoteType to BaseContikiMoteType

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -69,55 +69,55 @@ class Main {
   /**
    * Option for specifying log4j2 config file.
    */
-  @Option(names = "-log4j2", paramLabel = "FILE", description = "the log4j2 config file")
+  @Option(names = "--log4j2", paramLabel = "FILE", description = "the log4j2 config file")
   String logConfigFile;
 
   /**
    * Option for specifying log directory.
    */
-  @Option(names = "-logdir", paramLabel = "DIR", description = "the log directory use")
+  @Option(names = {"-logdir", "--logdir"}, paramLabel = "DIR", description = "the log directory use")
   String logDir = ".";
 
   /**
    * Option for also logging stdout output to a file.
    */
-  @Option(names = "-logname", paramLabel = "NAME", description = "the filename for the log")
+  @Option(names = "--logname", paramLabel = "NAME", description = "the filename for the log")
   String logName;
 
   /**
    * Option for specifying Contiki-NG path.
    */
-  @Option(names = "-contiki", paramLabel = "DIR", description = "the Contiki-NG directory")
+  @Option(names = {"-contiki", "--contiki"}, paramLabel = "DIR", description = "the Contiki-NG directory")
   String contikiPath;
 
   /**
    * Option for specifying Cooja path.
    */
-  @Option(names = "-cooja", paramLabel = "DIR", description = "the Cooja directory")
+  @Option(names = "--cooja", paramLabel = "DIR", description = "the Cooja directory")
   String coojaPath;
 
   /**
    * Option for specifying javac path.
    */
-  @Option(names = "-javac", paramLabel = "FILE", description = "the javac binary", required = true)
+  @Option(names = "--javac", paramLabel = "FILE", description = "the javac binary", required = true)
   String javac;
 
   /**
    * Option for specifying external config file of tools.
    */
-  @Option(names = "-external_tools_config", paramLabel = "FILE", description = "the filename for external config")
+  @Option(names = "--external_tools_config", paramLabel = "FILE", description = "the filename for external config")
   String externalToolsConfig;
 
   /**
    * Option for specifying seed used for simulation.
    */
-  @Option(names = "-random-seed", paramLabel = "SEED", description = "the random seed")
+  @Option(names = {"-random-seed", "--random-seed"}, paramLabel = "SEED", description = "the random seed")
   Long randomSeed;
 
   /**
    * Automatically start simulations.
    */
-  @Option(names = "-autostart", description = "automatically start -nogui/-quickstart simulations")
+  @Option(names = "--autostart", description = "automatically start -nogui/-quickstart simulations")
   boolean autoStart;
 
   /**
@@ -133,20 +133,20 @@ class Main {
     /**
      * Option for specifying file to start the simulation with.
      */
-    @Option(names = "-quickstart", paramLabel = "FILE", description = "start simulation with file")
+    @Option(names = {"-quickstart", "--quickstart"}, paramLabel = "FILE", description = "start simulation with file")
     String[] quickstart;
 
     /**
      * Option for specifying file to start the simulation with.
      */
-    @Option(names = "-nogui", paramLabel = "FILE", description = "start simulation with file")
+    @Option(names = {"-nogui", "--nogui"}, paramLabel = "FILE", description = "start simulation with file [DEPRECATED]")
     String[] nogui;
   }
 
   /**
    * Option for instructing Cooja to update the simulation file (.csc).
    */
-  @Option(names = "-update-simulation", description = "write an updated simulation file (.csc) and exit")
+  @Option(names = "--update-simulation", description = "write an updated simulation file (.csc) and exit")
   boolean updateSimulation;
 
   @Option(names = "--version", versionHelp = true,


### PR DESCRIPTION
Rename the command line options to use a double
dash for long options.

Add temporary compatibility versions of parameters that are used by the Contiki-NG regression tests.
These can be removed after the submodule and Contiki-NG tests have been updated for the new names.