### PR TITLE
Cooja: stop deselecting windows

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -783,9 +783,6 @@ public class Cooja {
 
           // Select plugin.
           try {
-            for (var existingPlugin : gui.myDesktopPane.getAllFrames()) {
-              existingPlugin.setSelected(false);
-            }
             pluginFrame.setSelected(true);
           } catch (Exception e) {
           }


### PR DESCRIPTION
Selecting a window will deselect the other
windows automatically.