### PR TITLE
Simulation: remove spurious check

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -864,12 +864,6 @@ public final class Simulation extends Observable {
    * @param type Mote type
    */
   public void removeMoteType(MoteType type) {
-    if (!moteTypes.contains(type)) {
-      logger.fatal("Mote type is not registered: " + type);
-      return;
-    }
-
-    /* Remove motes */
     for (Mote m: getMotes()) {
       if (m.getType() == type) {
         removeMote(m);


### PR DESCRIPTION
The other remove methods do not print
warnings, so remove this check and save
one full iteration of the container.