### PR TITLE
Simulation: remove unused method

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -23,6 +23,12 @@ use a double dash for consistency.
 
 ## Cooja API changes for plugins outside the main tree
 
+### Removed getMoteType(String identifier) method in Simulation
+
+The mote type identifier is no longer exposed in the simulation files,
+so the method is no longer used by Cooja. The mote type can be accessed
+through a mote by calling the `getType()` method.
+
 ### Method updates in MoteTypeCreationException
 
 The `hasCompilationOutput` and `setCompilationOutput` methods were removed from

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -845,22 +845,6 @@ public final class Simulation extends Observable {
   }
 
   /**
-   * Returns mote type with given identifier.
-   *
-   * @param identifier
-   *          Mote type identifier
-   * @return Mote type or null if not found
-   */
-  public MoteType getMoteType(String identifier) {
-    for (MoteType moteType : getMoteTypes()) {
-      if (moteType.getIdentifier().equals(identifier)) {
-        return moteType;
-      }
-    }
-    return null;
-  }
-
-  /**
    * Adds given mote type to simulation.
    *
    * @param newMoteType Mote type


### PR DESCRIPTION
This method was used by setConfigXML
before the motetype_identifier was removed.

Code that needs to access the mote type
for a mote can do so with mote.getType().