### PR TITLE
MoteInformation: remove type information button

### DIFF
--- a/java/org/contikios/cooja/plugins/MoteInformation.java
+++ b/java/org/contikios/cooja/plugins/MoteInformation.java
@@ -95,6 +95,9 @@ public class MoteInformation extends VisPlugin implements MotePlugin {
     mainPane.add(smallPane);
 
     smallPane = new JPanel(new BorderLayout());
+    label = new JLabel("Mote type identifier");
+    label.setPreferredSize(size);
+    smallPane.add(BorderLayout.WEST, label);
     label = new JLabel(mote.getType().getIdentifier());
     label.setPreferredSize(size);
     smallPane.add(BorderLayout.EAST, label);

--- a/java/org/contikios/cooja/plugins/MoteInformation.java
+++ b/java/org/contikios/cooja/plugins/MoteInformation.java
@@ -78,7 +78,6 @@ public class MoteInformation extends VisPlugin implements MotePlugin {
     this.simulation = s;
 
     JLabel label;
-    JButton button;
     JPanel smallPane;
 
     JPanel mainPane = new JPanel();
@@ -101,13 +100,6 @@ public class MoteInformation extends VisPlugin implements MotePlugin {
     smallPane.add(BorderLayout.EAST, label);
     mainPane.add(smallPane);
 
-    smallPane = new JPanel(new BorderLayout());
-    button = new JButton("Mote type information");
-    button.setPreferredSize(size);
-    button.addActionListener(e -> simulation.getCooja().tryStartPlugin(MoteTypeInformation.class, simulation, mote));
-    smallPane.add(BorderLayout.EAST, button);
-    mainPane.add(smallPane);
-
     /* Mote interfaces */
     smallPane = new JPanel(new BorderLayout());
     label = new JLabel("Mote interfaces");
@@ -119,7 +111,7 @@ public class MoteInformation extends VisPlugin implements MotePlugin {
     mainPane.add(smallPane);
 
     smallPane = new JPanel(new BorderLayout());
-    button = new JButton("Mote interface viewer");
+    var button = new JButton("Mote interface viewer");
     button.setPreferredSize(size);
     button.addActionListener(e -> simulation.getCooja().tryStartPlugin(MoteInterfaceViewer.class, simulation, mote));
     smallPane.add(BorderLayout.EAST, button);


### PR DESCRIPTION
This decouples the MoteTypeInformation plugin in preparation for eliminating observers of Simulation.