### PR TITLE
Motes: remove spurious implements

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMote.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMote.java
@@ -35,7 +35,6 @@ import org.contikios.cooja.interfaces.PolledAfterActiveTicks;
 import org.contikios.cooja.interfaces.PolledAfterAllTicks;
 import org.contikios.cooja.interfaces.PolledBeforeActiveTicks;
 import org.contikios.cooja.interfaces.PolledBeforeAllTicks;
-import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.mote.memory.SectionMoteMemory;
@@ -57,7 +56,7 @@ import org.contikios.cooja.motes.AbstractWakeupMote;
  *
  * @author      Fredrik Osterlind
  */
-public class ContikiMote extends AbstractWakeupMote<ContikiMoteType, SectionMoteMemory> implements Mote {
+public class ContikiMote extends AbstractWakeupMote<ContikiMoteType, SectionMoteMemory> {
   private final ArrayList<PolledBeforeActiveTicks> polledBeforeActive = new ArrayList<>();
   private final ArrayList<PolledAfterActiveTicks> polledAfterActive = new ArrayList<>();
   private final ArrayList<PolledBeforeAllTicks> polledBeforePassive = new ArrayList<>();

--- a/java/org/contikios/cooja/motes/AbstractApplicationMote.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMote.java
@@ -29,7 +29,6 @@
 package org.contikios.cooja.motes;
 
 import java.util.HashMap;
-import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.RadioPacket;
@@ -46,7 +45,7 @@ import org.contikios.cooja.interfaces.Radio;
  *
  * @author Fredrik Osterlind
  */
-public abstract class AbstractApplicationMote extends AbstractWakeupMote<MoteType, SectionMoteMemory> implements Mote {
+public abstract class AbstractApplicationMote extends AbstractWakeupMote<MoteType, SectionMoteMemory> {
   public abstract void receivedPacket(RadioPacket p);
   public abstract void sentPacket(RadioPacket p);
   

--- a/java/org/contikios/cooja/motes/AbstractEmulatedMote.java
+++ b/java/org/contikios/cooja/motes/AbstractEmulatedMote.java
@@ -28,14 +28,13 @@
 
 package org.contikios.cooja.motes;
 
-import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.mote.memory.MemoryInterface;
 import org.contikios.cooja.plugins.BufferListener;
 import org.contikios.cooja.plugins.TimeLine;
 
-public abstract class AbstractEmulatedMote<T extends MoteType, M extends MemoryInterface> extends AbstractWakeupMote<T, M> implements Mote {
+public abstract class AbstractEmulatedMote<T extends MoteType, M extends MemoryInterface> extends AbstractWakeupMote<T, M> {
   protected AbstractEmulatedMote(T moteType, Simulation sim) {
     super(moteType, sim);
   }


### PR DESCRIPTION
This is already inherited from AbstractWakeupMote.