### PR TITLE
Remove short help option

### DIFF
--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -148,7 +148,7 @@ class Main {
           description = "print version information and exit")
   boolean versionRequested;
 
-  @Option(names = {"-h", "--help"}, usageHelp = true, description = "display a help message")
+  @Option(names = "--help", usageHelp = true, description = "display a help message")
   boolean helpRequested;
 
   public static void main(String[] args) {


### PR DESCRIPTION
Short option names are sorted in unexpected
ways by Picocli. The help option is the only
short option in Cooja, and that is not used
a lot, so remove it.

This is preparation for grouping related
command line parameters in the output
from --help.