### PR TITLE
Simulation: remove stop on shutdown

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -753,7 +753,6 @@ public final class Simulation extends Observable {
    */
   void removed() {
     deleteObservers();
-    stopSimulation(); // FIXME: check if this is required.
     if (!isShutdown) {
       commandQueue.add(Command.QUIT);
     }


### PR DESCRIPTION
The stop and quit commands are quite similar,
so doing stop before quit only introduces a delay
since it waits for the thread.