### PR TITLE
Breakpoint: move call to MspBreakpoint

### DIFF
--- a/java/org/contikios/cooja/Breakpoint.java
+++ b/java/org/contikios/cooja/Breakpoint.java
@@ -69,7 +69,6 @@ public abstract class Breakpoint implements Watchpoint {
     this.address = address;
     this.codeFile = codeFile;
     this.lineNr = lineNr;
-    createMonitor();
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/plugins/MspBreakpoint.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspBreakpoint.java
@@ -54,6 +54,7 @@ public class MspBreakpoint extends Breakpoint {
   public MspBreakpoint(MspMote mote, long address, File codeFile, Integer lineNr) {
     super(mote, address, codeFile, lineNr);
     mspMote = mote;
+    createMonitor();
   }
 
   @Override


### PR DESCRIPTION
The subclasses need to initialize before
createMonitor is called, so move that
call from Breakpoint to MspBreakpoint.