### PR TITLE
MoteTypes: use Cooja.isVisualized

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -825,7 +825,7 @@ public class ContikiMoteType extends BaseContikiMoteType {
     if (getCompileCommands() == null) {
       throw new MoteTypeCreationException("No compile commands specified");
     }
-    return configureAndInit(Cooja.getTopParentContainer(), simulation, visAvailable);
+    return configureAndInit(Cooja.getTopParentContainer(), simulation, Cooja.isVisualized());
   }
 
   /**

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -271,7 +271,7 @@ public abstract class BaseContikiMoteType implements MoteType {
 
   @Override
   public boolean configureAndInit(Container top, Simulation sim, boolean vis) throws MoteTypeCreationException {
-    if (vis && !sim.isQuickSetup()) {
+    if (Cooja.isVisualized() && !sim.isQuickSetup()) {
       var currDesc = getDescription();
       var desc = currDesc == null ? getMoteName() + " Mote Type #" + (sim.getMoteTypes().length + 1) : currDesc;
       final var source = getContikiSourceFile();

--- a/java/org/contikios/cooja/motes/AbstractApplicationMoteType.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMoteType.java
@@ -182,8 +182,7 @@ public abstract class AbstractApplicationMoteType implements MoteType {
         description = element.getText();
       }
     }
-
-    return configureAndInit(Cooja.getTopParentContainer(), simulation, visAvailable);
+    return configureAndInit(Cooja.getTopParentContainer(), simulation, Cooja.isVisualized());
   }
 
   public static class SimpleMoteID implements MoteID {

--- a/java/org/contikios/cooja/motes/DisturberMoteType.java
+++ b/java/org/contikios/cooja/motes/DisturberMoteType.java
@@ -36,6 +36,7 @@ import java.awt.Container;
 import org.contikios.cooja.AbstractionLevelDescription;
 import org.contikios.cooja.COOJARadioPacket;
 import org.contikios.cooja.ClassDescription;
+import org.contikios.cooja.Cooja;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteTimeEvent;
 import org.contikios.cooja.MoteType;
@@ -64,7 +65,7 @@ public class DisturberMoteType extends AbstractApplicationMoteType {
   public boolean configureAndInit(Container parentContainer,
       Simulation simulation, boolean visAvailable) 
   throws MoteTypeCreationException {
-    if (!super.configureAndInit(parentContainer, simulation, visAvailable)) {
+    if (!super.configureAndInit(parentContainer, simulation, Cooja.isVisualized())) {
       return false;
     }
     setDescription("Disturber Mote Type #" + getIdentifier());

--- a/java/org/contikios/cooja/motes/ImportAppMoteType.java
+++ b/java/org/contikios/cooja/motes/ImportAppMoteType.java
@@ -102,19 +102,18 @@ public class ImportAppMoteType extends AbstractApplicationMoteType {
         moteClassPath = simulation.getCooja().restorePortablePath(new File(element.getText()));
       }
     }
-
-    return super.setConfigXML(simulation, configXML, visAvailable);
+    return super.setConfigXML(simulation, configXML, Cooja.isVisualized());
   }
 
   @Override
   public boolean configureAndInit(Container parentContainer,
       Simulation simulation, boolean visAvailable)
   throws MoteTypeCreationException {
-    if (!super.configureAndInit(parentContainer, simulation, visAvailable)) {
+    if (!super.configureAndInit(parentContainer, simulation, Cooja.isVisualized())) {
       return false;
     }
 
-    if (visAvailable) {
+    if (Cooja.isVisualized()) {
       /* Select mote class file */
       ImportAppMoteDialog dialog = new ImportAppMoteDialog(simulation.getCooja(), this);
       if (!dialog.waitForUserResponse()) {

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -131,7 +131,7 @@ public abstract class MspMoteType extends BaseContikiMoteType {
     if (getCompileCommands() == null) {
       throw new MoteTypeCreationException("No compile commands specified");
     }
-    return configureAndInit(Cooja.getTopParentContainer(), simulation, visAvailable);
+    return configureAndInit(Cooja.getTopParentContainer(), simulation, Cooja.isVisualized());
   }
 
   private ELF elf; /* cached */


### PR DESCRIPTION
The visAvailable parameter is not required,
but keep it around until the interfaces need
to be changed.