### PR TITLE
Move WatchpointMote from MspMote to AbstractWakeupMote

### DIFF
--- a/java/org/contikios/cooja/Watchpoint.java
+++ b/java/org/contikios/cooja/Watchpoint.java
@@ -32,6 +32,8 @@ package org.contikios.cooja;
 
 import java.awt.Color;
 import java.io.File;
+import java.util.Collection;
+import org.jdom2.Element;
 
 /**
  * @author Fredrik Osterlind
@@ -53,4 +55,7 @@ public interface Watchpoint {
 
   void setStopsSimulation(boolean b);
   boolean stopsSimulation();
+
+  Collection<Element> getConfigXML();
+  boolean setConfigXML(Collection<Element> configXML);
 }

--- a/java/org/contikios/cooja/Watchpoint.java
+++ b/java/org/contikios/cooja/Watchpoint.java
@@ -58,4 +58,6 @@ public interface Watchpoint {
 
   Collection<Element> getConfigXML();
   boolean setConfigXML(Collection<Element> configXML);
+
+  void removed();
 }

--- a/java/org/contikios/cooja/motes/AbstractWakeupMote.java
+++ b/java/org/contikios/cooja/motes/AbstractWakeupMote.java
@@ -28,15 +28,19 @@
 
 package org.contikios.cooja.motes;
 
+import static org.contikios.cooja.WatchpointMote.WatchpointListener;
+
+import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteTimeEvent;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.TimeEvent;
+import org.contikios.cooja.Watchpoint;
 import org.contikios.cooja.mote.memory.MemoryInterface;
 import org.jdom2.Element;
 
@@ -47,6 +51,9 @@ public abstract class AbstractWakeupMote<T extends MoteType, M extends MemoryInt
 
   protected MoteInterfaceHandler moteInterfaces;
   private long nextWakeupTime = -1;
+
+  protected final ArrayList<WatchpointListener> watchpointListeners = new ArrayList<>();
+  protected final ArrayList<Watchpoint> watchpoints = new ArrayList<>();
 
   protected AbstractWakeupMote(T moteType, Simulation sim) {
     this.moteType = moteType;
@@ -91,7 +98,23 @@ public abstract class AbstractWakeupMote<T extends MoteType, M extends MemoryInt
 
   @Override
   public Collection<Element> getConfigXML() {
-    return getInterfaces().getConfigXML();
+    var breakpoints = new ArrayList<Element>();
+    for (var breakpoint : watchpoints) {
+      var element = new Element("breakpoint");
+      element.addContent(breakpoint.getConfigXML());
+      breakpoints.add(element);
+    }
+
+    var config = new ArrayList<Element>();
+    if (!breakpoints.isEmpty()) {
+      var element = new Element("breakpoints");
+      element.addContent(breakpoints);
+      config.add(element);
+    }
+
+    // Mote interfaces.
+    config.addAll(getInterfaces().getConfigXML());
+    return config;
   }
 
   @Override
@@ -106,6 +129,61 @@ public abstract class AbstractWakeupMote<T extends MoteType, M extends MemoryInt
     }
     requestImmediateWakeup();
     return true;
+  }
+
+  public void addWatchpointListener(WatchpointListener listener) {
+    watchpointListeners.add(listener);
+  }
+
+  public void removeWatchpointListener(WatchpointListener listener) {
+    watchpointListeners.remove(listener);
+  }
+
+  public WatchpointListener[] getWatchpointListeners() {
+    return watchpointListeners.toArray(new WatchpointListener[0]);
+  }
+
+  public Watchpoint addBreakpoint(File codeFile, int lineNr, long address) {
+    return null; // FIXME: make a usable general Watchpoint class and implement this method.
+  }
+
+  public void removeBreakpoint(Watchpoint watchpoint) {
+    watchpoint.removed();
+    watchpoints.remove(watchpoint);
+    for (var listener : watchpointListeners) {
+      listener.watchpointsChanged();
+    }
+  }
+
+  public Watchpoint[] getBreakpoints() {
+    return watchpoints.toArray(new Watchpoint[0]);
+  }
+
+  public boolean breakpointExists(long address) {
+    if (address < 0) {
+      return false;
+    }
+    for (var watchpoint : watchpoints) {
+      if (watchpoint.getExecutableAddress() == address) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public boolean breakpointExists(File file, int lineNr) {
+    for (var watchpoint : watchpoints) {
+      if (watchpoint.getCodeFile() == null || watchpoint.getCodeFile().compareTo(file) != 0 ||
+          watchpoint.getLineNumber() != lineNr) {
+        continue;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  public long getExecutableAddressOf(File file, int lineNr) {
+    return -1; // FIXME: this belongs in MoteType, not Mote.
   }
 
   /**

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -451,7 +451,7 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
   }
   @Override
   public void removeBreakpoint(Watchpoint watchpoint) {
-    ((MspBreakpoint)watchpoint).unregisterBreakpoint();
+    watchpoint.removed();
     watchpoints.remove(watchpoint);
 
     for (WatchpointListener listener: watchpointListeners) {

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -328,7 +328,7 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
         for (Element elem : element.getChildren()) {
           if (elem.getName().equals("breakpoint")) {
             MspBreakpoint breakpoint = new MspBreakpoint(this);
-            if (!breakpoint.setConfigXML(elem.getChildren(), visAvailable)) {
+            if (!breakpoint.setConfigXML(elem.getChildren())) {
               logger.warn("Could not restore breakpoint: " + breakpoint);
             } else {
               watchpoints.add(breakpoint);

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -33,20 +33,18 @@ package org.contikios.cooja.mspmote;
 import java.awt.Component;
 import java.io.File;
 import java.io.PrintStream;
-import java.util.ArrayList;
 import java.util.Collection;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.Simulation.SimulationStop;
+import org.contikios.cooja.WatchpointMote;
 import org.jdom2.Element;
 import org.contikios.cooja.ContikiError;
 import org.contikios.cooja.Cooja;
-import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.Watchpoint;
-import org.contikios.cooja.WatchpointMote;
 import org.contikios.cooja.motes.AbstractEmulatedMote;
 import org.contikios.cooja.mspmote.plugins.CodeVisualizerSkin;
 import org.contikios.cooja.mspmote.plugins.MspBreakpoint;
@@ -76,7 +74,7 @@ import org.contikios.cooja.mspmote.interfaces.MspClock;
 /**
  * @author Fredrik Osterlind
  */
-public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteMemory> implements Mote, WatchpointMote {
+public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteMemory> implements WatchpointMote {
   private static final Logger logger = LogManager.getLogger(MspMote.class);
 
   private final static int EXECUTE_DURATION_US = 1; /* We always execute in 1 us steps */
@@ -347,23 +345,6 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
   }
 
   @Override
-  public Collection<Element> getConfigXML() {
-    ArrayList<Element> config = new ArrayList<>();
-
-    /* Breakpoints */
-    Collection<Element> breakpoints = getWatchpointConfigXML();
-    if (breakpoints != null && !breakpoints.isEmpty()) {
-      var element = new Element("breakpoints");
-      element.addContent(breakpoints);
-      config.add(element);
-    }
-
-    // Mote interfaces.
-    config.addAll(super.getConfigXML());
-    return config;
-  }
-
-  @Override
   public String getExecutionDetails() {
     return executeCLICommand("stacktrace");
   }
@@ -423,22 +404,6 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
 
 
   /* WatchpointMote */
-  private final ArrayList<WatchpointListener> watchpointListeners = new ArrayList<>();
-  private final ArrayList<MspBreakpoint> watchpoints = new ArrayList<>();
-
-  @Override
-  public void addWatchpointListener(WatchpointListener listener) {
-    watchpointListeners.add(listener);
-  }
-  @Override
-  public void removeWatchpointListener(WatchpointListener listener) {
-    watchpointListeners.remove(listener);
-  }
-  @Override
-  public WatchpointListener[] getWatchpointListeners() {
-    return watchpointListeners.toArray(new WatchpointListener[0]);
-  }
-
   @Override
   public Watchpoint addBreakpoint(File codeFile, int lineNr, long address) {
     MspBreakpoint bp = new MspBreakpoint(this, address, codeFile, lineNr);
@@ -448,48 +413,6 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
       listener.watchpointsChanged();
     }
     return bp;
-  }
-  @Override
-  public void removeBreakpoint(Watchpoint watchpoint) {
-    watchpoint.removed();
-    watchpoints.remove(watchpoint);
-
-    for (WatchpointListener listener: watchpointListeners) {
-      listener.watchpointsChanged();
-    }
-  }
-  @Override
-  public Watchpoint[] getBreakpoints() {
-    return watchpoints.toArray(new Watchpoint[0]);
-  }
-
-  @Override
-  public boolean breakpointExists(long address) {
-    if (address < 0) {
-      return false;
-    }
-    for (Watchpoint watchpoint: watchpoints) {
-      if (watchpoint.getExecutableAddress() == address) {
-        return true;
-      }
-    }
-    return false;
-  }
-  @Override
-  public boolean breakpointExists(File file, int lineNr) {
-    for (Watchpoint watchpoint: watchpoints) {
-      if (watchpoint.getCodeFile() == null) {
-        continue;
-      }
-      if (watchpoint.getCodeFile().compareTo(file) != 0) {
-        continue;
-      }
-      if (watchpoint.getLineNumber() != lineNr) {
-        continue;
-      }
-      return true;
-    }
-    return false;
   }
 
   @Override
@@ -514,17 +437,5 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
     for (WatchpointListener listener: listeners) {
       listener.watchpointTriggered(b);
     }
-  }
-
-  public Collection<Element> getWatchpointConfigXML() {
-    ArrayList<Element> config = new ArrayList<>();
-
-    for (MspBreakpoint breakpoint: watchpoints) {
-      Element element = new Element("breakpoint");
-      element.addContent(breakpoint.getConfigXML());
-      config.add(element);
-    }
-
-    return config;
   }
 }

--- a/java/org/contikios/cooja/mspmote/plugins/MspBreakpoint.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspBreakpoint.java
@@ -168,7 +168,8 @@ public class MspBreakpoint implements Watchpoint {
 
   }
 
-  public void unregisterBreakpoint() {
+  @Override
+  public void removed() {
     mspMote.getCPU().removeWatchPoint((int) address, memoryMonitor);
   }
 

--- a/java/org/contikios/cooja/mspmote/plugins/MspBreakpoint.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspBreakpoint.java
@@ -210,9 +210,8 @@ public class MspBreakpoint implements Watchpoint {
     return config;
   }
 
-  public boolean setConfigXML(Collection<Element> configXML, boolean visAvailable) {
-    /* Already knows mote and breakpoints */
-
+  public boolean setConfigXML(Collection<Element> configXML) {
+    // Already knows mote and breakpoints.
     for (Element element : configXML) {
       if (element.getName().equals("codefile")) {
         var file = mspMote.getSimulation().getCooja().restorePortablePath(new File(element.getText()));

--- a/java/org/contikios/cooja/mspmote/plugins/MspBreakpoint.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspBreakpoint.java
@@ -172,6 +172,7 @@ public class MspBreakpoint implements Watchpoint {
     mspMote.getCPU().removeWatchPoint((int) address, memoryMonitor);
   }
 
+  @Override
   public Collection<Element> getConfigXML() {
     ArrayList<Element> config = new ArrayList<>();
     Element element;
@@ -210,6 +211,7 @@ public class MspBreakpoint implements Watchpoint {
     return config;
   }
 
+  @Override
   public boolean setConfigXML(Collection<Element> configXML) {
     // Already knows mote and breakpoints.
     for (Element element : configXML) {


### PR DESCRIPTION
The watchpoint functionality is almost completely generic, so move that to AbstractWakeupMote.

There is no generic breakpoint implementation in Cooja yet, so addBreakpoint() and setConfigXML() need to be implemented by all motes that want the functionality.

The getExecutableAddressOf() method also needs to be implemented, but that really belongs in MoteType.