### PR TITLE
AbstractRadioMedium: remove unused method

### DIFF
--- a/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
+++ b/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
@@ -551,14 +551,7 @@ public abstract class AbstractRadioMedium implements RadioMedium {
 	public void addRadioMediumObserver(Observer observer) {
 		radioMediumObservable.addObserver(observer);
 	}
-	
-	/**
-	 * @return the radioMediumObservable
-	 */
-	public Observable getRadioMediumObservable() {
-		return radioMediumObservable;
-	}
-	
+
 	public void deleteRadioMediumObserver(Observer observer) {
 		radioMediumObservable.deleteObserver(observer);
 	}


### PR DESCRIPTION
This prevents other objects from getting
direct access to the radio medium observable.

This is preparation for removing Observers/Observables.