### PR TITLE
gradle: remove old resource dir

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ sourceSets {
       exclude 'org/contikios/cooja/corecomm/CoreCommTemplate.java'
     }
     resources {
-      srcDirs = [corecomm.resources, data.resources, 'config', 'images']
+      srcDirs = [corecomm.resources, data.resources, 'config']
     }
   }
 }


### PR DESCRIPTION
The directory was moved into config/
earlier.