### PR TITLE
MoteInterfaceHandler: add getConfigXML/setConfigXML methods

### DIFF
--- a/java/org/contikios/cooja/MoteInterfaceHandler.java
+++ b/java/org/contikios/cooja/MoteInterfaceHandler.java
@@ -84,6 +84,7 @@ import org.contikios.cooja.radiomediums.SilentRadioMedium;
 import org.contikios.cooja.radiomediums.UDGM;
 import org.contikios.cooja.radiomediums.UDGMConstantLoss;
 import org.contikios.mrm.MRM;
+import org.jdom2.Element;
 
 /**
  * The mote interface handler holds all interfaces for a specific mote.
@@ -418,6 +419,37 @@ public class MoteInterfaceHandler {
   public Collection<MoteInterface> getInterfaces() {
     return moteInterfaces;
   }
+
+  public Collection<Element> getConfigXML() {
+    var config = new ArrayList<Element>();
+    for (var moteInterface: moteInterfaces) {
+      var element = new Element("interface_config");
+      element.setText(moteInterface.getClass().getName());
+      var interfaceXML = moteInterface.getConfigXML();
+      if (interfaceXML != null) {
+        element.addContent(interfaceXML);
+        config.add(element);
+      }
+    }
+    return config;
+  }
+
+  public boolean setConfigXML(Simulation sim, Element element, Object caller) {
+    var clazz = element.getText().trim();
+    var moteInterfaceClass = getInterfaceClass(sim.getCooja(), caller, clazz);
+    if (moteInterfaceClass == null) {
+      logger.warn("Cannot find mote interface class: " + clazz);
+      return false;
+    }
+    var moteInterface = getInterfaceOfType(moteInterfaceClass);
+    if (moteInterface == null) {
+      logger.fatal("Cannot find mote interface of class: " + moteInterfaceClass);
+      return false;
+    }
+    moteInterface.setConfigXML(element.getChildren(), Cooja.isVisualized());
+    return true;
+  }
+
 
   @Override
   public String toString() {

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -45,7 +45,6 @@ import org.jdom2.Element;
 import org.contikios.cooja.ContikiError;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.Mote;
-import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
@@ -368,22 +367,11 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
           }
         }
       } else if (name.equals("interface_config")) {
-        String intfClass = element.getText().trim();
-        var moteInterfaceClass = MoteInterfaceHandler.getInterfaceClass(simulation.getCooja(), this, intfClass);
-        if (moteInterfaceClass == null) {
-          logger.fatal("Could not load mote interface class: " + intfClass);
+        if (!getInterfaces().setConfigXML(simulation, element, this)) {
           return false;
         }
-
-        MoteInterface moteInterface = getInterfaces().getInterfaceOfType(moteInterfaceClass);
-        if (moteInterface == null) {
-            logger.fatal("Could not find mote interface of class: " + moteInterfaceClass);
-            return false;
-        }
-        moteInterface.setConfigXML(element.getChildren(), visAvailable);
       }
     }
-
     /* Schedule us immediately */
     requestImmediateWakeup();
     return true;
@@ -401,18 +389,8 @@ public abstract class MspMote extends AbstractEmulatedMote implements Mote, Watc
       config.add(element);
     }
 
-    // Mote interfaces
-    for (MoteInterface moteInterface: getInterfaces().getInterfaces()) {
-      var element = new Element("interface_config");
-      element.setText(moteInterface.getClass().getName());
-
-      Collection<Element> interfaceXML = moteInterface.getConfigXML();
-      if (interfaceXML != null) {
-        element.addContent(interfaceXML);
-        config.add(element);
-      }
-    }
-
+    // Mote interfaces.
+    config.addAll(getInterfaces().getConfigXML());
     return config;
   }
 


### PR DESCRIPTION
Put the getConfigXML/setConfigXML methods in
MoteInterfaceHandler instead of having the same
code in every mote implementation.

This is tested by running --update-simulation on
07-simulation-base, and the simulation files are
unchanged.