### PR TITLE
SafeRandom: set seed at construction

### DIFF
--- a/java/org/contikios/cooja/SafeRandom.java
+++ b/java/org/contikios/cooja/SafeRandom.java
@@ -71,10 +71,11 @@ class SafeRandom extends Random {
     
   }
 
-  public SafeRandom(Simulation sim) {
+  public SafeRandom(long seed, Simulation sim) {
     // assertSimThread is called by the super-constructor.
     super();
     this.sim = sim;
+    setSeed(seed);
   }
 
   @Override

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -198,8 +198,7 @@ public final class Simulation {
     this.title = title;
     randomSeed = seed;
     randomSeedGenerated = generateSeed;
-    randomGenerator = new SafeRandom(this);
-    randomGenerator.setSeed(seed);
+    randomGenerator = new SafeRandom(seed, this);
     if (radioMediumClass.startsWith("se.sics")) {
       radioMediumClass = radioMediumClass.replaceFirst("se\\.sics", "org.contikios");
     }


### PR DESCRIPTION
SafeRandom is only created in one place,
and setSeed is only called directly
after that. Move the call to setSeed
into the SafeRandom constructor instead.