### PR TITLE
SimEventCentral: remove mote count observer

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -737,7 +737,7 @@ public final class Simulation extends Observable {
     for (MoteInterface i: mote.getInterfaces().getInterfaces()) {
       i.removed();
     }
-
+    eventCentral.removeMote(mote);
     setChanged();
     notifyObservers(mote);
 
@@ -784,7 +784,7 @@ public final class Simulation extends Observable {
       for (MoteInterface i: mote.getInterfaces().getInterfaces()) {
         i.added();
       }
-
+      eventCentral.addMote(mote);
       setChanged();
       notifyObservers(mote);
       Cooja.updateGUIComponentState();


### PR DESCRIPTION
Simulation is the owner of the SimEventCentral object, so make a call to that instead of observing it.

Calling different methods when adding/removing motes eliminates the need to iterate over all motes to
figure out if the mote was added or removed.