### PR TITLE
Disable history with --update-simulation

### DIFF
--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -1324,7 +1324,7 @@ public class GUI {
       return null;
     }
 
-    if (configFile != null) {
+    if (configFile != null && !cfg.updateSim()) {
       addToFileHistory(configFile);
     }
 


### PR DESCRIPTION
Updating simulation files is usually not
done interactively, so avoid changing
the file history for the user.