### PR TITLE
RTC: prevent sign-extension on constant

### DIFF
--- a/java/se/sics/mspsim/core/RTC.java
+++ b/java/se/sics/mspsim/core/RTC.java
@@ -562,7 +562,7 @@ public class RTC extends IOUnit {
                                 parseCalReg(Calendar.SECOND, lo);
                                 parseCalReg(Calendar.MINUTE, hi);
                         } else {
-                                rtcCount &= 0xffff0000;
+                                rtcCount &= 0xffff0000L;
                                 rtcCount |= value;
                         }
                         break;


### PR DESCRIPTION
Use a long constant to avoid sign-extension.