### PR TITLE
ChannelModel: fix RX gain

### DIFF
--- a/java/org/contikios/mrm/ChannelModel.java
+++ b/java/org/contikios/mrm/ChannelModel.java
@@ -1860,7 +1860,7 @@ public class ChannelModel {
       if (!(getToRadio() instanceof DirectionalAntennaRadio)) {
         return 0;
       }
-      DirectionalAntennaRadio r = (DirectionalAntennaRadio)getFromRadio();
+      DirectionalAntennaRadio r = (DirectionalAntennaRadio)getToRadio();
       return r.getRelativeGain(r.getDirection() + getAngle() + Math.PI, getDistance());
     }
   }


### PR DESCRIPTION
The method getToRadio returns the receiver
in the implementations, so use that when
calculating the RX gain.