### PR TITLE
ScriptMote: use API to get serial port

### DIFF
--- a/java/org/contikios/cooja/MoteInterfaceHandler.java
+++ b/java/org/contikios/cooja/MoteInterfaceHandler.java
@@ -45,6 +45,7 @@ import org.contikios.cooja.interfaces.MoteID;
 import org.contikios.cooja.interfaces.PIR;
 import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.Radio;
+import org.contikios.cooja.interfaces.SerialPort;
 import org.jdom2.Element;
 
 /**
@@ -69,6 +70,7 @@ public class MoteInterfaceHandler {
   private PIR myPIR;
   private Position myPosition;
   private Radio myRadio;
+  private SerialPort mySerialPort;
 
   /**
    * Creates new mote interface handler. All given interfaces are created.
@@ -252,6 +254,23 @@ public class MoteInterfaceHandler {
       myRadio = getInterfaceOfType(Radio.class);
     }
     return myRadio;
+  }
+
+  /**
+   * Returns the first serial port interface (if any).
+   *
+   * @return Serial port interface
+   */
+  public SerialPort getSerialPort() {
+    if (mySerialPort == null) {
+      for (var moteInterface : moteInterfaces) {
+        if (moteInterface instanceof SerialPort port) {
+          mySerialPort = port;
+          break;
+        }
+      }
+    }
+    return mySerialPort;
   }
 
   /**

--- a/java/org/contikios/cooja/script/ScriptMote.java
+++ b/java/org/contikios/cooja/script/ScriptMote.java
@@ -29,9 +29,8 @@
  */
 
 package org.contikios.cooja.script;
+
 import org.contikios.cooja.Mote;
-import org.contikios.cooja.interfaces.Log;
-import org.contikios.cooja.interfaces.SerialPort;
 
 /**
  * 
@@ -56,7 +55,6 @@ public class ScriptMote {
 
   public void write(String data) {
     if (mote == null) return;
-    SerialPort serialPort = (SerialPort) mote.getInterfaces().getInterfaceOfType(Log.class);
-    serialPort.writeString(data);
+    mote.getInterfaces().getSerialPort().writeString(data);
   }
 }


### PR DESCRIPTION
There is nothing that ensures a log and a serial port are the same thing, so add an API to get the serial port and use that.