### PR TITLE
Cooja: stop calling System.gc()

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1419,7 +1419,6 @@ public class Cooja {
       delay = config.moteStartDelay();
     }
     doRemoveSimulation();
-    System.gc();
     Simulation sim;
     try {
       sim = new Simulation(cfg, this, title, generatedSeed, seed, medium, delay, quick, root);


### PR DESCRIPTION
Removing this seems to save 1-2 seconds on
07-simulation-base.

Before:
real 78.07
user 1.44
sys 0.18

After:
real 77.23
user 1.32
sys 0.27

Cooja has 2 GB heap by default, so there
should not be a shortage of memory for
typical use. If Cooja still needs to
call System.gc() somewhere, it would
probably be better to do it last in
the simulation thread.