### PR TITLE
Stop exposing motetype_identifier

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -772,11 +772,7 @@ public class ContikiMoteType extends BaseContikiMoteType {
   public Collection<Element> getConfigXML(Simulation simulation) {
     ArrayList<Element> config = new ArrayList<>();
 
-    var element = new Element("identifier");
-    element.setText(getIdentifier());
-    config.add(element);
-
-    element = new Element("description");
+    var element = new Element("description");
     element.setText(getDescription());
     config.add(element);
 

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -72,13 +72,8 @@ public abstract class MspMoteType extends BaseContikiMoteType {
   public Collection<Element> getConfigXML(Simulation simulation) {
     ArrayList<Element> config = new ArrayList<>();
 
-    // Identifier
-    var element = new Element("identifier");
-    element.setText(getIdentifier());
-    config.add(element);
-
     // Description
-    element = new Element("description");
+    var element = new Element("description");
     element.setText(getDescription());
     config.add(element);
 


### PR DESCRIPTION
Put <mote> inside <motetype> and make
the identifier an internal detail
of mote types.