### PR TITLE
GUI: remove unused parameter

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1298,7 +1298,7 @@ public class Cooja {
       Simulation sim = null;
       try {
         sim = config.vis
-                ? Cooja.gui.doLoadConfig(simConfig, simConfig.randomSeed())
+                ? Cooja.gui.doLoadConfig(simConfig)
                 : gui.loadSimulationConfig(simConfig, true, simConfig.randomSeed());
       } catch (Exception e) {
         logger.fatal("Exception when loading simulation: ", e);

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -1238,15 +1238,14 @@ public class GUI {
   /**
    * Load a simulation configuration file from disk and return the simulation.
    *
-   * @param cfg Configuration to load, reloads current sim if null
-   * @param manualRandomSeed The random seed to use for the simulation
+   * @param cfg Configuration to load
    * @return The simulation
    */
-  Simulation doLoadConfig(Simulation.SimConfig cfg, Long manualRandomSeed) {
+  Simulation doLoadConfig(Simulation.SimConfig cfg) {
     final var worker = new Cooja.RunnableInEDT<SwingWorker<Simulation, Cooja.SimulationCreationException>>() {
       @Override
       public SwingWorker<Simulation, Cooja.SimulationCreationException> work() {
-        return createLoadSimWorker(cfg, true, manualRandomSeed);
+        return createLoadSimWorker(cfg, true, cfg.randomSeed());
       }
     }.invokeAndWait();
     worker.execute();


### PR DESCRIPTION
The method has one caller and the arguments
are always the same, push that information
into the body of the callee.

Also remove the possibility for passing
in null to this method.