### PR TITLE
ChannelModel: use copy constructor

### DIFF
--- a/java/org/contikios/mrm/ChannelModel.java
+++ b/java/org/contikios/mrm/ChannelModel.java
@@ -229,7 +229,7 @@ public class ChannelModel {
       parameters.put(p, Parameter.getDefaultValue(p));
     }
 
-    parametersDefaults = (HashMap<Parameter,Object>) parameters.clone();
+    parametersDefaults = new HashMap<>(parameters);
 
     // Ray Tracer - Use scattering
     //parameters.put(Parameters.rt_use_scattering, Parameter.getDefaultValue(Parameters.rt_use_scattering)); // TODO Not used yet


### PR DESCRIPTION
This avoids the cast.