### PR TITLE
Move info log from Simulation to Cooja

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1294,6 +1294,7 @@ public class Cooja {
     int rv = 0;
     boolean autoQuit = !simConfigs.isEmpty() && !config.vis;
     for (var simConfig : simConfigs) {
+      logger.info("Loading " + simConfig.file() + " random seed: " + config.randomSeed);
       Simulation sim = null;
       try {
         sim = config.vis
@@ -1304,6 +1305,7 @@ public class Cooja {
       }
       if (sim == null) {
         autoQuit = true;
+        logger.warn("TEST FAILED\n");
         rv = Math.max(rv, 1);
       } else if (simConfig.updateSim()) {
         autoQuit = true;

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -174,7 +174,6 @@ public final class Simulation extends Observable {
                     String radioMediumClass, long moteStartDelay, boolean quick, Element root)
           throws MoteType.MoteTypeCreationException, SimulationCreationException {
     this.cfg = cfg;
-    logger.info("Simulation " + (cfg.file == null ? "(unnamed)" : cfg.file) + " random seed: " + seed);
     this.cooja = cooja;
     this.title = title;
     randomSeed = seed;


### PR DESCRIPTION
The message was printed first in the constructor
so it would be possible to pinpoint errors based
on the CI logs.

Move the message to the main loop instead, so creating a new simulation doesn't cause printouts to the console.