### PR TITLE
Use Path.of instead of Paths.get

### DIFF
--- a/java/org/contikios/cooja/LogScriptEngine.java
+++ b/java/org/contikios/cooja/LogScriptEngine.java
@@ -38,7 +38,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Observer;
 import java.util.concurrent.Semaphore;
@@ -125,7 +125,7 @@ public class LogScriptEngine {
     this.simulation = simulation;
     if (!Cooja.isVisualized()) {
       var logName = logNumber == 0 ? "COOJA.testlog" : String.format("COOJA-%02d.testlog", logNumber);
-      var logFile = Paths.get(simulation.getCfg().logDir(), logName);
+      var logFile = Path.of(simulation.getCfg().logDir(), logName);
       try {
         logWriter = Files.newBufferedWriter(logFile, UTF_8);
         logWriter.write("Random seed: " + simulation.getRandomSeed() + "\n");
@@ -337,7 +337,7 @@ public class LogScriptEngine {
     }
     @Override
     public void append(String filename, String msg) {
-      try (var out = Files.newBufferedWriter(Paths.get(filename), UTF_8, CREATE, APPEND)) {
+      try (var out = Files.newBufferedWriter(Path.of(filename), UTF_8, CREATE, APPEND)) {
         out.write(msg);
       } catch (Exception e) {
         logger.warn("Test append failed: " + filename + ": " + e.getMessage());
@@ -345,7 +345,7 @@ public class LogScriptEngine {
     }
     @Override
     public void writeFile(String filename, String msg) {
-      try (var out = Files.newBufferedWriter(Paths.get(filename), UTF_8)) {
+      try (var out = Files.newBufferedWriter(Path.of(filename), UTF_8)) {
         out.write(msg);
       } catch (Exception e) {
         logger.warn("Write file failed: " + filename + ": " + e.getMessage());

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -52,7 +52,6 @@ import java.io.File;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Contains the command line parameters and is the main entry point for Cooja.
@@ -267,7 +266,7 @@ class Main {
       try {
         /* Find path to Cooja installation directory from code base */
         URI domain_uri = Cooja.class.getProtectionDomain().getCodeSource().getLocation().toURI();
-        Path path = Paths.get(domain_uri).toAbsolutePath();
+        Path path = Path.of(domain_uri).toAbsolutePath();
         File fp = path.toFile();
         if (fp.isFile()) {
           // Get the directory where the JAR file is placed


### PR DESCRIPTION
The Javadoc recommends using Path.of instead
of Paths.get since it might be deprecated
in a future release.