### PR TITLE
MoteTypeInformation: simplify implementation

### DIFF
--- a/java/org/contikios/cooja/plugins/MoteTypeInformation.java
+++ b/java/org/contikios/cooja/plugins/MoteTypeInformation.java
@@ -92,10 +92,7 @@ public class MoteTypeInformation extends VisPlugin {
 
     /* Mote types */
     for (MoteType moteType: simulation.getMoteTypes()) {
-      String moteTypeString =
-        Cooja.getDescriptionOf(moteType) +": " +
-        "ID=" + moteType.getIdentifier() +
-        ", \"" + moteType.getDescription() + "\"";
+      String moteTypeString = Cooja.getDescriptionOf(moteType) +": \"" + moteType.getDescription() + "\"";
 
       JComponent moteTypeVisualizer = moteType.getTypeVisualizer();
       if (moteTypeVisualizer == null) {

--- a/java/org/contikios/cooja/plugins/MoteTypeInformation.java
+++ b/java/org/contikios/cooja/plugins/MoteTypeInformation.java
@@ -30,7 +30,6 @@
 package org.contikios.cooja.plugins;
 
 import java.awt.BorderLayout;
-import java.util.Observable;
 import java.util.Observer;
 
 import javax.swing.BorderFactory;
@@ -63,32 +62,29 @@ public class MoteTypeInformation extends VisPlugin {
   public MoteTypeInformation(Simulation simulation, Cooja gui) {
     super("Mote Type Information", gui);
     this.simulation = simulation;
-    simulation.addObserver(simObserver = new Observer() {
-      @Override
-      public void update(Observable obs, Object obj) {
-        if (simulation.getMoteTypes().length == nrMotesTypes) {
-          return;
-        }
-        nrMotesTypes = simulation.getMoteTypes().length;
-        getContentPane().removeAll();
-        var box = Box.createVerticalBox();
-        box.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
-        for (var moteType : simulation.getMoteTypes()) {
-          var visualizer = moteType.getTypeVisualizer();
-          if (visualizer == null) {
-            visualizer = new JLabel("[no information available]");
-          }
-          visualizer.setAlignmentX(Box.LEFT_ALIGNMENT);
-          var moteTypeString = Cooja.getDescriptionOf(moteType) + ": \"" + moteType.getDescription() + "\"";
-          visualizer.setBorder(BorderFactory.createTitledBorder(moteTypeString));
-          box.add(visualizer);
-          box.add(Box.createVerticalStrut(15));
-        }
-        getContentPane().add(BorderLayout.CENTER,
-            new JScrollPane(box, JScrollPane.VERTICAL_SCROLLBAR_ALWAYS, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED));
-        revalidate();
-        repaint();
+    simulation.addObserver(simObserver = (obs, obj) -> {
+      if (simulation.getMoteTypes().length == nrMotesTypes) {
+        return;
       }
+      nrMotesTypes = simulation.getMoteTypes().length;
+      getContentPane().removeAll();
+      var box = Box.createVerticalBox();
+      box.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+      for (var moteType : simulation.getMoteTypes()) {
+        var visualizer = moteType.getTypeVisualizer();
+        if (visualizer == null) {
+          visualizer = new JLabel("[no information available]");
+        }
+        visualizer.setAlignmentX(Box.LEFT_ALIGNMENT);
+        var moteTypeString = Cooja.getDescriptionOf(moteType) + ": \"" + moteType.getDescription() + "\"";
+        visualizer.setBorder(BorderFactory.createTitledBorder(moteTypeString));
+        box.add(visualizer);
+        box.add(Box.createVerticalStrut(15));
+      }
+      getContentPane().add(BorderLayout.CENTER,
+          new JScrollPane(box, JScrollPane.VERTICAL_SCROLLBAR_ALWAYS, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED));
+      revalidate();
+      repaint();
     });
     simObserver.update(null, null);
     setSize(Math.min(getWidth(), 600), Math.min(getHeight(), 600));

--- a/java/org/contikios/cooja/plugins/MoteTypeInformation.java
+++ b/java/org/contikios/cooja/plugins/MoteTypeInformation.java
@@ -35,14 +35,11 @@ import java.util.Observer;
 
 import javax.swing.BorderFactory;
 import javax.swing.Box;
-import javax.swing.JComponent;
 import javax.swing.JLabel;
-import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
-import org.contikios.cooja.MoteType;
 import org.contikios.cooja.PluginType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.VisPlugin;
@@ -74,9 +71,21 @@ public class MoteTypeInformation extends VisPlugin {
         }
         nrMotesTypes = simulation.getMoteTypes().length;
         getContentPane().removeAll();
-        var panel = createPanel();
+        var box = Box.createVerticalBox();
+        box.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+        for (var moteType : simulation.getMoteTypes()) {
+          var visualizer = moteType.getTypeVisualizer();
+          if (visualizer == null) {
+            visualizer = new JLabel("[no information available]");
+          }
+          visualizer.setAlignmentX(Box.LEFT_ALIGNMENT);
+          var moteTypeString = Cooja.getDescriptionOf(moteType) + ": \"" + moteType.getDescription() + "\"";
+          visualizer.setBorder(BorderFactory.createTitledBorder(moteTypeString));
+          box.add(visualizer);
+          box.add(Box.createVerticalStrut(15));
+        }
         getContentPane().add(BorderLayout.CENTER,
-            new JScrollPane(panel, JScrollPane.VERTICAL_SCROLLBAR_ALWAYS, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED));
+            new JScrollPane(box, JScrollPane.VERTICAL_SCROLLBAR_ALWAYS, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED));
         revalidate();
         repaint();
       }
@@ -85,27 +94,6 @@ public class MoteTypeInformation extends VisPlugin {
     setSize(Math.min(getWidth(), 600), Math.min(getHeight(), 600));
     pack();
   }
-
-  private JComponent createPanel() {
-    Box box = Box.createVerticalBox();
-    box.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
-
-    /* Mote types */
-    for (MoteType moteType: simulation.getMoteTypes()) {
-      String moteTypeString = Cooja.getDescriptionOf(moteType) +": \"" + moteType.getDescription() + "\"";
-
-      JComponent moteTypeVisualizer = moteType.getTypeVisualizer();
-      if (moteTypeVisualizer == null) {
-        moteTypeVisualizer = new JLabel("[no information available]");
-      }
-      moteTypeVisualizer.setAlignmentX(Box.LEFT_ALIGNMENT);
-      moteTypeVisualizer.setBorder(BorderFactory.createTitledBorder(moteTypeString));
-      box.add(moteTypeVisualizer);
-      box.add(Box.createVerticalStrut(15));
-    }
-    return box;
-  }
-
 
   @Override
   public void closePlugin() {

--- a/java/org/contikios/cooja/plugins/MoteTypeInformation.java
+++ b/java/org/contikios/cooja/plugins/MoteTypeInformation.java
@@ -37,6 +37,7 @@ import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
+import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
 import org.contikios.cooja.ClassDescription;
@@ -56,7 +57,7 @@ import org.contikios.cooja.VisPlugin;
 public class MoteTypeInformation extends VisPlugin {
   private final Simulation simulation;
   private final Observer simObserver;
-  private int nrMotesTypes;
+  private int nrMotesTypes = 0;
 
   /**
    * @param simulation Simulation
@@ -65,31 +66,24 @@ public class MoteTypeInformation extends VisPlugin {
   public MoteTypeInformation(Simulation simulation, Cooja gui) {
     super("Mote Type Information", gui);
     this.simulation = simulation;
-
-    this.getContentPane().add(BorderLayout.CENTER,
-        new JScrollPane(createPanel(),
-        JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
-        JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED));
-    pack();
-    setSize(Math.min(getWidth(), 600), Math.min(getHeight(), 600));
-    nrMotesTypes = simulation.getMoteTypes().length;
-
     simulation.addObserver(simObserver = new Observer() {
       @Override
       public void update(Observable obs, Object obj) {
-        if (MoteTypeInformation.this.simulation.getMoteTypes().length == nrMotesTypes) {
+        if (simulation.getMoteTypes().length == nrMotesTypes) {
           return;
         }
-        nrMotesTypes = MoteTypeInformation.this.simulation.getMoteTypes().length;
-        MoteTypeInformation.this.getContentPane().removeAll();
-        MoteTypeInformation.this.getContentPane().add(BorderLayout.CENTER,
-            new JScrollPane(createPanel(),
-                JScrollPane.VERTICAL_SCROLLBAR_ALWAYS,
-                JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED));
+        nrMotesTypes = simulation.getMoteTypes().length;
+        getContentPane().removeAll();
+        var panel = createPanel();
+        getContentPane().add(BorderLayout.CENTER,
+            new JScrollPane(panel, JScrollPane.VERTICAL_SCROLLBAR_ALWAYS, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED));
         revalidate();
         repaint();
       }
     });
+    simObserver.update(null, null);
+    setSize(Math.min(getWidth(), 600), Math.min(getHeight(), 600));
+    pack();
   }
 
   private JComponent createPanel() {


### PR DESCRIPTION
Always use the observer for putting information in the content pane, and inline the single-use method inside the observer.