### PR TITLE
AddressVisualizerSkin: tweak description

### DIFF
--- a/java/org/contikios/cooja/plugins/skins/AddressVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/AddressVisualizerSkin.java
@@ -54,7 +54,7 @@ import org.contikios.cooja.plugins.Visualizer.MoteMenuAction;
  *
  * @author Fredrik Osterlind
  */
-@ClassDescription("Addresses: IP")
+@ClassDescription("IP addresses")
 public class AddressVisualizerSkin implements VisualizerSkin {
   private Simulation simulation = null;
   private Visualizer visualizer = null;


### PR DESCRIPTION
This is the menu item name used by the visualizer, so align it with the other skin names.