### PR TITLE
MoteInterfaceHandler: make failure conditional

### DIFF
--- a/java/org/contikios/cooja/MoteInterfaceHandler.java
+++ b/java/org/contikios/cooja/MoteInterfaceHandler.java
@@ -391,7 +391,7 @@ public class MoteInterfaceHandler {
     return config;
   }
 
-  public boolean setConfigXML(Mote mote, Element element) {
+  public boolean setConfigXML(Mote mote, Element element, boolean ignoreFailure) {
     var name = element.getText().trim();
     if (name.startsWith("se.sics")) {
       name = name.replaceFirst("se\\.sics", "org.contikios");
@@ -410,13 +410,13 @@ public class MoteInterfaceHandler {
               ? MoteID.class : mote.getSimulation().getCooja().tryLoadClass(mote, MoteInterface.class, name);
       if (moteInterfaceClass == null) {
         logger.warn("Cannot find mote interface class: " + name);
-        return false;
+        return ignoreFailure;
       }
     }
     var moteInterface = getInterfaceOfType(moteInterfaceClass);
     if (moteInterface == null) {
-      logger.fatal("Cannot find mote interface of class: " + moteInterfaceClass);
-      return false;
+      logger.warn("Cannot find mote interface of class: " + moteInterfaceClass);
+      return ignoreFailure;
     }
     moteInterface.setConfigXML(element.getChildren(), Cooja.isVisualized());
     return true;

--- a/java/org/contikios/cooja/motes/AbstractWakeupMote.java
+++ b/java/org/contikios/cooja/motes/AbstractWakeupMote.java
@@ -122,7 +122,7 @@ public abstract class AbstractWakeupMote<T extends MoteType, M extends MemoryInt
     for (var element : configXML) {
       var name = element.getName();
       if (name.equals("interface_config")) {
-        if (!getInterfaces().setConfigXML(this, element)) {
+        if (!getInterfaces().setConfigXML(this, element, !simulation.isQuickSetup())) {
           return false;
         }
       }

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -334,7 +334,7 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
           }
         }
       } else if (name.equals("interface_config")) {
-        if (!getInterfaces().setConfigXML(this, element)) {
+        if (!getInterfaces().setConfigXML(this, element, !simulation.isQuickSetup())) {
           return false;
         }
       }


### PR DESCRIPTION
Allow the caller to specify if failure should
be permitted. Also downgrade the fatal to warn
since the loading might continue after the message.

This fixes reconfiguring old csc files, for example rpl-udp-cooja.csc.