### PR TITLE
Base BaseContikiMoteType on AbstractApplicationMoteType

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -186,6 +186,12 @@ public class ContikiMoteType extends BaseContikiMoteType {
   }
 
   @Override
+  public String getMoteTypeIdentifierPrefix() {
+    // The "mtype" prefix for ContikiMoteType is hardcoded elsewhere, so use that instead of "cooja".
+    return "mtype";
+  }
+
+  @Override
   public String getMoteName() {
     return "Cooja";
   }

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -177,7 +177,7 @@ public class ContikiMoteType extends BaseContikiMoteType {
    */
   public ContikiMoteType(Cooja gui) {
     this.gui = gui;
-    projectConfig = new ProjectConfig(gui.getProjectConfig());
+    myConfig = new ProjectConfig(gui.getProjectConfig());
   }
 
   @Override

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -42,7 +42,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.swing.Action;
@@ -55,27 +54,19 @@ import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.MoteInterfaceHandler;
-import org.contikios.cooja.MoteType;
-import org.contikios.cooja.ProjectConfig;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.dialogs.AbstractCompileDialog;
 import org.contikios.cooja.dialogs.MessageContainer;
 import org.contikios.cooja.dialogs.MessageList;
+import org.contikios.cooja.motes.AbstractApplicationMoteType;
 import org.contikios.cooja.util.StringUtils;
 import org.jdom2.Element;
 
 /**
  * The common parts of mote types based on compiled Contiki-NG targets.
  */
-public abstract class BaseContikiMoteType implements MoteType {
+public abstract class BaseContikiMoteType extends AbstractApplicationMoteType {
   private static final Logger logger = LogManager.getLogger(BaseContikiMoteType.class);
-  /** Description of the mote type. */
-  protected String description = null;
-  /** Identifier of the mote type. */
-  protected String identifier;
-
-  /** Project configuration of the mote type. */
-  protected ProjectConfig projectConfig = null;
   // FIXME: combine fileSource and fileFirmware so only one can be active.
   /** Source file of the mote type. */
   protected File fileSource = null;
@@ -87,24 +78,15 @@ public abstract class BaseContikiMoteType implements MoteType {
   /** MoteInterface classes used by the mote type. */
   protected final ArrayList<Class<? extends MoteInterface>> moteInterfaceClasses = new ArrayList<>();
 
-  /** Random generator for generating a unique mote ID. */
-  private static final Random rnd = new Random();
-
   protected BaseContikiMoteType() {
-    String testID = "";
-    boolean available = false;
-    while (!available) {
-      testID = getMoteTypeIdentifierPrefix() + rnd.nextInt(1000000000);
-      available = !Cooja.usedMoteTypeIDs.contains(testID);
-      // FIXME: add check that the library name is not already used.
-    }
-    identifier = testID;
+    super();
   }
 
   /** Returns file name extension for firmware. */
   public abstract String getMoteType();
 
   /** Returns the mote type identifier prefix. Should not be overridden, special case for ContikiMoteType. */
+  @Override
   public String getMoteTypeIdentifierPrefix() {
     return getMoteType();
   }
@@ -113,26 +95,6 @@ public abstract class BaseContikiMoteType implements MoteType {
   public abstract String getMoteName();
 
   protected abstract String getMoteImage();
-
-  @Override
-  public String getDescription() {
-    return description;
-  }
-
-  @Override
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public String getIdentifier() {
-    return identifier;
-  }
-
-  @Override
-  public ProjectConfig getConfig() {
-    return projectConfig;
-  }
 
   public File getContikiSourceFile() {
     return fileSource;

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -91,12 +91,10 @@ public abstract class BaseContikiMoteType implements MoteType {
   private static final Random rnd = new Random();
 
   protected BaseContikiMoteType() {
-    var namePrefix = getMoteType();
     String testID = "";
     boolean available = false;
     while (!available) {
-      // The "mtype" prefix for ContikiMoteType is hardcoded elsewhere, so use that instead of "cooja".
-      testID = ("cooja".equals(namePrefix) ? "mtype" : namePrefix) + rnd.nextInt(1000000000);
+      testID = getMoteTypeIdentifierPrefix() + rnd.nextInt(1000000000);
       available = !Cooja.usedMoteTypeIDs.contains(testID);
       // FIXME: add check that the library name is not already used.
     }
@@ -105,6 +103,11 @@ public abstract class BaseContikiMoteType implements MoteType {
 
   /** Returns file name extension for firmware. */
   public abstract String getMoteType();
+
+  /** Returns the mote type identifier prefix. Should not be overridden, special case for ContikiMoteType. */
+  public String getMoteTypeIdentifierPrefix() {
+    return getMoteType();
+  }
 
   /** Returns human-readable name for mote type. */
   public abstract String getMoteName();

--- a/java/org/contikios/cooja/motes/AbstractApplicationMoteType.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMoteType.java
@@ -30,7 +30,7 @@ package org.contikios.cooja.motes;
 import java.awt.Container;
 import java.util.ArrayList;
 import java.util.Collection;
-
+import java.util.Random;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -54,10 +54,13 @@ import org.contikios.cooja.interfaces.Position;
 
 @ClassDescription("Application Mote Type")
 public abstract class AbstractApplicationMoteType implements MoteType {
-  private final ProjectConfig myConfig = null;
+  /** Description of the mote type. */
+  protected String description = null;
+  /** Identifier of the mote type. */
+  protected String identifier;
 
-  private String identifier = null;
-  private String description = null;
+  /** Project configuration of the mote type. */
+  protected ProjectConfig myConfig = null;
 
   @SuppressWarnings("unchecked")
   private final Class<? extends MoteInterface>[] moteInterfaceClasses = new Class[] {
@@ -70,8 +73,19 @@ public abstract class AbstractApplicationMoteType implements MoteType {
       MoteAttributes.class
   };
 
+  /** Random generator for generating a unique mote ID. */
+  private static final Random rnd = new Random();
+
   public AbstractApplicationMoteType() {
     super();
+    String testID = "";
+    boolean available = false;
+    while (!available) {
+      testID = getMoteTypeIdentifierPrefix() + rnd.nextInt(1000000000);
+      available = !Cooja.usedMoteTypeIDs.contains(testID);
+      // FIXME: add check that the library name is not already used.
+    }
+    identifier = testID;
   }
 
   /** Returns the mote type identifier prefix. */
@@ -82,25 +96,6 @@ public abstract class AbstractApplicationMoteType implements MoteType {
   @Override
   public boolean configureAndInit(Container parentContainer, Simulation simulation, boolean visAvailable)
   throws MoteTypeCreationException {
-    if (identifier == null) {
-      /* Create unique identifier */
-      int counter = 0;
-      boolean identifierOK = false;
-      while (!identifierOK) {
-        counter++;
-        identifier = getMoteTypeIdentifierPrefix() + counter;
-        identifierOK = true;
-
-        // Check if identifier is already used by some other type
-        for (MoteType existingMoteType : simulation.getMoteTypes()) {
-          if (existingMoteType != this
-              && existingMoteType.getIdentifier().equals(identifier)) {
-            identifierOK = false;
-            break;
-          }
-        }
-      }
-    }
     if (description == null) {
       description = "Application Mote Type #" + identifier;
     }

--- a/java/org/contikios/cooja/motes/AbstractApplicationMoteType.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMoteType.java
@@ -74,6 +74,11 @@ public abstract class AbstractApplicationMoteType implements MoteType {
     super();
   }
 
+  /** Returns the mote type identifier prefix. */
+  public String getMoteTypeIdentifierPrefix() {
+    return "apptype";
+  }
+
   @Override
   public boolean configureAndInit(Container parentContainer, Simulation simulation, boolean visAvailable)
   throws MoteTypeCreationException {
@@ -83,7 +88,7 @@ public abstract class AbstractApplicationMoteType implements MoteType {
       boolean identifierOK = false;
       while (!identifierOK) {
         counter++;
-        identifier = "apptype" + counter;
+        identifier = getMoteTypeIdentifierPrefix() + counter;
         identifierOK = true;
 
         // Check if identifier is already used by some other type


### PR DESCRIPTION
This unifies the identifier allocation for all mote types in the tree.