### PR TITLE
Visualizer: work around race condition

### DIFF
--- a/java/org/contikios/cooja/plugins/Visualizer.java
+++ b/java/org/contikios/cooja/plugins/Visualizer.java
@@ -229,6 +229,9 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
 
     /* Register external visualizers */
     registerVisualizerSkin(DGRMVisualizerSkin.class);
+    registerVisualizerSkin(LogisticLossVisualizerSkin.class);
+    registerVisualizerSkin(MRMVisualizerSkin.class);
+    registerVisualizerSkin(UDGMVisualizerSkin.class);
     String[] skins = gui.getProjectConfig().getStringArrayValue(Visualizer.class, "SKINS");
 
     for (String skinClass : skins) {

--- a/java/org/contikios/cooja/radiomediums/LogisticLoss.java
+++ b/java/org/contikios/cooja/radiomediums/LogisticLoss.java
@@ -35,15 +35,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 import java.util.Map;
-import org.contikios.cooja.Cooja;
 import org.jdom2.Element;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.RadioConnection;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.Radio;
-import org.contikios.cooja.plugins.Visualizer;
-import org.contikios.cooja.plugins.skins.LogisticLossVisualizerSkin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -204,10 +201,6 @@ public class LogisticLoss extends AbstractRadioMedium {
         simulation.getMoteTriggers().addTrigger(this, (o, m) -> dgrm.requestEdgeAnalysis());
 
         dgrm.requestEdgeAnalysis();
-
-        if (Cooja.isVisualized()) {
-            Visualizer.registerVisualizerSkin(LogisticLossVisualizerSkin.class);
-        }
     }
 
     @Override
@@ -215,14 +208,6 @@ public class LogisticLoss extends AbstractRadioMedium {
         return dgrm.getNeighbors(radio);
     }
 
-    @Override
-    public void removed() {
-        super.removed();
-        if (Cooja.isVisualized()) {
-            Visualizer.unregisterVisualizerSkin(LogisticLossVisualizerSkin.class);
-        }
-    }
-  
     @Override
     protected RadioConnection createConnections(Radio sender) {
         RadioConnection newConnection = new RadioConnection(sender);

--- a/java/org/contikios/cooja/radiomediums/UDGM.java
+++ b/java/org/contikios/cooja/radiomediums/UDGM.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
-import org.contikios.cooja.Cooja;
 import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
@@ -42,7 +41,6 @@ import org.contikios.cooja.RadioConnection;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.Radio;
-import org.contikios.cooja.plugins.Visualizer;
 import org.contikios.cooja.plugins.skins.UDGMVisualizerSkin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -126,10 +124,6 @@ public class UDGM extends AbstractRadioMedium {
     simulation.getMoteTriggers().addTrigger(this, (o, m) -> dgrm.requestEdgeAnalysis());
 
     dgrm.requestEdgeAnalysis();
-
-    if (Cooja.isVisualized()) {
-      Visualizer.registerVisualizerSkin(UDGMVisualizerSkin.class);
-    }
   }
 
   @Override
@@ -150,15 +144,6 @@ public class UDGM extends AbstractRadioMedium {
     return list;
   }
 
-  @Override
-  public void removed() {
-  	super.removed();
-
-    if (Cooja.isVisualized()) {
-      Visualizer.unregisterVisualizerSkin(UDGMVisualizerSkin.class);
-    }
-  }
-  
   public void setTxRange(double r) {
     TRANSMITTING_RANGE = r;
     dgrm.requestEdgeAnalysis();

--- a/java/org/contikios/mrm/MRM.java
+++ b/java/org/contikios/mrm/MRM.java
@@ -44,7 +44,6 @@ import org.contikios.cooja.interfaces.DirectionalAntennaRadio;
 import org.contikios.cooja.interfaces.NoiseSourceRadio;
 import org.contikios.cooja.interfaces.NoiseSourceRadio.NoiseLevelListener;
 import org.contikios.cooja.interfaces.Radio;
-import org.contikios.cooja.plugins.Visualizer;
 import org.contikios.cooja.radiomediums.AbstractRadioMedium;
 import org.contikios.mrm.ChannelModel.Parameter;
 import org.contikios.mrm.ChannelModel.RadioPair;
@@ -106,7 +105,6 @@ public class MRM extends AbstractRadioMedium {
     if (Cooja.isVisualized()) {
       simulation.getCooja().registerPlugin(AreaViewer.class);
       simulation.getCooja().registerPlugin(FormulaViewer.class);
-      Visualizer.registerVisualizerSkin(MRMVisualizerSkin.class);
     }
   }
 
@@ -117,7 +115,6 @@ public class MRM extends AbstractRadioMedium {
     if (Cooja.isVisualized()) {
       simulation.getCooja().unregisterPlugin(AreaViewer.class);
       simulation.getCooja().unregisterPlugin(FormulaViewer.class);
-      Visualizer.unregisterVisualizerSkin(MRMVisualizerSkin.class);
     }
     currentChannelModel.getSettingsTriggers().deleteTriggers(this);
   }


### PR DESCRIPTION
The last thing the simulation thread does
is call radioMedium.removed(), and some
radio mediums will call
Visualizer.unregisterVisualizerSkin to
unregister the skin they have registered.
If Cooja is loading a new simulation while
this is happening, the new simulation might
fail to load its visualizer skin because
the old simulation removed the skin midway
through the load of the new simulation.

There is no way to get a handle of the current
visualizer, so just move the registration to
inside the Visualizer constructor to avoid
the issue for now.

Long term, skins should have a way to register
themselves without having to call static
methods in the Visualizer.