### PR TITLE
Add a typed Observable replacement

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -23,6 +23,13 @@ use a double dash for consistency.
 
 ## Cooja API changes for plugins outside the main tree
 
+### Removed addMoteRelationsObserver/deleteMoteRelationsObserver from Cooja
+
+Use `simulation.getMoteRelationsTriggers()` to get the object where triggers
+can be managed. The available methods are similar to the previous Observable
+interface, except an explicit owner is passed in (usually `this` in the caller):
+`addTrigger`/`removeTrigger`/`deleteTriggers`.
+
 ### Removed simulationFinishedLoading from RadioMedium interface
 
 Cooja now calls setConfigXML on the radio medium last, so the hook is

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1663,30 +1663,6 @@ public class Cooja {
   }
 
   /**
-   * Adds mote relation observer.
-   * Typically, used by visualizer plugins.
-   *
-   * @param newObserver Observer
-   */
-  public static void addMoteRelationsObserver(Observer newObserver) {
-    if (gui != null) {
-      gui.moteRelationObservable.addObserver(newObserver);
-    }
-  }
-
-  /**
-   * Removes mote relation observer.
-   * Typically, used by visualizer plugins.
-   *
-   * @param observer Observer
-   */
-  public static void deleteMoteRelationsObserver(Observer observer) {
-    if (gui != null) {
-      gui.moteRelationObservable.deleteObserver(observer);
-    }
-  }
-
-  /**
    * Tries to convert given file to be "portable".
    * The portable path is either relative to Contiki, or to the configuration (.csc) file.
    * The config relative path is preferred if the two paths are the same length, otherwise

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -134,14 +134,12 @@ public class GUI {
 
   final ScnObservable moteHighlightObservable;
 
-  final ScnObservable moteRelationObservable;
   private final Cooja cooja;
   boolean hasFileHistoryChanged;
 
   public GUI(Cooja cooja) {
     this.cooja = cooja;
     moteHighlightObservable = new ScnObservable();
-    moteRelationObservable = new ScnObservable();
     myDesktopPane = new JDesktopPane() {
       @Override
       public void setBounds(int x, int y, int w, int h) {

--- a/java/org/contikios/cooja/plugins/Visualizer.java
+++ b/java/org/contikios/cooja/plugins/Visualizer.java
@@ -201,7 +201,6 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
   private final Observer moteHighligtObserver;
   private final ArrayList<Mote> highlightedMotes = new ArrayList<>();
   private final static Color HIGHLIGHT_COLOR = Color.CYAN;
-  private final Observer moteRelationsObserver;
 
   /* Popup menu */
   public interface SimulationMenuAction {
@@ -481,7 +480,7 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
     });
 
     /* Observe mote relations */
-    Cooja.addMoteRelationsObserver(moteRelationsObserver = (obs, obj) -> repaint());
+    simulation.getMoteRelationsTriggers().addTrigger(this, (k, v) -> repaint());
 
     canvas.getInputMap().put(KeyStroke.getKeyStroke("ESCAPE"), "abort_action");
     canvas.getInputMap().put(KeyStroke.getKeyStroke("DELETE"), "delete_motes");
@@ -1383,9 +1382,7 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
     if (moteHighligtObserver != null) {
       Cooja.deleteMoteHighlightObserver(moteHighligtObserver);
     }
-    if (moteRelationsObserver != null) {
-      Cooja.deleteMoteRelationsObserver(moteRelationsObserver);
-    }
+    simulation.getMoteRelationsTriggers().deleteTriggers(this);
 
     simulation.getEventCentral().removeMoteCountListener(newMotesListener);
     for (Mote mote : simulation.getMotes()) {

--- a/java/org/contikios/cooja/util/EventTriggers.java
+++ b/java/org/contikios/cooja/util/EventTriggers.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.contikios.cooja.util;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.function.BiConsumer;
+
+/**
+ * Helper class that holds triggers. Triggers are called with a key for the kind
+ * of event that happened, and the data.
+ * @param <K> Key/event type
+ * @param <T> Data value
+ */
+public class EventTriggers<K, T> {
+  /** Utility enum that indicates something was added or removed. */
+  public enum AddRemove {ADD, REMOVE}
+  private final LinkedHashMap<Object, ArrayList<BiConsumer<K, T>>> triggers = new LinkedHashMap<>();
+
+  /**
+   * Add a trigger owned by an object.
+   */
+  public void addTrigger(Object owner, BiConsumer<K, T> observer) {
+    triggers.computeIfAbsent(owner, k -> new ArrayList<>()).add(observer);
+  }
+
+  /**
+   * Remove a trigger owned by an object.
+   */
+  public void removeTrigger(Object owner, BiConsumer<K, T> observer) {
+    var l = triggers.get(owner);
+    if (l == null) return;
+    l.remove(observer);
+    if (l.isEmpty()) {
+      triggers.remove(owner);
+    }
+  }
+
+  /**
+   * Delete all triggers belonging to an object.
+   */
+  public void deleteTriggers(Object owner) {
+    triggers.remove(owner);
+  }
+
+  /**
+   * Invoke all triggers with the key and value as parameters.
+   */
+  public void trigger(K key, T value) {
+    for (var observables : triggers.values()) {
+      observables.forEach(o -> o.accept(key, value));
+    }
+  }
+}


### PR DESCRIPTION
Replace the deprecated Observable with a typed replacement called EventTriggers. The replacement keeps track of the owner, so observers can easily remove all their triggers upon shutdown without needing to keep track of the triggers that were added.