### PR TITLE
AbstractCompileDialog: fix clean button state

### DIFF
--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -487,7 +487,7 @@ public abstract class AbstractCompileDialog extends JDialog {
         }
         contikiSource = null;
         contikiFirmware = new File(input);
-        cleanButton.setEnabled(true);
+        cleanButton.setEnabled(false);
         compileButton.setEnabled(false);
         createButton.setEnabled(true);
         commandsArea.setEnabled(false);


### PR DESCRIPTION
Selecting a firmware should not enable the button
that performs make clean.