### PR TITLE
DGRMDestinationRadio: remove unused clone method

### DIFF
--- a/java/org/contikios/cooja/radiomediums/DGRMDestinationRadio.java
+++ b/java/org/contikios/cooja/radiomediums/DGRMDestinationRadio.java
@@ -53,17 +53,6 @@ public class DGRMDestinationRadio extends DestinationRadio {
 	}
 
 	@Override
-	protected Object clone() throws CloneNotSupportedException {
-		DGRMDestinationRadio clone = new DGRMDestinationRadio(this.radio);
-		clone.ratio = this.ratio;
-		clone.delay = this.delay;
-		clone.signal = this.signal;
-		clone.lqi = this.lqi;
-		clone.channel = this.channel;
-		return clone;
-	}
-	
-	@Override
 	public Collection<Element> getConfigXML() {
 		Collection<Element> config = super.getConfigXML();
 		Element element;


### PR DESCRIPTION
This removes IntelliJ warnings about the clone
method.