### PR TITLE
Do not sort --help output

### DIFF
--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -59,7 +59,7 @@ import java.nio.file.Path;
 @Command(version = {
         "Cooja " + Cooja.VERSION + ", Contiki-NG build interface version " + Cooja.CONTIKI_NG_BUILD_VERSION,
         "JVM: ${java.version} (${java.vendor} ${java.vm.name} ${java.vm.version})",
-        "OS: ${os.name} ${os.version} ${os.arch}"})
+        "OS: ${os.name} ${os.version} ${os.arch}"}, sortOptions = false, sortSynopsis = false)
 class Main {
   /**
    * Option for specifying if a GUI should be used.


### PR DESCRIPTION
Print the options in the order they are declared.

This is preparation for grouping the parameters
based on general category (Cooja options such as
--javac, simulation options such as --logdir/--autostart, and the rest such as --help and --version).