### PR TITLE
CoreComm: convert to interface

### DIFF
--- a/java/org/contikios/cooja/CoreComm.java
+++ b/java/org/contikios/cooja/CoreComm.java
@@ -61,15 +61,15 @@ package org.contikios.cooja;
  *
  * @author Fredrik Osterlind
  */
-public abstract class CoreComm {
+public interface CoreComm {
 
   /**
    * Ticks a mote once.
    */
-  public abstract void tick();
+  void tick();
 
   /**
    * Returns the absolute memory address of the reference variable.
    */
-  public abstract long getReferenceAddress();
+  long getReferenceAddress();
 }

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -894,19 +894,15 @@ public class ContikiMoteType extends BaseContikiMoteType {
     final var className = "Lib" + fileCounter++;
     generateLibSourceFile(tempDir, className);
     compileSourceFile(tempDir, className);
-
-    Class<?> newCoreCommClass;
+    Class<? extends CoreComm> newCoreCommClass;
     try (var loader = URLClassLoader.newInstance(new URL[]{tempDir.toUri().toURL()})) {
-      newCoreCommClass = loader.loadClass("org.contikios.cooja.corecomm." + className);
-    } catch (IOException | ClassNotFoundException e1) {
+      newCoreCommClass = loader.loadClass("org.contikios.cooja.corecomm." + className).asSubclass(CoreComm.class);
+    } catch (IOException | NullPointerException | ClassNotFoundException e1) {
       throw new MoteTypeCreationException("Could not load corecomm class file: " + className + ".class", e1);
-    }
-    if (newCoreCommClass == null) {
-      throw new MoteTypeCreationException("Could not load corecomm class file: " + className + ".class");
     }
 
     try {
-      return (CoreComm) newCoreCommClass.getConstructor(File.class).newInstance(libFile);
+      return newCoreCommClass.getConstructor(File.class).newInstance(libFile);
     } catch (Exception e) {
       throw new MoteTypeCreationException("Error when creating corecomm instance: " + className, e);
     }

--- a/java/org/contikios/cooja/corecomm/CoreCommTemplate.java
+++ b/java/org/contikios/cooja/corecomm/CoreCommTemplate.java
@@ -45,7 +45,7 @@ import org.contikios.cooja.CoreComm;
  * @see CoreComm
  * @author Fredrik Osterlind
  */
-public class CoreCommTemplate extends CoreComm {
+public class CoreCommTemplate implements CoreComm {
   private final SymbolLookup symbols;
   private final MethodHandle coojaTick;
   /**


### PR DESCRIPTION
Using the new FFI made this class
tiny, so convert it to an interface.