### PR TITLE
Cooja: parse project config after GUI()

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -243,6 +243,16 @@ public class Cooja extends Observable {
 
     if (configuration.vis) {
       gui = new GUI(this);
+      // Allocate GUI before parsing project config, otherwise gui is null and
+      // gui.menuMotePluginClasses becomes empty.
+      gui.parseProjectConfig();
+      // Start all standard GUI plugins
+      for (var pluginClass : getRegisteredPlugins()) {
+        var pluginType = pluginClass.getAnnotation(PluginType.class).value();
+        if (pluginType == PluginType.PType.COOJA_STANDARD_PLUGIN) {
+          tryStartPlugin(pluginClass, null, null);
+        }
+      }
     } else {
       parseProjectConfig();
     }

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -195,17 +195,6 @@ public class GUI {
       });
     }
 
-    // Parse current extension configuration.
-    parseProjectConfig();
-
-    // Start all standard GUI plugins
-    for (var pluginClass : cooja.getRegisteredPlugins()) {
-      var pluginType = pluginClass.getAnnotation(PluginType.class).value();
-      if (pluginType == PluginType.PType.COOJA_STANDARD_PLUGIN) {
-        cooja.tryStartPlugin(pluginClass, null, null);
-      }
-    }
-
     frame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
 
     // Menu bar.
@@ -1050,7 +1039,7 @@ public class GUI {
     frame.setVisible(true);
   }
 
-  private void parseProjectConfig() {
+  void parseProjectConfig() {
     try {
       cooja.parseProjectConfig();
     } catch (Cooja.ParseProjectsException e) {


### PR DESCRIPTION
There are null checks on the containers inside
GUI, so ensure we have a gui before trying to use
the containers.