### PR TITLE
WatchpointMote: remove useless argument

### DIFF
--- a/java/org/contikios/cooja/WatchpointMote.java
+++ b/java/org/contikios/cooja/WatchpointMote.java
@@ -62,8 +62,8 @@ public interface WatchpointMote extends Mote {
    */
   WatchpointListener[] getWatchpointListeners();
 
-  Watchpoint createBreakpoint(WatchpointMote mote);
-  Watchpoint createBreakpoint(WatchpointMote mote, long address, File codeFile, Integer lineNr);
+  Watchpoint createBreakpoint();
+  Watchpoint createBreakpoint(long address, File codeFile, Integer lineNr);
 
   Watchpoint addBreakpoint(File codeFile, int lineNr, long address);
   void removeBreakpoint(Watchpoint watchpoint);

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -327,7 +327,7 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
       if ("breakpoints".equals(name)) {
         for (Element elem : element.getChildren()) {
           if (elem.getName().equals("breakpoint")) {
-            var breakpoint = createBreakpoint(this);
+            var breakpoint = createBreakpoint();
             if (breakpoint.setConfigXML(elem.getChildren())) {
               watchpoints.add(breakpoint);
             }
@@ -405,18 +405,18 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
 
   /* WatchpointMote */
   @Override
-  public Watchpoint createBreakpoint(WatchpointMote mote) {
-    return new MspBreakpoint((MspMote) mote);
+  public Watchpoint createBreakpoint() {
+    return new MspBreakpoint(this);
   }
 
   @Override
-  public Watchpoint createBreakpoint(WatchpointMote mote, long address, File codeFile, Integer lineNr) {
-    return new MspBreakpoint((MspMote) mote, address, codeFile, lineNr);
+  public Watchpoint createBreakpoint(long address, File codeFile, Integer lineNr) {
+    return new MspBreakpoint(this, address, codeFile, lineNr);
   }
 
   @Override
   public Watchpoint addBreakpoint(File codeFile, int lineNr, long address) {
-    var bp = createBreakpoint(this, address, codeFile, lineNr);
+    var bp = createBreakpoint(address, codeFile, lineNr);
     watchpoints.add(bp);
 
     for (WatchpointListener listener: watchpointListeners) {


### PR DESCRIPTION
The method is in the mote, so stop passing
in a mote and casting the argument.