### PR TITLE
Move CreateSimDialog call to GUI

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -61,7 +61,6 @@ import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.MoteType.MoteTypeCreationException;
 import org.contikios.cooja.VisPlugin.PluginRequiresVisualizationException;
 import org.contikios.cooja.contikimote.ContikiMoteType;
-import org.contikios.cooja.dialogs.CreateSimDialog;
 import org.contikios.cooja.dialogs.MessageListUI;
 import org.contikios.cooja.motes.DisturberMoteType;
 import org.contikios.cooja.motes.ImportAppMoteType;
@@ -1408,16 +1407,6 @@ public class Cooja {
     long delay = cfgDelay == null
             ? Integer.parseInt(simCfg.getChild("motedelay_us").getText())
             : Integer.parseInt(cfgDelay.getText()) * Simulation.MILLISECOND;
-    if (Cooja.isVisualized() && !quick) {
-      var config = CreateSimDialog.showDialog(this, new CreateSimDialog.SimConfig(title, medium,
-              generatedSeed, seed, delay));
-      if (config == null) return null;
-      title = config.title();
-      generatedSeed = config.generatedSeed();
-      seed = config.randomSeed();
-      medium = config.radioMedium();
-      delay = config.moteStartDelay();
-    }
     doRemoveSimulation();
     System.gc();
     Simulation sim;

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -1364,16 +1364,21 @@ public class GUI {
     var worker = new SwingWorker<Simulation, Cooja.SimulationCreationException>() {
       @Override
       public Simulation doInBackground() {
-        Element root = configFile == null ? cooja.extractSimulationConfig() : null;
+        Element root;
+        try {
+          root = configFile == null ? cooja.extractSimulationConfig() : cooja.readSimulationConfig(cfg);
+        } catch (Exception e) {
+          Cooja.showErrorDialog("Config file read error", e, false);
+          return null;
+        }
         boolean shouldRetry;
         Simulation newSim = null;
+        var config = configFile == null ? cooja.getSimulation().getCfg() : cfg;
         do {
           try {
             shouldRetry = false;
             PROGRESS_WARNINGS.clear();
-            newSim = configFile == null
-                    ? cooja.createSimulation(cooja.getSimulation().getCfg(), root, quick, manualRandomSeed)
-                    : cooja.loadSimulationConfig(cfg, quick, manualRandomSeed);
+            newSim = cooja.createSimulation(config, root, quick, manualRandomSeed);
             if (newSim != null && autoStart) {
               newSim.startSimulation();
             }


### PR DESCRIPTION
This moves the dialog invocation from createSimulation into
GUI. The logic is clunky, but it removes GUI handling from
Cooja so it is a step in the right direction.