### PR TITLE
Move builtinInterfaces to BaseContikiMoteType

### DIFF
--- a/java/org/contikios/cooja/MoteInterfaceHandler.java
+++ b/java/org/contikios/cooja/MoteInterfaceHandler.java
@@ -30,26 +30,12 @@
 
 package org.contikios.cooja;
 
-import static java.util.Map.entry;
-
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.contikimote.ContikiMoteType;
-import org.contikios.cooja.contikimote.interfaces.ContikiBeeper;
-import org.contikios.cooja.contikimote.interfaces.ContikiButton;
-import org.contikios.cooja.contikimote.interfaces.ContikiCFS;
-import org.contikios.cooja.contikimote.interfaces.ContikiClock;
-import org.contikios.cooja.contikimote.interfaces.ContikiEEPROM;
-import org.contikios.cooja.contikimote.interfaces.ContikiLED;
-import org.contikios.cooja.contikimote.interfaces.ContikiMoteID;
-import org.contikios.cooja.contikimote.interfaces.ContikiPIR;
-import org.contikios.cooja.contikimote.interfaces.ContikiRS232;
-import org.contikios.cooja.contikimote.interfaces.ContikiRadio;
-import org.contikios.cooja.contikimote.interfaces.ContikiVib;
 import org.contikios.cooja.interfaces.Battery;
 import org.contikios.cooja.interfaces.Beeper;
 import org.contikios.cooja.interfaces.Button;
@@ -57,8 +43,6 @@ import org.contikios.cooja.interfaces.Clock;
 import org.contikios.cooja.interfaces.IPAddress;
 import org.contikios.cooja.interfaces.LED;
 import org.contikios.cooja.interfaces.Log;
-import org.contikios.cooja.interfaces.Mote2MoteRelations;
-import org.contikios.cooja.interfaces.MoteAttributes;
 import org.contikios.cooja.interfaces.MoteID;
 import org.contikios.cooja.interfaces.PIR;
 import org.contikios.cooja.interfaces.Position;
@@ -67,17 +51,6 @@ import org.contikios.cooja.motes.DisturberMoteType;
 import org.contikios.cooja.motes.ImportAppMoteType;
 import org.contikios.cooja.mspmote.SkyMoteType;
 import org.contikios.cooja.mspmote.Z1MoteType;
-import org.contikios.cooja.mspmote.interfaces.Msp802154Radio;
-import org.contikios.cooja.mspmote.interfaces.MspClock;
-import org.contikios.cooja.mspmote.interfaces.MspDebugOutput;
-import org.contikios.cooja.mspmote.interfaces.MspDefaultSerial;
-import org.contikios.cooja.mspmote.interfaces.MspLED;
-import org.contikios.cooja.mspmote.interfaces.MspMoteID;
-import org.contikios.cooja.mspmote.interfaces.MspSerial;
-import org.contikios.cooja.mspmote.interfaces.SkyButton;
-import org.contikios.cooja.mspmote.interfaces.SkyCoffeeFilesystem;
-import org.contikios.cooja.mspmote.interfaces.SkyFlash;
-import org.contikios.cooja.mspmote.interfaces.SkyTemperature;
 import org.jdom2.Element;
 
 /**
@@ -87,42 +60,6 @@ import org.jdom2.Element;
  */
 public class MoteInterfaceHandler {
   private static final Logger logger = LogManager.getLogger(MoteInterfaceHandler.class);
-
-  /** Static translation map from name -> class for builtin interfaces. */
-  private static final Map<String, Class<? extends MoteInterface>> builtinInterfaces = Map.ofEntries(
-          entry("org.contikios.cooja.interfaces.IPAddress", IPAddress.class),
-          entry("org.contikios.cooja.interfaces.Position", Position.class),
-          entry("org.contikios.cooja.interfaces.Battery", Battery.class),
-          entry("org.contikios.cooja.contikimote.interfaces.ContikiVib", ContikiVib.class),
-          entry("org.contikios.cooja.contikimote.interfaces.ContikiMoteID", ContikiMoteID.class),
-          entry("org.contikios.cooja.contikimote.interfaces.ContikiRS232", ContikiRS232.class),
-          entry("org.contikios.cooja.contikimote.interfaces.ContikiBeeper", ContikiBeeper.class),
-          entry("org.contikios.cooja.contikimote.interfaces.ContikiIPAddress", IPAddress.class), // Compatibility.
-          entry("org.contikios.cooja.contikimote.interfaces.ContikiRadio", ContikiRadio.class),
-          entry("org.contikios.cooja.contikimote.interfaces.ContikiButton", ContikiButton.class),
-          entry("org.contikios.cooja.contikimote.interfaces.ContikiPIR", ContikiPIR.class),
-          entry("org.contikios.cooja.contikimote.interfaces.ContikiClock", ContikiClock.class),
-          entry("org.contikios.cooja.contikimote.interfaces.ContikiLED", ContikiLED.class),
-          entry("org.contikios.cooja.contikimote.interfaces.ContikiCFS", ContikiCFS.class),
-          entry("org.contikios.cooja.contikimote.interfaces.ContikiEEPROM", ContikiEEPROM.class),
-          entry("org.contikios.cooja.interfaces.Mote2MoteRelations", Mote2MoteRelations.class),
-          entry("org.contikios.cooja.interfaces.MoteAttributes", MoteAttributes.class),
-          entry("org.contikios.cooja.mspmote.interfaces.ESBLog", MspSerial.class), // Compatibility.
-          entry("org.contikios.cooja.mspmote.interfaces.MspClock", MspClock.class),
-          entry("org.contikios.cooja.mspmote.interfaces.MspDebugOutput", MspDebugOutput.class),
-          entry("org.contikios.cooja.mspmote.interfaces.MspDefaultSerial", MspDefaultSerial.class),
-          entry("org.contikios.cooja.mspmote.interfaces.MspIPAddress", IPAddress.class), // Compatibility.
-          entry("org.contikios.cooja.mspmote.interfaces.MspLED", MspLED.class),
-          entry("org.contikios.cooja.mspmote.interfaces.MspMoteID", MspMoteID.class),
-          entry("org.contikios.cooja.mspmote.interfaces.MspSerial", MspSerial.class),
-          entry("org.contikios.cooja.mspmote.interfaces.Msp802154Radio", Msp802154Radio.class),
-          entry("org.contikios.cooja.mspmote.interfaces.SkyButton", SkyButton.class),
-          entry("org.contikios.cooja.mspmote.interfaces.SkyByteRadio", Msp802154Radio.class), // Compatibility.
-          entry("org.contikios.cooja.mspmote.interfaces.SkyCoffeeFilesystem", SkyCoffeeFilesystem.class),
-          entry("org.contikios.cooja.mspmote.interfaces.SkyFlash", SkyFlash.class),
-          entry("org.contikios.cooja.mspmote.interfaces.SkyLED", MspLED.class), // Compatibility
-          entry("org.contikios.cooja.mspmote.interfaces.SkySerial", MspSerial.class), // Compatibility.
-          entry("org.contikios.cooja.mspmote.interfaces.SkyTemperature", SkyTemperature.class));
 
   private final ArrayList<MoteInterface> moteInterfaces = new ArrayList<>();
 
@@ -182,24 +119,6 @@ public class MoteInterfaceHandler {
     } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
       return null;
     }
-  }
-
-  /** Fast translation from class name to class file for builtin interfaces. Uses the classloader
-   * to load other interfaces.
-   * @param gui Cooja
-   * @param caller Object calling
-   * @param name Name of class to find
-   * @return Found class or null
-   */
-  public static Class<? extends MoteInterface> getInterfaceClass(Cooja gui, Object caller, String name) {
-    if (name.startsWith("se.sics")) {
-      name = name.replaceFirst("se\\.sics", "org.contikios");
-    }
-    var clazz = builtinInterfaces.get(name);
-    if (clazz != null) {
-      return clazz;
-    }
-    return gui.tryLoadClass(caller, MoteInterface.class, name);
   }
 
   /**


### PR DESCRIPTION
There is a single caller to getInterfaceClass,
so inline that method at the caller.

This moves the map of builtin interfaces from
MoteInterfaceHandlder to BaseContikiMoteType
where it belongs.