### PR TITLE
Move getExecutableAddressOf to MoteType

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -23,6 +23,11 @@ use a double dash for consistency.
 
 ## Cooja API changes for plugins outside the main tree
 
+### Moved getExecutableAddressOf from WatchpointMote to MoteType
+
+Call the method with `mote.getType().getExecutableAddressOf(file, line)`
+instead of `mote.getExecutableAddressOf(file, line)`.
+
 ### Add added/removed methods to Mote interface
 
 Cooja calls these methods when motes are added and removed from the simulation.

--- a/java/org/contikios/cooja/MoteType.java
+++ b/java/org/contikios/cooja/MoteType.java
@@ -28,6 +28,7 @@
 package org.contikios.cooja;
 
 import java.awt.Container;
+import java.io.File;
 import java.util.Collection;
 
 import javax.swing.JComponent;
@@ -151,6 +152,10 @@ public interface MoteType {
   boolean setConfigXML(
       Simulation simulation, Collection<Element> configXML, boolean visAvailable)
   throws MoteTypeCreationException;
+
+  default long getExecutableAddressOf(File file, int lineNr) {
+    return -1;
+  }
 
   class MoteTypeCreationException extends Exception {
     private MessageList compilationOutput;

--- a/java/org/contikios/cooja/WatchpointMote.java
+++ b/java/org/contikios/cooja/WatchpointMote.java
@@ -68,6 +68,4 @@ public interface WatchpointMote extends Mote {
 
   boolean breakpointExists(long address);
   boolean breakpointExists(File file, int lineNr);
-
-  long getExecutableAddressOf(File file, int lineNr);
 }

--- a/java/org/contikios/cooja/motes/AbstractWakeupMote.java
+++ b/java/org/contikios/cooja/motes/AbstractWakeupMote.java
@@ -182,10 +182,6 @@ public abstract class AbstractWakeupMote<T extends MoteType, M extends MemoryInt
     return false;
   }
 
-  public long getExecutableAddressOf(File file, int lineNr) {
-    return -1; // FIXME: this belongs in MoteType, not Mote.
-  }
-
   /**
    * Execute mote software.
    * This method is only called from the simulation thread.

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -415,11 +415,6 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
     return bp;
   }
 
-  @Override
-  public long getExecutableAddressOf(File file, int lineNr) {
-    return moteType.getExecutableAddressOf(file, lineNr);
-  }
-
   private long lastBreakpointCycles = -1;
   public void signalBreakpointTrigger(MspBreakpoint b) {
     if (lastBreakpointCycles == myCpu.cycles) {

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -138,6 +138,7 @@ public abstract class MspMoteType extends BaseContikiMoteType {
     return configureAndInit(Cooja.getTopParentContainer(), simulation, Cooja.isVisualized());
   }
 
+  @Override
   public long getExecutableAddressOf(File file, int lineNr) {
     if (file == null || lineNr < 0) {
       return -1;

--- a/java/org/contikios/cooja/mspmote/plugins/CodeUI.java
+++ b/java/org/contikios/cooja/mspmote/plugins/CodeUI.java
@@ -131,7 +131,7 @@ public class CodeUI extends JPanel {
         /* Configure breakpoint menu options */
         /* XXX TODO We should ask for the file specified in the firmware, not
          * the actual file on disk. */
-        var address = CodeUI.this.mote.getExecutableAddressOf(displayedFile, line);
+        var address = CodeUI.this.mote.getType().getExecutableAddressOf(displayedFile, line);
         if (address < 0) {
           return;
         }

--- a/java/org/contikios/cooja/mspmote/plugins/MspBreakpoint.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspBreakpoint.java
@@ -256,7 +256,7 @@ public class MspBreakpoint implements Watchpoint {
     }
 
     /* Update executable address */
-    address = mspMote.getExecutableAddressOf(codeFile, lineNr);
+    address = mspMote.getType().getExecutableAddressOf(codeFile, lineNr);
     if (address < 0) {
       logger.fatal("Could not restore breakpoint, did source code change?");
       return false;


### PR DESCRIPTION
This method belongs with the mote type
since it concerns the firmware. The Contiki
mote type could implement this method today,
but not the rest of the watchpoint support.