### PR TITLE
Add option to specify simulation files as positional parameters

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -2,11 +2,12 @@
 
 ## Cooja User Interface Changes
 
-### Deprecated `-nogui` parameter
+### Deprecated `-nogui` and `-quickstart` parameters
 
 Graphical/headless mode is now controlled by separate parameter (`--[no-]gui`),
-so `-nogui` has been deprecated. The old behavior for `-nogui=file.csc` is now
-accomplished with `--quickstart=file.csc --no-gui`.
+so `-nogui` and `-quickstart` have been deprecated. The old behavior for
+`-nogui=file.csc` is now accomplished with `--no-gui file.csc`, and
+`-quickstart=file.csc` is now accomplished with `file.csc`.
 
 ### Double dash before long command line options
 


### PR DESCRIPTION
There is no longer any need to specify `-nogui`/`-quickstart` for each simulation file as there is a separate argument to select between no GUI and GUI mode (`--[no-]gui`). The old arguments `-nogui`/`-quickstart` remain for backward compatibility.