### PR TITLE
Push Observable into leaf nodes

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -23,6 +23,13 @@ use a double dash for consistency.
 
 ## Cooja API changes for plugins outside the main tree
 
+### Converted MoteInterface/Beeper/Button/MoteID into interfaces
+
+To reduce the scope of the deprecated Observable, MoteInterface was converted
+from a class to an interface. This also forced Beeper, Button and MoteID
+to be made into interfaces. The abstract class Button was renamed to
+AbstractButton and resides inside the Button interface.
+
 ### Removed registerMote/unregisterMote in RadioMedium
 
 Use registerRadioInterface/unregisterRadioInterface instead.

--- a/java/org/contikios/cooja/MoteInterface.java
+++ b/java/org/contikios/cooja/MoteInterface.java
@@ -31,7 +31,6 @@
 package org.contikios.cooja;
 
 import java.util.Collection;
-import java.util.Observable;
 import javax.swing.JPanel;
 import org.jdom2.Element;
 
@@ -60,7 +59,7 @@ import org.contikios.cooja.interfaces.PolledBeforeAllTicks;
  *
  * @author Fredrik Osterlind
  */
-public abstract class MoteInterface extends Observable {
+public interface MoteInterface {
   /**
    * Returns a panel visualizing this interface. This could for
    * example show last messages sent/received for a radio interface, or logged
@@ -74,7 +73,7 @@ public abstract class MoteInterface extends Observable {
    * @see #releaseInterfaceVisualizer(JPanel)
    * @return Interface visualizer or null
    */
-  public abstract JPanel getInterfaceVisualizer();
+  JPanel getInterfaceVisualizer();
 
   /**
    * This method should be called when a visualizer panel is no longer in use.
@@ -86,7 +85,7 @@ public abstract class MoteInterface extends Observable {
    *          An interface visualizer panel fetched earlier for this mote
    *          interface.
    */
-  public abstract void releaseInterfaceVisualizer(JPanel panel);
+  void releaseInterfaceVisualizer(JPanel panel);
 
   /**
    * Returns XML elements representing the current config of this mote
@@ -99,7 +98,7 @@ public abstract class MoteInterface extends Observable {
    * @see #setConfigXML(Collection, boolean)
    * @return XML elements representing the current interface config
    */
-  public Collection<Element> getConfigXML() {
+  default Collection<Element> getConfigXML() {
     return null;
   }
 
@@ -112,20 +111,16 @@ public abstract class MoteInterface extends Observable {
    * @param visAvailable
    *          Is this object allowed to show a visualizer?
    */
-  public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
-  }
+  default void setConfigXML(Collection<Element> configXML, boolean visAvailable) {}
   
   /**
    * Called to free resources used by the mote interface.
    * This method is called when the mote is removed from the simulation.
    */
-  public void removed() {
-  }
+  default void removed() {}
   
   /**
    * Called when all mote interfaces have been added to mote.
    */
-  public void added() {
-  }
-
+  default void added() {}
 }

--- a/java/org/contikios/cooja/SimEventCentral.java
+++ b/java/org/contikios/cooja/SimEventCentral.java
@@ -123,8 +123,8 @@ public class SimEventCentral {
         if (logOutputListeners.length > 0) {
           // Add another log output observation (supports multiple log interfaces per mote).
           for (MoteInterface mi: evMote.getInterfaces().getInterfaces()) {
-            if (mi instanceof Log) {
-              moteObservations.add(new MoteObservation(evMote, mi, logOutputObserver));
+            if (mi instanceof Log log) {
+              moteObservations.add(new MoteObservation(evMote, log, logOutputObserver));
             }
           }
         }
@@ -229,8 +229,8 @@ public class SimEventCentral {
       Mote[] motes = simulation.getMotes();
       for (Mote m: motes) {
         for (MoteInterface mi: m.getInterfaces().getInterfaces()) {
-          if (mi instanceof Log) {
-            moteObservations.add(new MoteObservation(m, mi, logOutputObserver));
+          if (mi instanceof Log log) {
+            moteObservations.add(new MoteObservation(m, log, logOutputObserver));
           }
         }
       }

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiBeeper.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiBeeper.java
@@ -32,6 +32,7 @@ package org.contikios.cooja.contikimote.interfaces;
 
 import java.awt.Dimension;
 import java.awt.Toolkit;
+import java.util.Observable;
 import java.util.Observer;
 
 import javax.swing.BoxLayout;
@@ -59,7 +60,7 @@ import org.contikios.cooja.mote.memory.VarMemory;
  *
  * @author Fredrik Osterlind
  */
-public class ContikiBeeper extends Beeper implements PolledAfterActiveTicks {
+public class ContikiBeeper extends Observable implements Beeper, PolledAfterActiveTicks {
   private final Mote mote;
   private final VarMemory moteMem;
   private static final Logger logger = LogManager.getLogger(ContikiBeeper.class);

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiButton.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiButton.java
@@ -49,7 +49,7 @@ import org.contikios.cooja.mote.memory.VarMemory;
  *
  * @author Fredrik Osterlind
  */
-public class ContikiButton extends Button {
+public class ContikiButton extends Button.AbstractButton {
   private final VarMemory moteMem;
   private final ContikiMote mote;
 

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiCFS.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiCFS.java
@@ -35,6 +35,7 @@ import java.awt.Dimension;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.util.Observable;
 import java.util.Observer;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -66,7 +67,7 @@ import org.contikios.cooja.mote.memory.VarMemory;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Filesystem (CFS)")
-public class ContikiCFS extends MoteInterface implements PolledAfterActiveTicks {
+public class ContikiCFS extends Observable implements MoteInterface, PolledAfterActiveTicks {
   private static final Logger logger = LogManager.getLogger(ContikiCFS.class);
 
   public static final int FILESYSTEM_SIZE = 4000; /* Configure CFS size here and in cfs-cooja.c */

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiEEPROM.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiEEPROM.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Formatter;
+import java.util.Observable;
 import java.util.Observer;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -78,7 +79,7 @@ import org.contikios.cooja.mote.memory.VarMemory;
  * @author Claes Jakobsson (based on ContikiCFS by Fredrik Osterlind)
  */
 @ClassDescription("EEPROM")
-public class ContikiEEPROM extends MoteInterface implements PolledAfterActiveTicks {
+public class ContikiEEPROM extends Observable implements MoteInterface, PolledAfterActiveTicks {
   private static final Logger logger = LogManager.getLogger(ContikiEEPROM.class);
 
   public static final int EEPROM_SIZE = 1024; /* Configure EEPROM size here and in eeprom.c. Should really be multiple of 16 */

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiMoteID.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiMoteID.java
@@ -30,6 +30,7 @@
 
 package org.contikios.cooja.contikimote.interfaces;
 
+import java.util.Observable;
 import java.util.Observer;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -56,7 +57,7 @@ import org.contikios.cooja.mote.memory.VarMemory;
  *
  * @author Fredrik Osterlind
  */
-public class ContikiMoteID extends MoteID {
+public class ContikiMoteID extends Observable implements MoteID {
   private final VarMemory moteMem;
   private static final Logger logger = LogManager.getLogger(ContikiMoteID.class);
 

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiVib.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiVib.java
@@ -53,7 +53,7 @@ import org.contikios.cooja.mote.memory.VarMemory;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Vibration sensor")
-public class ContikiVib extends MoteInterface {
+public class ContikiVib implements MoteInterface {
 
   private final ContikiMote mote;
   private final VarMemory moteMem;

--- a/java/org/contikios/cooja/interfaces/Battery.java
+++ b/java/org/contikios/cooja/interfaces/Battery.java
@@ -47,7 +47,7 @@ import org.contikios.cooja.MoteInterface;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Battery")
-public class Battery extends MoteInterface {
+public class Battery implements MoteInterface {
   /**
    * @param mote Mote
    */

--- a/java/org/contikios/cooja/interfaces/Beeper.java
+++ b/java/org/contikios/cooja/interfaces/Beeper.java
@@ -41,10 +41,10 @@ import org.contikios.cooja.MoteInterface;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Beeper")
-public abstract class Beeper extends MoteInterface {
+public interface Beeper extends MoteInterface {
 
   /**
    * @return True if beeper is beeping
    */
-  public abstract boolean isBeeping();
+  boolean isBeeping();
 }

--- a/java/org/contikios/cooja/interfaces/Clock.java
+++ b/java/org/contikios/cooja/interfaces/Clock.java
@@ -56,7 +56,7 @@ import org.jdom2.Element;
  *         Andreas Löscher
  */
 @ClassDescription("Clock")
-public abstract class Clock extends MoteInterface {
+public abstract class Clock implements MoteInterface {
   /**
    * Set mote's time to given time.
    *

--- a/java/org/contikios/cooja/interfaces/IPAddress.java
+++ b/java/org/contikios/cooja/interfaces/IPAddress.java
@@ -32,6 +32,7 @@ package org.contikios.cooja.interfaces;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Observable;
 import java.util.Observer;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -53,7 +54,7 @@ import org.contikios.cooja.util.IPUtils;
  * @author Enrico Joerns
  */
 @ClassDescription("IP Addresses")
-public class IPAddress extends MoteInterface {
+public class IPAddress extends Observable implements MoteInterface {
 
   private static final Logger logger = LogManager.getLogger(IPAddress.class);
   private static final int IPv6_MAX_ADDRESSES = 4;
@@ -246,7 +247,6 @@ public class IPAddress extends MoteInterface {
 
   @Override
   public void removed() {
-    super.removed();
     if (memMonitor != null && ipVersion == IPv.IPv6) {
       moteMem.removeVarMonitor("uip_ds6_netif_addr_list_offset", memMonitor);
       moteMem.removeVarMonitor("uip_ds6_addr_size", memMonitor);

--- a/java/org/contikios/cooja/interfaces/LED.java
+++ b/java/org/contikios/cooja/interfaces/LED.java
@@ -30,6 +30,7 @@
 
 package org.contikios.cooja.interfaces;
 
+import java.util.Observable;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.MoteInterface;
 
@@ -40,7 +41,7 @@ import org.contikios.cooja.MoteInterface;
  * @author Fredrik Osterlind
  */
 @ClassDescription("LEDs")
-public abstract class LED extends MoteInterface {
+public abstract class LED extends Observable implements MoteInterface {
   
   /**
    * @return True if any LED is on, false otherwise

--- a/java/org/contikios/cooja/interfaces/Log.java
+++ b/java/org/contikios/cooja/interfaces/Log.java
@@ -30,6 +30,7 @@
 
 package org.contikios.cooja.interfaces;
 
+import java.util.Observable;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.MoteInterface;
 
@@ -40,7 +41,7 @@ import org.contikios.cooja.MoteInterface;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Log Output")
-public abstract class Log extends MoteInterface {
+public abstract class Log extends Observable implements MoteInterface {
 
   /**
    * @return Last log message. Note that several messages may appear during one tick.

--- a/java/org/contikios/cooja/interfaces/Mote2MoteRelations.java
+++ b/java/org/contikios/cooja/interfaces/Mote2MoteRelations.java
@@ -43,7 +43,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.ClassDescription;
-import org.contikios.cooja.Cooja;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.SimEventCentral.MoteCountListener;
@@ -73,7 +72,7 @@ import org.contikios.cooja.SimEventCentral.MoteCountListener;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Mote2Mote Relations")
-public class Mote2MoteRelations extends MoteInterface {
+public class Mote2MoteRelations extends Observable implements MoteInterface {
   private static final Logger logger = LogManager.getLogger(Mote2MoteRelations.class);
   private final Mote mote;
 
@@ -151,12 +150,10 @@ public class Mote2MoteRelations extends MoteInterface {
 
   @Override
   public void added() {
-    super.added();
-    
     /* Observe log interfaces */
     for (MoteInterface mi: mote.getInterfaces().getInterfaces()) {
-      if (mi instanceof Log) {
-        mi.addObserver(logObserver);
+      if (mi instanceof Log log) {
+        log.addObserver(logObserver);
       }
     }
 
@@ -184,12 +181,10 @@ public class Mote2MoteRelations extends MoteInterface {
   
   @Override
   public void removed() {
-    super.removed();
-
     /* Stop observing log interfaces */
     for (MoteInterface mi: mote.getInterfaces().getInterfaces()) {
-      if (mi instanceof Log) {
-        mi.deleteObserver(logObserver);
+      if (mi instanceof Log log) {
+        log.deleteObserver(logObserver);
       }
     }
     logObserver = null;

--- a/java/org/contikios/cooja/interfaces/MoteAttributes.java
+++ b/java/org/contikios/cooja/interfaces/MoteAttributes.java
@@ -32,6 +32,7 @@ package org.contikios.cooja.interfaces;
 
 import java.awt.BorderLayout;
 import java.util.HashMap;
+import java.util.Observable;
 import java.util.Observer;
 
 import javax.swing.JPanel;
@@ -75,7 +76,7 @@ import org.contikios.cooja.plugins.skins.AttributeVisualizerSkin;
  * @author Joakim Eriksson
  */
 @ClassDescription("Mote Attributes")
-public class MoteAttributes extends MoteInterface {
+public class MoteAttributes extends Observable implements MoteInterface {
   private static final Logger logger = LogManager.getLogger(MoteAttributes.class);
   private final Mote mote;
 
@@ -92,24 +93,20 @@ public class MoteAttributes extends MoteInterface {
 
   @Override
   public void added() {
-    super.added();
-
     /* Observe log interfaces */
     for (MoteInterface mi: mote.getInterfaces().getInterfaces()) {
-      if (mi instanceof Log) {
-        mi.addObserver(logObserver);
+      if (mi instanceof Log log) {
+        log.addObserver(logObserver);
       }
     }
   }
 
   @Override
   public void removed() {
-    super.removed();
-
     /* Stop observing log interfaces */
     for (MoteInterface mi: mote.getInterfaces().getInterfaces()) {
-      if (mi instanceof Log) {
-        mi.deleteObserver(logObserver);
+      if (mi instanceof Log log) {
+        log.deleteObserver(logObserver);
       }
     }
     logObserver = null;

--- a/java/org/contikios/cooja/interfaces/MoteID.java
+++ b/java/org/contikios/cooja/interfaces/MoteID.java
@@ -45,21 +45,20 @@ import org.contikios.cooja.MoteInterface;
  * @author Fredrik Osterlind
  */
 @ClassDescription("ID")
-public abstract class MoteID extends MoteInterface {
-
+public interface MoteID extends MoteInterface {
   /**
    * @return Current mote ID number
    */
-  public abstract int getMoteID();
+  int getMoteID();
   
   /**
    * Sets mote ID to given number.
    * @param id New mote ID number
    */
-  public abstract void setMoteID(int id);
+  void setMoteID(int id);
   
   @Override
-  public Collection<Element> getConfigXML() {
+  default Collection<Element> getConfigXML() {
     ArrayList<Element> config = new ArrayList<>();
     Element element = new Element("id");
     element.setText(Integer.toString(getMoteID()));
@@ -68,7 +67,7 @@ public abstract class MoteID extends MoteInterface {
   }
 
   @Override
-  public void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
+  default void setConfigXML(Collection<Element> configXML, boolean visAvailable) {
     for (Element element : configXML) {
       if (element.getName().equals("id")) {
         setMoteID(Integer.parseInt(element.getText()));

--- a/java/org/contikios/cooja/interfaces/PIR.java
+++ b/java/org/contikios/cooja/interfaces/PIR.java
@@ -40,7 +40,7 @@ import org.contikios.cooja.MoteInterface;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Passive IR")
-public abstract class PIR extends MoteInterface {
+public abstract class PIR implements MoteInterface {
 
   /**
    * Simulates a change in the PIR sensor.

--- a/java/org/contikios/cooja/interfaces/Position.java
+++ b/java/org/contikios/cooja/interfaces/Position.java
@@ -33,6 +33,7 @@ package org.contikios.cooja.interfaces;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Observable;
 import java.util.Observer;
 import javax.swing.BoxLayout;
 import javax.swing.JLabel;
@@ -53,7 +54,7 @@ import org.jdom2.Element;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Position")
-public class Position extends MoteInterface {
+public class Position extends Observable implements MoteInterface {
   private static final Logger logger = LogManager.getLogger(Position.class);
   private final Mote mote;
   private final double[] coords = new double[3];

--- a/java/org/contikios/cooja/interfaces/Radio.java
+++ b/java/org/contikios/cooja/interfaces/Radio.java
@@ -29,6 +29,7 @@
 package org.contikios.cooja.interfaces;
 
 import java.awt.BorderLayout;
+import java.util.Observable;
 import java.util.Observer;
 
 import javax.swing.Box;
@@ -55,7 +56,7 @@ import org.contikios.cooja.contikimote.interfaces.ContikiRadio;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Radio")
-public abstract class Radio extends MoteInterface {
+public abstract class Radio extends Observable implements MoteInterface {
   private static final Logger logger = LogManager.getLogger(Radio.class);
 
   /**

--- a/java/org/contikios/cooja/interfaces/RimeAddress.java
+++ b/java/org/contikios/cooja/interfaces/RimeAddress.java
@@ -30,6 +30,7 @@
 
 package org.contikios.cooja.interfaces;
 
+import java.util.Observable;
 import java.util.Observer;
 
 import javax.swing.JLabel;
@@ -52,7 +53,7 @@ import org.contikios.cooja.mote.memory.VarMemory;
  * @author Fredrik Osterlind
  */
 @ClassDescription("Rime address")
-public class RimeAddress extends MoteInterface {
+public class RimeAddress extends Observable implements MoteInterface {
   private static final Logger logger = LogManager.getLogger(RimeAddress.class);
   private final VarMemory moteMem;
 
@@ -123,7 +124,6 @@ public class RimeAddress extends MoteInterface {
 
   @Override
   public void removed() {
-    super.removed();
     if (memMonitor != null) {
       moteMem.removeVarMonitor("linkaddr_node_addr", memMonitor);
     }

--- a/java/org/contikios/cooja/motes/AbstractApplicationMoteType.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMoteType.java
@@ -191,7 +191,7 @@ public abstract class AbstractApplicationMoteType implements MoteType {
     return configureAndInit(Cooja.getTopParentContainer(), simulation, visAvailable);
   }
 
-  public static class SimpleMoteID extends MoteID {
+  public static class SimpleMoteID implements MoteID {
     private int id = -1;
     public SimpleMoteID(Mote mote) {
     }

--- a/java/org/contikios/cooja/mspmote/interfaces/MspButton.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/MspButton.java
@@ -37,7 +37,7 @@ import org.contikios.cooja.mspmote.MspMote;
  * @author Fredrik Osterlind, Niclas Finne
  */
 @ClassDescription("Button")
-public class MspButton extends Button {
+public class MspButton extends Button.AbstractButton {
     private final se.sics.mspsim.chip.Button button;
 
     public MspButton(Mote mote) {

--- a/java/org/contikios/cooja/mspmote/interfaces/MspMoteID.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/MspMoteID.java
@@ -29,6 +29,7 @@
  */
 
 package org.contikios.cooja.mspmote.interfaces;
+import java.util.Observable;
 import java.util.Observer;
 
 import javax.swing.JLabel;
@@ -49,7 +50,7 @@ import se.sics.mspsim.core.MemoryMonitor;
  *
  * @author Fredrik Osterlind
  */
-public class MspMoteID extends MoteID {
+public class MspMoteID extends Observable implements MoteID {
 	private static final Logger logger = LogManager.getLogger(MspMoteID.class);
 
 	private final MspMote mote;
@@ -189,7 +190,6 @@ public class MspMoteID extends MoteID {
 
 	@Override
 	public void removed() {
-	  super.removed();
 	  if (memoryMonitor != null) {
 	      removeMonitor("node_id", memoryMonitor);
 	      removeMonitor("TOS_NODE_ID", memoryMonitor);

--- a/java/org/contikios/cooja/mspmote/interfaces/SkyButton.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/SkyButton.java
@@ -36,7 +36,7 @@ import org.contikios.cooja.interfaces.Button;
 import org.contikios.cooja.mspmote.SkyMote;
 
 @ClassDescription("Button")
-public class SkyButton extends Button {
+public class SkyButton extends Button.AbstractButton {
   private final SkyMote skyMote;
 
   public SkyButton(Mote mote) {

--- a/java/org/contikios/cooja/mspmote/interfaces/SkyCoffeeFilesystem.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/SkyCoffeeFilesystem.java
@@ -65,7 +65,7 @@ import org.contikios.cooja.dialogs.TableColumnAdjuster;
  * @author Fredrik Osterlind, Nicolas Tsiftes
  */
 @ClassDescription("Coffee Filesystem")
-public class SkyCoffeeFilesystem extends MoteInterface {
+public class SkyCoffeeFilesystem implements MoteInterface {
   private static final Logger logger = LogManager.getLogger(SkyCoffeeFilesystem.class);
 
   private final Mote mote;

--- a/java/org/contikios/cooja/mspmote/interfaces/SkyFlash.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/SkyFlash.java
@@ -35,6 +35,7 @@ import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.util.Observable;
 import java.util.Observer;
 import javax.swing.JButton;
 import javax.swing.JFileChooser;
@@ -52,7 +53,7 @@ import org.contikios.cooja.mspmote.MspMote;
  * @author Fredrik Osterlind
  */
 @ClassDescription("M25P80 Flash")
-public class SkyFlash extends MoteInterface {
+public class SkyFlash extends Observable implements MoteInterface {
   private static final Logger logger = LogManager.getLogger(SkyFlash.class);
 
   protected final CoojaM25P80 m24p80;

--- a/java/org/contikios/cooja/mspmote/interfaces/SkyTemperature.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/SkyTemperature.java
@@ -38,7 +38,7 @@ import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.mspmote.SkyMote;
 
 @ClassDescription("Temperature")
-public class SkyTemperature extends MoteInterface {
+public class SkyTemperature implements MoteInterface {
 
   private final SkyMote skyMote;
 

--- a/java/org/contikios/cooja/plugins/EventListener.java
+++ b/java/org/contikios/cooja/plugins/EventListener.java
@@ -286,9 +286,8 @@ public class EventListener extends VisPlugin {
         for (int i = 0; i < mySimulation.getMotesCount(); i++) {
           MoteInterface moteInterface = mySimulation.getMote(i).getInterfaces()
               .getInterfaceOfType(interfaceClass);
-          if (moteInterface != null) {
-            allObservers.add(new InterfaceEventObserver(myPlugin, mySimulation
-                .getMote(i), moteInterface));
+          if (moteInterface instanceof Observable obs) {
+            allObservers.add(new InterfaceEventObserver(myPlugin, mySimulation.getMote(i), obs));
           }
         }
       }


### PR DESCRIPTION
Move the deprecated Observable from MoteInterface, which is the superclass of everything, closer
to the leaves of the class graph.

This makes it easier to remove the dependency
on Observable on a case-by-case basis.