### PR TITLE
Move stop exception into Simulation

### DIFF
--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -43,7 +43,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.Cooja.PluginConstructionException;
 import org.contikios.cooja.Cooja.SimulationCreationException;
-import org.contikios.cooja.mspmote.MspMote.MSPSimStop;
 import org.jdom2.Element;
 
 /**
@@ -216,8 +215,8 @@ public final class Simulation extends Observable {
               nextEvent.event.execute(currentSimulationTime);
             }
           }
-        } catch (MSPSimStop e) {
-          logger.info("Simulation stopped due to MSPSim breakpoint");
+        } catch (SimulationStop e) {
+          logger.info("Simulation stopped: {}", e.getMessage());
         } catch (RuntimeException e) {
           logger.fatal("Simulation stopped due to error: " + e.getMessage(), e);
           if (Cooja.isVisualized()) {
@@ -1022,6 +1021,13 @@ public final class Simulation extends Observable {
   /** Returns the simulation configuration. */
   public SimConfig getCfg() {
     return cfg;
+  }
+
+  /** Exception for signaling the simulation that an emulator has stopped. */
+  public static class SimulationStop extends RuntimeException {
+    public SimulationStop(String emulator, String reason) {
+      super(emulator + " requested simulation stop for " + reason);
+    }
   }
 
   /** Structure to hold the simulation parameters. */

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.contikios.cooja.Simulation.SimulationStop;
 import org.jdom2.Element;
 import org.contikios.cooja.ContikiError;
 import org.contikios.cooja.Cooja;
@@ -261,7 +262,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     if (stopNextInstruction) {
       stopNextInstruction = false;
       scheduleNextWakeup(t);
-      throw new MSPSimStop();
+      throw new SimulationStop("MSPSim", "breakpoint");
     }
 
     if (lastExecute < 0) {
@@ -282,7 +283,7 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
 
     if (stopNextInstruction) {
       stopNextInstruction = false;
-      throw new MSPSimStop();
+      throw new SimulationStop("MSPSim", "breakpoint");
     }
 
     // TODO: Reimplement stack monitoring using MSPSim internals.
@@ -620,12 +621,5 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
     }
 
     return config;
-  }
-
-  /** Exception for signaling the simulation that MSPSim has stopped. */
-  public static class MSPSimStop extends RuntimeException {
-    public MSPSimStop() {
-      super("MSPSim requested simulation stop");
-    }
   }
 }


### PR DESCRIPTION
This exception type can be used by other
emulators to stop the simulation, so
generalize it slightly and move it
to Simulation.