### PR TITLE
GUI: fix the abort button

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1384,6 +1384,7 @@ public class Cooja {
       // (SwingWorker communicates internally through SimulationCreationExceptions.)
       throw new SimulationCreationException("Unknown error", e);
     }
+    setSimulation(sim);
     return sim;
   }
 
@@ -1428,7 +1429,6 @@ public class Cooja {
     } catch (MoteTypeCreationException e) {
       throw new SimulationCreationException("Unknown error: " + e.getMessage(), e);
     }
-    setSimulation(sim);
     return sim;
   }
 


### PR DESCRIPTION
GUI: fix the abort button

Make the abort button in the progress dialog
work. This is accomplished by loading simulation
files in the background thread, but creating
the simulation in the AWT thread, and then
invokeLater to transfer the simulation back
to the background thread.
    
This is preparation for letting the user keep
the current simulation when loading a new simulation
fails.