### PR TITLE
Rename argument external_tools_config to config

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -8,6 +8,12 @@ Graphical/headless mode is now controlled by separate parameter (`--[no-]gui`),
 so `-nogui` has been deprecated. The old behavior for `-nogui=file.csc` is now
 accomplished with `--quickstart=file.csc --no-gui`.
 
+### Renamed `--external_tools_config` parameter to `--config`
+
+This parameter specifies a configuration file not only with user specified
+external tools, but also other user settings such as window location,
+file history, etc.
+
 ### Double dash before long command line options
 
 The implementation of the command line option `--[no-]gui` was required to use

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -103,10 +103,10 @@ class Main {
   String javac;
 
   /**
-   * Option for specifying external config file of tools.
+   * Option for specifying external user config file.
    */
-  @Option(names = "--external_tools_config", paramLabel = "FILE", description = "the filename for external config")
-  String externalToolsConfig;
+  @Option(names = "--config", paramLabel = "FILE", description = "the filename for external user config")
+  String externalUserConfig;
 
   /**
    * Option for specifying seed used for simulation.
@@ -246,8 +246,8 @@ class Main {
       System.exit(1);
     }
 
-    if (options.externalToolsConfig != null && !Files.exists(Path.of(options.externalToolsConfig))) {
-      System.err.println("Specified external tools configuration '" + options.externalToolsConfig + "' not found");
+    if (options.externalUserConfig != null && !Files.exists(Path.of(options.externalUserConfig))) {
+      System.err.println("Specified external user configuration '" + options.externalUserConfig + "' not found");
       System.exit(1);
     }
 
@@ -293,7 +293,7 @@ class Main {
       options.logName += ".log";
     }
 
-    var cfg = new Config(options.gui, options.randomSeed, options.externalToolsConfig,
+    var cfg = new Config(options.gui, options.randomSeed, options.externalUserConfig,
             options.logDir, options.contikiPath, options.coojaPath, options.javac);
     // Configure logger
     if (options.logConfigFile == null) {

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -246,11 +246,6 @@ class Main {
       System.exit(1);
     }
 
-    if (options.externalUserConfig != null && !Files.exists(Path.of(options.externalUserConfig))) {
-      System.err.println("Specified external user configuration '" + options.externalUserConfig + "' not found");
-      System.exit(1);
-    }
-
     if (options.contikiPath != null && !Files.exists(Path.of(options.contikiPath))) {
       System.err.println("Contiki-NG path '" + options.contikiPath + "' does not exist");
       System.exit(1);


### PR DESCRIPTION
The argument `--external_tools_config` specifies a configuration not only with user specified external tools, but also other user settings such as window location, file history, etc.