### PR TITLE
MoteInterfaceHandler: query mote type for class

### DIFF
--- a/java/org/contikios/cooja/motes/AbstractWakeupMote.java
+++ b/java/org/contikios/cooja/motes/AbstractWakeupMote.java
@@ -122,7 +122,7 @@ public abstract class AbstractWakeupMote<T extends MoteType, M extends MemoryInt
     for (var element : configXML) {
       var name = element.getName();
       if (name.equals("interface_config")) {
-        if (!getInterfaces().setConfigXML(sim, element, this)) {
+        if (!getInterfaces().setConfigXML(this, element)) {
           return false;
         }
       }

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -334,7 +334,7 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
           }
         }
       } else if (name.equals("interface_config")) {
-        if (!getInterfaces().setConfigXML(simulation, element, this)) {
+        if (!getInterfaces().setConfigXML(this, element)) {
           return false;
         }
       }


### PR DESCRIPTION
The mote type already contains a list of
the classes, query that instead of loading
something dynamically.