### PR TITLE
AbstractApplicationMote: remove duplicate observer

### DIFF
--- a/java/org/contikios/cooja/motes/AbstractApplicationMote.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMote.java
@@ -130,8 +130,6 @@ public abstract class AbstractApplicationMote extends AbstractWakeupMote impleme
   @Override
   public boolean setConfigXML(Simulation simulation,
       Collection<Element> configXML, boolean visAvailable) {
-    moteInterfaces.getRadio().addObserver(radioDataObserver);
-
     for (Element element : configXML) {
       String name = element.getName();
       if (name.equals("interface_config")) {


### PR DESCRIPTION
The observer is already added in the constructor.