### PR TITLE
MspMoteMemory: take a symbol map

### DIFF
--- a/java/org/contikios/cooja/mspmote/Exp5438Mote.java
+++ b/java/org/contikios/cooja/mspmote/Exp5438Mote.java
@@ -29,10 +29,11 @@
 
 package org.contikios.cooja.mspmote;
 
+import java.util.Map;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
+import org.contikios.cooja.mote.memory.MemoryInterface.Symbol;
 import se.sics.mspsim.platform.GenericNode;
-import se.sics.mspsim.util.MapEntry;
 
 /**
  * @author Fredrik Osterlind
@@ -41,9 +42,9 @@ public class Exp5438Mote extends MspMote {
   public final GenericNode exp5438Node;
   private final String description;
   
-  public Exp5438Mote(MspMoteType moteType, Simulation sim, GenericNode node, String desc, MapEntry[] allEntries)
+  public Exp5438Mote(MspMoteType moteType, Simulation sim, GenericNode node, String desc, Map<String, Symbol> symbols)
           throws MoteType.MoteTypeCreationException {
-    super(moteType, sim, node, allEntries);
+    super(moteType, sim, node, symbols);
     exp5438Node = node;
     description = desc;
   }

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -33,6 +33,7 @@ package org.contikios.cooja.mspmote;
 import java.awt.Component;
 import java.io.File;
 import java.io.PrintStream;
+import java.util.Map;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.Simulation.SimulationStop;
@@ -43,11 +44,11 @@ import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.Watchpoint;
+import org.contikios.cooja.mote.memory.MemoryInterface.Symbol;
 import org.contikios.cooja.motes.AbstractEmulatedMote;
 import org.contikios.cooja.mspmote.plugins.CodeVisualizerSkin;
 import org.contikios.cooja.mspmote.plugins.MspBreakpoint;
 import org.contikios.cooja.plugins.Visualizer;
-
 import se.sics.mspsim.cli.CommandContext;
 import se.sics.mspsim.cli.CommandHandler;
 import se.sics.mspsim.cli.LineListener;
@@ -90,8 +91,8 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
   /* Stack monitoring variables */
   private boolean stopNextInstruction = false;
 
-  public MspMote(MspMoteType moteType, Simulation sim, GenericNode node, MapEntry[] allEntries) throws MoteType.MoteTypeCreationException {
-    super(moteType, new MspMoteMemory(allEntries, node.getCPU()), sim);
+  public MspMote(MspMoteType moteType, Simulation sim, GenericNode node, Map<String, Symbol> symbols) throws MoteType.MoteTypeCreationException {
+    super(moteType, new MspMoteMemory(symbols, node.getCPU()), sim);
     registry = node.getRegistry();
     node.setCommandHandler(commandHandler);
     node.setup(new ConfigManager());

--- a/java/org/contikios/cooja/mspmote/MspMoteMemory.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteMemory.java
@@ -32,29 +32,22 @@ package org.contikios.cooja.mspmote;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
-
 import org.contikios.cooja.mote.memory.MemoryInterface;
 import org.contikios.cooja.mote.memory.MemoryInterface.SegmentMonitor.EventType;
 import org.contikios.cooja.mote.memory.MemoryLayout;
 import se.sics.mspsim.core.MSP430;
 import se.sics.mspsim.core.Memory.AccessMode;
 import se.sics.mspsim.core.Memory.AccessType;
-import se.sics.mspsim.util.MapEntry;
 
 public class MspMoteMemory implements MemoryInterface {
-  private final ArrayList<MapEntry> mapEntries = new ArrayList<>();
+  private final Map<String, Symbol> symbols;
   private final MemoryLayout memLayout = new MemoryLayout(ByteOrder.LITTLE_ENDIAN, MemoryLayout.ARCH_16BIT, 2);
 
   private final MSP430 cpu;
 
-  public MspMoteMemory(MapEntry[] allEntries, MSP430 cpu) {
-    for (MapEntry entry: allEntries) {
-      if (entry.getType() == MapEntry.TYPE.variable) {
-        mapEntries.add(entry);
-      }
-    }
+  public MspMoteMemory(Map<String, Symbol> symbols, MSP430 cpu) {
+    this.symbols = symbols;
     this.cpu = cpu;
   }
 
@@ -106,18 +99,7 @@ public class MspMoteMemory implements MemoryInterface {
 
   @Override
   public Map<String, Symbol> getSymbolMap() {
-    Map<String, Symbol> vars = new HashMap<>();
-    for (MapEntry entry : mapEntries) {
-      if (entry.getType() != MapEntry.TYPE.variable) {
-        continue;
-      }
-      vars.put(entry.getName(), new Symbol(
-              Symbol.Type.VARIABLE,
-              entry.getName(), 
-              entry.getAddress(), 
-              entry.getSize()));
-    }
-    return vars;
+    return symbols;
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/SkyMote.java
+++ b/java/org/contikios/cooja/mspmote/SkyMote.java
@@ -30,10 +30,11 @@
 
 package org.contikios.cooja.mspmote;
 
+import java.util.Map;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
+import org.contikios.cooja.mote.memory.MemoryInterface.Symbol;
 import se.sics.mspsim.platform.sky.SkyNode;
-import se.sics.mspsim.util.MapEntry;
 
 /**
  * @author Fredrik Osterlind
@@ -41,8 +42,8 @@ import se.sics.mspsim.util.MapEntry;
 public class SkyMote extends MspMote {
   public final SkyNode skyNode;
 
-  public SkyMote(MspMoteType moteType, Simulation sim, SkyNode node, MapEntry[] allEntries) throws MoteType.MoteTypeCreationException {
-    super(moteType, sim, node, allEntries);
+  public SkyMote(MspMoteType moteType, Simulation sim, SkyNode node, Map<String, Symbol> symbols) throws MoteType.MoteTypeCreationException {
+    super(moteType, sim, node, symbols);
     skyNode = node;
   }
 

--- a/java/org/contikios/cooja/mspmote/Z1Mote.java
+++ b/java/org/contikios/cooja/mspmote/Z1Mote.java
@@ -29,18 +29,19 @@
  */
 
 package org.contikios.cooja.mspmote;
+import java.util.Map;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
+import org.contikios.cooja.mote.memory.MemoryInterface.Symbol;
 import se.sics.mspsim.platform.z1.Z1Node;
-import se.sics.mspsim.util.MapEntry;
 
 /**
  * @author Fredrik Osterlind, Niclas Finne
  */
 public class Z1Mote extends MspMote {
 
-    public Z1Mote(MspMoteType moteType, Simulation sim, Z1Node node, MapEntry[] allEntries) throws MoteType.MoteTypeCreationException {
-        super(moteType, sim, node, allEntries);
+    public Z1Mote(MspMoteType moteType, Simulation sim, Z1Node node, Map<String, Symbol> symbols) throws MoteType.MoteTypeCreationException {
+        super(moteType, sim, node, symbols);
     }
 
     @Override


### PR DESCRIPTION
This aligns the symbol map handling with
SectionMoteMemory, and avoids regenerating
the symbols for each call to getSymbolMap().