### PR TITLE
LogOutputListener: split in two interfaces

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -23,6 +23,11 @@ use a double dash for consistency.
 
 ## Cooja API changes for plugins outside the main tree
 
+### LogOutputListener interface no longer extends MoteCountListener
+
+Plugins that need to observe both logs and motes added/removed should
+install separate listeners for the two.
+
 ### RadioMedium converted to interface
 
 RadioMediums should now implement the interface instead of extending the class.

--- a/java/org/contikios/cooja/LogScriptEngine.java
+++ b/java/org/contikios/cooja/LogScriptEngine.java
@@ -74,12 +74,6 @@ public class LogScriptEngine {
 
   private final LogOutputListener logOutputListener = new LogOutputListener() {
     @Override
-    public void moteWasAdded(Mote mote) {
-    }
-    @Override
-    public void moteWasRemoved(Mote mote) {
-    }
-    @Override
     public void newLogOutput(LogOutputEvent ev) {
       if (scriptThread == null || !scriptThread.isAlive()) {
         logger.warn("No script thread, deactivate script.");

--- a/java/org/contikios/cooja/SimEventCentral.java
+++ b/java/org/contikios/cooja/SimEventCentral.java
@@ -152,7 +152,7 @@ public class SimEventCentral {
   /** Default buffer sizes. */
   private int logOutputBufferSize = Integer.parseInt(Cooja.getExternalToolsSetting("BUFFERSIZE_LOGOUTPUT", "" + 40000));
   private final ArrayDeque<LogOutputEvent> logOutputEvents = new ArrayDeque<>();
-  public interface LogOutputListener extends MoteCountListener {
+  public interface LogOutputListener {
     void removedLogOutput(LogOutputEvent ev);
     void newLogOutput(LogOutputEvent ev);
   }
@@ -208,12 +208,9 @@ public class SimEventCentral {
     }
 
     logOutputListeners = ArrayUtils.add(logOutputListeners, listener);
-    addMoteCountListener(listener);
   }
   public void removeLogOutputListener(LogOutputListener listener) {
     logOutputListeners = ArrayUtils.remove(logOutputListeners, listener);
-    removeMoteCountListener(listener);
-
     if (logOutputListeners.length == 0) {
       /* Stop observing all log interfaces */
       MoteObservation[] observations = moteObservations.toArray(new MoteObservation[0]);

--- a/java/org/contikios/cooja/plugins/LogListener.java
+++ b/java/org/contikios/cooja/plugins/LogListener.java
@@ -84,7 +84,6 @@ import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.HasQuickHelp;
-import org.contikios.cooja.Mote;
 import org.contikios.cooja.PluginType;
 import org.contikios.cooja.SimEventCentral.LogOutputEvent;
 import org.contikios.cooja.SimEventCentral.LogOutputListener;
@@ -571,12 +570,6 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
     /* Start observing motes for new log output */
     logUpdateAggregator.start();
     simulation.getEventCentral().addLogOutputListener(logOutputListener = new LogOutputListener() {
-      @Override
-      public void moteWasAdded(Mote mote) {
-      }
-      @Override
-      public void moteWasRemoved(Mote mote) {
-      }
       @Override
       public void newLogOutput(LogOutputEvent ev) {
         if (!hasHours && ev.getTime() > TIME_HOUR) {

--- a/java/org/contikios/cooja/plugins/TimeLine.java
+++ b/java/org/contikios/cooja/plugins/TimeLine.java
@@ -86,6 +86,7 @@ import org.contikios.cooja.Mote;
 import org.contikios.cooja.PluginType;
 import org.contikios.cooja.SimEventCentral.LogOutputEvent;
 import org.contikios.cooja.SimEventCentral.LogOutputListener;
+import org.contikios.cooja.SimEventCentral.MoteCountListener;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.VisPlugin;
 import org.contikios.cooja.Watchpoint;
@@ -131,6 +132,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
 
   private final Simulation simulation;
   private final LogOutputListener newMotesListener;
+  private final MoteCountListener moteCountListener;
   
   /* Experimental features: Use currently active plugin to filter Timeline Log outputs */
   private LogListener logEventFilterPlugin = null;
@@ -425,14 +427,6 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     // Automatically add/delete motes. This listener also observes mote log outputs.
     simulation.getEventCentral().addLogOutputListener(newMotesListener = new LogOutputListener() {
       @Override
-      public void moteWasAdded(Mote mote) {
-        addMote(mote);
-      }
-      @Override
-      public void moteWasRemoved(Mote mote) {
-        removeMote(mote);
-      }
-      @Override
       public void removedLogOutput(LogOutputEvent ev) {
       }
       @Override
@@ -448,6 +442,16 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
             break;
           }
         }
+      }
+    });
+    simulation.getEventCentral().addMoteCountListener(moteCountListener = new MoteCountListener() {
+      @Override
+      public void moteWasAdded(Mote mote) {
+        addMote(mote);
+      }
+      @Override
+      public void moteWasRemoved(Mote mote) {
+        removeMote(mote);
       }
     });
     for (Mote m: simulation.getMotes()) {
@@ -1112,7 +1116,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     if (moteHighlightObserver != null) {
       Cooja.deleteMoteHighlightObserver(moteHighlightObserver);
     }
-
+    simulation.getEventCentral().removeMoteCountListener(moteCountListener);
     simulation.getEventCentral().removeLogOutputListener(newMotesListener);
 
     /* Remove active mote interface observers */

--- a/java/org/contikios/cooja/plugins/skins/LogVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/LogVisualizerSkin.java
@@ -38,6 +38,7 @@ import java.awt.Point;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterface;
+import org.contikios.cooja.SimEventCentral.MoteCountListener;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.SimEventCentral.LogOutputEvent;
 import org.contikios.cooja.SimEventCentral.LogOutputListener;
@@ -60,14 +61,6 @@ public class LogVisualizerSkin implements VisualizerSkin {
 
   private final LogOutputListener logOutputListener = new LogOutputListener() {
     @Override
-    public void moteWasAdded(Mote mote) {
-      visualizer.repaint();
-    }
-    @Override
-    public void moteWasRemoved(Mote mote) {
-      visualizer.repaint();
-    }
-    @Override
     public void newLogOutput(LogOutputEvent ev) {
       visualizer.repaint();
     }
@@ -76,16 +69,28 @@ public class LogVisualizerSkin implements VisualizerSkin {
     }
   };
 
+  private final MoteCountListener moteCountListener = new MoteCountListener() {
+    @Override
+    public void moteWasAdded(Mote mote) {
+      visualizer.repaint();
+    }
+    @Override
+    public void moteWasRemoved(Mote mote) {
+      visualizer.repaint();
+    }
+  };
+
   @Override
   public void setActive(Simulation simulation, Visualizer vis) {
     this.simulation = simulation;
     this.visualizer = vis;
-
     simulation.getEventCentral().addLogOutputListener(logOutputListener);
+    simulation.getEventCentral().addMoteCountListener(moteCountListener);
   }
 
   @Override
   public void setInactive() {
+    simulation.getEventCentral().removeMoteCountListener(moteCountListener);
     simulation.getEventCentral().removeLogOutputListener(logOutputListener);
   }
 


### PR DESCRIPTION
Adding/removing motes, and motes logging things
are unrelated actions. Decouple the interfaces,
so plugins can focus on the relevant information.