### PR TITLE
Cooja: use copy constructor instead of clone

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1072,7 +1072,7 @@ public class Cooja {
 
   /** Set the external tools settings to default. */
   public static void resetExternalToolsSettings() {
-    currentExternalToolsSettings = (Properties) defaultExternalToolsSettings.clone();
+    currentExternalToolsSettings = new Properties(defaultExternalToolsSettings);
   }
 
   /** Get default external tools settings. */


### PR DESCRIPTION
This avoids having to cast the result.