### PR TITLE
GUI: hide incompatible plugins in tools menu

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -823,30 +823,6 @@ public class Cooja {
     return l.toArray(new Plugin[0]);
   }
 
-  static boolean isMoteCompatible(SupportedArguments supportedArgs, Mote mote) {
-    if (supportedArgs == null) {
-      return true;
-    }
-
-    /* Check mote interfaces */
-    final var moteInterfaces = mote.getInterfaces();
-    for (Class<? extends MoteInterface> requiredMoteInterface: supportedArgs.moteInterfaces()) {
-      if (moteInterfaces.getInterfaceOfType(requiredMoteInterface) == null) {
-        return false;
-      }
-    }
-
-    /* Check mote type */
-    final var clazz = mote.getClass();
-    for (Class<? extends Mote> supportedMote: supportedArgs.motes()) {
-      if (supportedMote.isAssignableFrom(clazz)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
   public static JMenu createMotePluginsSubmenu(Class<? extends Plugin> pluginClass) {
     return gui.createMotePluginsSubmenu(pluginClass);
   }

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -823,8 +823,7 @@ public class Cooja {
     return l.toArray(new Plugin[0]);
   }
 
-  static boolean isMotePluginCompatible(Class<? extends Plugin> motePluginClass, Mote mote) {
-    var supportedArgs = motePluginClass.getAnnotation(SupportedArguments.class);
+  static boolean isMoteCompatible(SupportedArguments supportedArgs, Mote mote) {
     if (supportedArgs == null) {
       return true;
     }

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -1190,7 +1190,7 @@ public class GUI {
 
     int added = 0;
     for (var mote : cooja.getSimulation().getMotes()) {
-      if (!Cooja.isMotePluginCompatible(pluginClass, mote)) {
+      if (!Cooja.isMoteCompatible(pluginClass.getAnnotation(SupportedArguments.class), mote)) {
         continue;
       }
       JMenuItem menuItem = new JMenuItem(mote.toString() + "...");
@@ -1215,7 +1215,7 @@ public class GUI {
   public JMenu createMotePluginsSubmenu(Mote mote) {
     JMenu menuMotePlugins = new JMenu("Mote tools for " + mote);
     for (var motePluginClass: menuMotePluginClasses) {
-      if (!Cooja.isMotePluginCompatible(motePluginClass, mote)) {
+      if (!Cooja.isMoteCompatible(motePluginClass.getAnnotation(SupportedArguments.class), mote)) {
         continue;
       }
       var menuItem = new JMenuItem(new StartPluginGUIAction(Cooja.getDescriptionOf(motePluginClass) + "..."));

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -934,11 +934,15 @@ public class GUI {
         }
 
         // Simulation plugins.
+        var radioMedium = cooja.getSimulation() == null ? null : cooja.getSimulation().getRadioMedium();
         boolean hasSimPlugins = false;
         for (Class<? extends Plugin> pluginClass : cooja.getRegisteredPlugins()) {
           var pluginType = pluginClass.getAnnotation(PluginType.class).value();
           if (pluginType != PluginType.PType.SIM_PLUGIN && pluginType != PluginType.PType.SIM_STANDARD_PLUGIN
                   && pluginType != PluginType.PType.SIM_CONTROL_PLUGIN) {
+            continue;
+          }
+          if (!Annotations.isCompatible(pluginClass.getAnnotation(SupportedArguments.class), radioMedium)) {
             continue;
           }
 

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -110,6 +110,7 @@ import org.contikios.cooja.dialogs.MessageListUI;
 import org.contikios.cooja.dialogs.ProjectDirectoriesDialog;
 import org.contikios.cooja.interfaces.MoteID;
 import org.contikios.cooja.interfaces.Position;
+import org.contikios.cooja.util.Annotations;
 import org.jdom2.Element;
 import org.jdom2.Text;
 
@@ -1190,7 +1191,7 @@ public class GUI {
 
     int added = 0;
     for (var mote : cooja.getSimulation().getMotes()) {
-      if (!Cooja.isMoteCompatible(pluginClass.getAnnotation(SupportedArguments.class), mote)) {
+      if (!Annotations.isCompatible(pluginClass.getAnnotation(SupportedArguments.class), mote)) {
         continue;
       }
       JMenuItem menuItem = new JMenuItem(mote.toString() + "...");
@@ -1215,7 +1216,7 @@ public class GUI {
   public JMenu createMotePluginsSubmenu(Mote mote) {
     JMenu menuMotePlugins = new JMenu("Mote tools for " + mote);
     for (var motePluginClass: menuMotePluginClasses) {
-      if (!Cooja.isMoteCompatible(motePluginClass.getAnnotation(SupportedArguments.class), mote)) {
+      if (!Annotations.isCompatible(motePluginClass.getAnnotation(SupportedArguments.class), mote)) {
         continue;
       }
       var menuItem = new JMenuItem(new StartPluginGUIAction(Cooja.getDescriptionOf(motePluginClass) + "..."));

--- a/java/org/contikios/cooja/SupportedArguments.java
+++ b/java/org/contikios/cooja/SupportedArguments.java
@@ -30,20 +30,13 @@ package org.contikios.cooja;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-import org.contikios.cooja.plugins.Visualizer;
-import org.contikios.cooja.plugins.skins.DGRMVisualizerSkin;
-
 /**
  * With this annotation, Cooja components (e.g. mote plugins) can be activated
  * or deactivated depending on the given argument (e.g. mote). This may for
  * example be used by a mote plugin that only accepts emulated motes, and that
- * consequently should be hidden in other non-emulated motes' plugin menues.
- * <p>
- * See below code usage examples.
+ * consequently should be hidden in other non-emulated motes' plugin menus.
  *
- * @see Cooja#createMotePluginsSubmenu(Mote)
- * @see Visualizer#isSkinCompatible(Class)
- * @see DGRMVisualizerSkin
+ * @see org.contikios.cooja.util.Annotations
  *
  * @author Fredrik Osterlind
  */

--- a/java/org/contikios/cooja/plugins/Visualizer.java
+++ b/java/org/contikios/cooja/plugins/Visualizer.java
@@ -87,6 +87,7 @@ import javax.swing.plaf.basic.BasicInternalFrameUI;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.contikios.cooja.RadioMedium;
 import org.contikios.cooja.mote.BaseContikiMoteType;
 import org.contikios.cooja.plugins.skins.DGRMVisualizerSkin;
 import org.contikios.cooja.plugins.skins.LogisticLossVisualizerSkin;
@@ -256,7 +257,7 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
         viewMenu.add(new JSeparator());
         for (var skinClass : visualizerSkins) {
           // Should skin be enabled in this simulation?
-          if (!isSkinCompatible(skinClass)) {
+          if (!isSkinCompatible(skinClass.getAnnotation(SupportedArguments.class), simulation.getRadioMedium())) {
             continue;
           }
 
@@ -813,7 +814,7 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
       }
     }
 
-    if (!isSkinCompatible(skinClass)) {
+    if (!isSkinCompatible(skinClass.getAnnotation(SupportedArguments.class), simulation.getRadioMedium())) {
       return;
     }
 
@@ -910,18 +911,13 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
 
   private boolean showMoteToMoteRelations = true;
 
-  public boolean isSkinCompatible(Class<? extends VisualizerSkin> skinClass) {
-    if (skinClass == null) {
-      return false;
-    }
-
-    /* Check if skin depends on any particular radio medium */
+  public static boolean isSkinCompatible(SupportedArguments annotation, RadioMedium radioMedium) {
+    // Check if skin depends on any particular radio medium.
     boolean showMenuItem = true;
-    var annotation = skinClass.getAnnotation(SupportedArguments.class);
     if (annotation != null) {
       showMenuItem = false;
       for (var o : annotation.radioMediums()) {
-        if (o.isAssignableFrom(simulation.getRadioMedium().getClass())) {
+        if (o.isAssignableFrom(radioMedium.getClass())) {
           return true;
         }
       }

--- a/java/org/contikios/cooja/plugins/Visualizer.java
+++ b/java/org/contikios/cooja/plugins/Visualizer.java
@@ -87,10 +87,10 @@ import javax.swing.plaf.basic.BasicInternalFrameUI;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
-import org.contikios.cooja.RadioMedium;
 import org.contikios.cooja.mote.BaseContikiMoteType;
 import org.contikios.cooja.plugins.skins.DGRMVisualizerSkin;
 import org.contikios.cooja.plugins.skins.LogisticLossVisualizerSkin;
+import org.contikios.cooja.util.Annotations;
 import org.contikios.cooja.util.EventTriggers;
 import org.contikios.mrm.MRMVisualizerSkin;
 import org.jdom2.Element;
@@ -257,7 +257,7 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
         viewMenu.add(new JSeparator());
         for (var skinClass : visualizerSkins) {
           // Should skin be enabled in this simulation?
-          if (!isSkinCompatible(skinClass.getAnnotation(SupportedArguments.class), simulation.getRadioMedium())) {
+          if (!Annotations.isCompatible(skinClass.getAnnotation(SupportedArguments.class), simulation.getRadioMedium())) {
             continue;
           }
 
@@ -814,7 +814,7 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
       }
     }
 
-    if (!isSkinCompatible(skinClass.getAnnotation(SupportedArguments.class), simulation.getRadioMedium())) {
+    if (!Annotations.isCompatible(skinClass.getAnnotation(SupportedArguments.class), simulation.getRadioMedium())) {
       return;
     }
 
@@ -910,20 +910,6 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
   }
 
   private boolean showMoteToMoteRelations = true;
-
-  public static boolean isSkinCompatible(SupportedArguments annotation, RadioMedium radioMedium) {
-    // Check if skin depends on any particular radio medium.
-    boolean showMenuItem = true;
-    if (annotation != null) {
-      showMenuItem = false;
-      for (var o : annotation.radioMediums()) {
-        if (o.isAssignableFrom(radioMedium.getClass())) {
-          return true;
-        }
-      }
-    }
-    return showMenuItem;
-  }
 
   private void handleMousePress(MouseEvent mouseEvent) {
     int x = mouseEvent.getX();

--- a/java/org/contikios/cooja/util/Annotations.java
+++ b/java/org/contikios/cooja/util/Annotations.java
@@ -31,6 +31,7 @@
 package org.contikios.cooja.util;
 
 import org.contikios.cooja.Mote;
+import org.contikios.cooja.RadioMedium;
 import org.contikios.cooja.SupportedArguments;
 
 /**
@@ -60,6 +61,21 @@ public class Annotations {
     var clazz = mote.getClass();
     for (var supportedMote : annotation.motes()) {
       if (supportedMote.isAssignableFrom(clazz)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Return true if a radio medium is compatible with an annotation.
+   */
+  public static boolean isCompatible(SupportedArguments annotation, RadioMedium radioMedium) {
+    if (annotation == null) {
+      return true;
+    }
+    for (var o : annotation.radioMediums()) {
+      if (o.isAssignableFrom(radioMedium.getClass())) {
         return true;
       }
     }

--- a/java/org/contikios/cooja/util/Annotations.java
+++ b/java/org/contikios/cooja/util/Annotations.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.contikios.cooja.util;
+
+import org.contikios.cooja.Mote;
+import org.contikios.cooja.SupportedArguments;
+
+/**
+ * Utility methods for annotations.
+ */
+public class Annotations {
+  /**
+   * Prevent instances of this class
+   */
+  private Annotations() {}
+
+  /**
+   * Return true if a mote is compatible with an annotation.
+   */
+  public static boolean isCompatible(SupportedArguments annotation, Mote mote) {
+    if (annotation == null) {
+      return true;
+    }
+    // Check mote interfaces.
+    var moteInterfaces = mote.getInterfaces();
+    for (var requiredMoteInterface : annotation.moteInterfaces()) {
+      if (moteInterfaces.getInterfaceOfType(requiredMoteInterface) == null) {
+        return false;
+      }
+    }
+    // Check mote type.
+    var clazz = mote.getClass();
+    for (var supportedMote : annotation.motes()) {
+      if (supportedMote.isAssignableFrom(clazz)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/java/org/contikios/cooja/util/Annotations.java
+++ b/java/org/contikios/cooja/util/Annotations.java
@@ -47,7 +47,7 @@ public class Annotations {
    * Return true if a mote is compatible with an annotation.
    */
   public static boolean isCompatible(SupportedArguments annotation, Mote mote) {
-    if (annotation == null) {
+    if (annotation == null || mote == null) {
       return true;
     }
     // Check mote interfaces.
@@ -71,7 +71,7 @@ public class Annotations {
    * Return true if a radio medium is compatible with an annotation.
    */
   public static boolean isCompatible(SupportedArguments annotation, RadioMedium radioMedium) {
-    if (annotation == null) {
+    if (annotation == null || radioMedium == null) {
       return true;
     }
     for (var o : annotation.radioMediums()) {


### PR DESCRIPTION
Do not add plugins that are incompatible with
the radio medium to the tools menu.
    
This removes the DGRMConfigurator from the
Tools menu for incompatible radio mediums.