### PR TITLE
MoteInterfaceHandler: add clock fallback

### DIFF
--- a/java/org/contikios/cooja/MoteInterfaceHandler.java
+++ b/java/org/contikios/cooja/MoteInterfaceHandler.java
@@ -446,6 +446,8 @@ public class MoteInterfaceHandler {
       // Check for compatible interfaces, for example, when reconfiguring mote types.
       if (MoteID.class.isAssignableFrom(moteInterfaceClass)) {
         moteInterface = getMoteID();
+      } else if (Clock.class.isAssignableFrom(moteInterfaceClass)) {
+        moteInterface = getClock();
       }
       if (moteInterface == null) {
         logger.fatal("Cannot find mote interface of class: " + moteInterfaceClass);


### PR DESCRIPTION
Use the default clock type when the specified
clock cannot be found. Required for changing
mote types when reconfiguring simulations.