### PR TITLE
Cooja: remove spurious loop

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -698,10 +698,8 @@ public class Cooja {
     }
 
     if (root != null) {
-      for (var cfg : root.getChildren("plugin_config")) {
-        if (!plugin.setConfigXML(cfg.getChildren(), isVisualized())) {
-          throw new PluginConstructionException("Failed to set config for " + pluginClass.getName());
-        }
+      if (!plugin.setConfigXML(root.getChild("plugin_config").getChildren(), isVisualized())) {
+        throw new PluginConstructionException("Failed to set config for " + pluginClass.getName());
       }
     }
 


### PR DESCRIPTION
There is only one config per plugin,
so call getChild instead of getChildren.