### PR TITLE
Factor out CPU creation from MSP430 motes

### DIFF
--- a/java/org/contikios/cooja/mspmote/Exp5438MoteType.java
+++ b/java/org/contikios/cooja/mspmote/Exp5438MoteType.java
@@ -45,6 +45,7 @@ import org.contikios.cooja.mspmote.interfaces.MspClock;
 import org.contikios.cooja.mspmote.interfaces.MspDebugOutput;
 import org.contikios.cooja.mspmote.interfaces.MspMoteID;
 import org.contikios.cooja.mspmote.interfaces.UsciA1Serial;
+import se.sics.mspsim.core.MSP430;
 import se.sics.mspsim.platform.GenericNode;
 import se.sics.mspsim.platform.ti.Exp1101Node;
 import se.sics.mspsim.platform.ti.Exp1120Node;
@@ -63,23 +64,30 @@ public class Exp5438MoteType extends MspMoteType {
     String filename = fileELF.getName();
     final GenericNode exp5438Node;
     final String desc;
+    final MSP430 cpu;
     if (filename.endsWith(".exp1101")) {
-      exp5438Node = new Exp1101Node();
+      cpu = Exp1101Node.makeCPU(Exp1101Node.makeChipConfig());
+      exp5438Node = new Exp1101Node(cpu);
       desc = "Exp5438+CC1101";
     } else if (filename.endsWith(".exp1120")) {
-      exp5438Node = new Exp1120Node();
+      cpu = Exp1120Node.makeCPU(Exp1120Node.makeChipConfig());
+      exp5438Node = new Exp1120Node(cpu);
       desc = "Exp5438+CC1120";
     } else if (filename.endsWith(".trxeb2520")) {
-      exp5438Node = new Trxeb2520Node();
+      cpu = Trxeb2520Node.makeCPU(Trxeb2520Node.makeChipConfig());
+      exp5438Node = new Trxeb2520Node(cpu);
       desc = "Trxeb2520";
     } else if (filename.endsWith(".trxeb1120")) {
-      exp5438Node = new Trxeb1120Node(false);
+      cpu = Trxeb1120Node.makeCPU(Trxeb1120Node.makeChipConfig());
+      exp5438Node = new Trxeb1120Node(false, cpu);
       desc = "Trxeb1120";
     } else if (filename.endsWith(".eth1120")) {
-      exp5438Node = new Trxeb1120Node(true);
+      cpu = Trxeb1120Node.makeCPU(Trxeb1120Node.makeChipConfig());
+      exp5438Node = new Trxeb1120Node(true, cpu);
       desc = "Eth1120";
     } else if (filename.endsWith(".exp2420") || filename.endsWith(".exp5438")) {
-      exp5438Node = new Exp5438Node();
+      cpu = Exp5438Node.makeCPU(Exp5438Node.makeChipConfig());
+      exp5438Node = new Exp5438Node(cpu);
       desc = "Exp5438+CC2420";
     } else {
       throw new IllegalStateException("Unknown file extension, cannot figure out what MSPSim node type to use: " + filename);

--- a/java/org/contikios/cooja/mspmote/SkyMoteType.java
+++ b/java/org/contikios/cooja/mspmote/SkyMoteType.java
@@ -58,8 +58,9 @@ public class SkyMoteType extends MspMoteType {
 
   @Override
   public MspMote generateMote(Simulation simulation) throws MoteTypeCreationException {
-    var node = new SkyNode();
-    node.setFlash(new CoojaM25P80(node.getCPU()));
+    var cpu = SkyNode.makeCPU(SkyNode.makeChipConfig());
+    var node = new SkyNode(cpu);
+    node.setFlash(new CoojaM25P80(cpu));
     return new SkyMote(this, simulation, node);
   }
 

--- a/java/org/contikios/cooja/mspmote/Z1MoteType.java
+++ b/java/org/contikios/cooja/mspmote/Z1MoteType.java
@@ -69,8 +69,9 @@ public class Z1MoteType extends MspMoteType {
 
     @Override
     public MspMote generateMote(Simulation simulation) throws MoteTypeCreationException {
-        var node = new Z1Node();
-        node.setFlash(new CoojaM25P80(node.getCPU()));
+        var cpu = Z1Node.makeCPU(Z1Node.makeChipConfig());
+        var node = new Z1Node(cpu);
+        node.setFlash(new CoojaM25P80(cpu));
         return new Z1Mote(this, simulation, node);
     }
 

--- a/java/se/sics/mspsim/Main.java
+++ b/java/se/sics/mspsim/Main.java
@@ -64,21 +64,60 @@ public class Main {
 
   public static GenericNode createNode(String className) {
     return switch (className) { // Sorted alphabetically.
-      case "se.sics.mspsim.platform.esb.ESBNode" -> new ESBNode();
-      case "se.sics.mspsim.platform.jcreate.JCreateNode" -> new JCreateNode();
-      case "se.sics.mspsim.platform.sentillausb.SentillaUSBNode" -> new SentillaUSBNode();
+      case "se.sics.mspsim.platform.esb.ESBNode" -> {
+        var cpu = ESBNode.makeCPU(ESBNode.makeChipConfig());
+        yield new ESBNode(cpu);
+      }
+      case "se.sics.mspsim.platform.jcreate.JCreateNode" -> {
+        var cpu = JCreateNode.makeCPU(JCreateNode.makeChipConfig());
+        yield new JCreateNode(cpu);
+      }
+      case "se.sics.mspsim.platform.sentillausb.SentillaUSBNode" -> {
+        var cpu = SentillaUSBNode.makeCPU(SentillaUSBNode.makeChipConfig());
+        yield new SentillaUSBNode(cpu);
+      }
       case "se.sics.mspsim.platform.ti.CC430Node" -> new CC430Node();
-      case "se.sics.mspsim.platform.ti.Exp1101Node" -> new Exp1101Node();
-      case "se.sics.mspsim.platform.ti.Exp1120Node" -> new Exp1120Node();
-      case "se.sics.mspsim.platform.ti.Exp5438Node" -> new Exp5438Node();
+      case "se.sics.mspsim.platform.ti.Exp1101Node" -> {
+        var cpu = Exp1101Node.makeCPU(Exp1101Node.makeChipConfig());
+        yield new Exp1101Node(cpu);
+      }
+      case "se.sics.mspsim.platform.ti.Exp1120Node" -> {
+        var cpu = Exp1120Node.makeCPU(Exp1120Node.makeChipConfig());
+        yield new Exp1120Node(cpu);
+      }
+      case "se.sics.mspsim.platform.ti.Exp5438Node" -> {
+        var cpu = Exp5438Node.makeCPU(Exp5438Node.makeChipConfig());
+        yield new Exp5438Node(cpu);
+      }
       // Default to the Trxeb1120 node without ethernet.
-      case "java.se.sics.mspsim.platform.ti.Trxeb1120Node.java" -> new Trxeb1120Node(false);
-      case "java.se.sics.mspsim.platform.ti.Trxeb2520Node.java" -> new Trxeb2520Node();
-      case "java.se.sics.mspsim.platform.sky.SkyNode.java" -> new SkyNode();
-      case "java.se.sics.mspsim.platform.sky.TelosNode.java" -> new TelosNode();
-      case "java.se.sics.mspsim.platform.tyndall.TyndallNode.java" -> new TyndallNode();
-      case "java.se.sics.mspsim.platform.wismote.WismoteNode.java" -> new WismoteNode();
-      case "java.se.sics.mspsim.platform.z1.Z1Node.java" -> new Z1Node();
+      case "java.se.sics.mspsim.platform.ti.Trxeb1120Node.java" -> {
+        var cpu = Trxeb1120Node.makeCPU(Trxeb1120Node.makeChipConfig());
+        yield new Trxeb1120Node(false, cpu);
+      }
+      case "java.se.sics.mspsim.platform.ti.Trxeb2520Node.java" -> {
+        var cpu = Trxeb2520Node.makeCPU(Trxeb2520Node.makeChipConfig());
+        yield new Trxeb2520Node(cpu);
+      }
+      case "java.se.sics.mspsim.platform.sky.SkyNode.java" -> {
+        var cpu = SkyNode.makeCPU(SkyNode.makeChipConfig());
+        yield new SkyNode(cpu);
+      }
+      case "java.se.sics.mspsim.platform.sky.TelosNode.java" -> {
+        var cpu = TelosNode.makeCPU(TelosNode.makeChipConfig());
+        yield new TelosNode(cpu);
+      }
+      case "java.se.sics.mspsim.platform.tyndall.TyndallNode.java" -> {
+        var cpu = TyndallNode.makeCPU(TyndallNode.makeChipConfig());
+        yield new TyndallNode(cpu);
+      }
+      case "java.se.sics.mspsim.platform.wismote.WismoteNode.java" -> {
+        var cpu = WismoteNode.makeCPU(WismoteNode.makeChipConfig());
+        yield new WismoteNode(cpu);
+      }
+      case "java.se.sics.mspsim.platform.z1.Z1Node.java" -> {
+        var cpu = Z1Node.makeCPU(Z1Node.makeChipConfig());
+        yield new Z1Node(cpu);
+      }
       default -> {
         try {
           yield Class.forName(className).asSubclass(GenericNode.class).getDeclaredConstructor().newInstance();

--- a/java/se/sics/mspsim/platform/GenericNode.java
+++ b/java/se/sics/mspsim/platform/GenericNode.java
@@ -79,10 +79,17 @@ public abstract class GenericNode extends Chip implements Runnable {
   protected String firmwareFile = null;
   protected OperatingModeStatistics stats;
 
+  public static MSP430 makeCPU(MSP430Config config) {
+    return new MSP430(new ComponentRegistry(), config);
+  }
 
   public GenericNode(String id, MSP430Config config) {
-    super(id, new MSP430(new ComponentRegistry(), config));
-    this.cpu = (MSP430)super.cpu;
+    this(id, makeCPU(config));
+  }
+
+  public GenericNode(String id, MSP430 cpu) {
+    super(id, cpu);
+    this.cpu = cpu;
     this.registry = cpu.getRegistry();
   }
 

--- a/java/se/sics/mspsim/platform/esb/ESBNode.java
+++ b/java/se/sics/mspsim/platform/esb/ESBNode.java
@@ -46,6 +46,7 @@ import se.sics.mspsim.config.MSP430f149Config;
 import se.sics.mspsim.core.EmulationException;
 import se.sics.mspsim.core.IOPort;
 import se.sics.mspsim.core.MSP430;
+import se.sics.mspsim.core.MSP430Config;
 import se.sics.mspsim.core.PortListener;
 import se.sics.mspsim.core.USART;
 import se.sics.mspsim.extutil.jfreechart.DataChart;
@@ -83,12 +84,16 @@ public class ESBNode extends GenericNode implements PortListener {
   private Beeper beeper;
   private ESBGui gui;
 
+  public static MSP430Config makeChipConfig() {
+    return new MSP430f149Config();
+  }
+
   /**
    * Creates a new <code>ESBNode</code> instance.
    *
    */
-  public ESBNode() {
-      super("ESB", new MSP430f149Config());
+  public ESBNode(MSP430 cpu) {
+      super("ESB", cpu);
   }
 
   public Leds getLeds() {
@@ -217,7 +222,7 @@ public class ESBNode extends GenericNode implements PortListener {
   }
 
   public static void main(String[] args) throws IOException {
-    ESBNode node = new ESBNode();
+    ESBNode node = new ESBNode(ESBNode.makeCPU(ESBNode.makeChipConfig()));
     ArgumentManager config = new ArgumentManager();
     config.handleArguments(args);
     node.setupArgs(config);

--- a/java/se/sics/mspsim/platform/jcreate/JCreateNode.java
+++ b/java/se/sics/mspsim/platform/jcreate/JCreateNode.java
@@ -47,6 +47,7 @@ import se.sics.mspsim.chip.M25P80;
 import se.sics.mspsim.chip.MMA7260QT;
 import se.sics.mspsim.core.ADC12;
 import se.sics.mspsim.core.IOPort;
+import se.sics.mspsim.core.MSP430;
 import se.sics.mspsim.core.USARTSource;
 import se.sics.mspsim.platform.sky.CC2420Node;
 import se.sics.mspsim.util.ArgumentManager;
@@ -70,8 +71,8 @@ public class JCreateNode extends CC2420Node {
 
     private JCreateGui gui;
 
-    public JCreateNode() {
-        super("Sentilla JCreate");
+    public JCreateNode(MSP430 cpu) {
+        super("Sentilla JCreate", cpu);
         setMode(MODE_LEDS_OFF);
     }
 
@@ -167,7 +168,7 @@ public class JCreateNode extends CC2420Node {
     }
 
     public static void main(String[] args) throws IOException {
-        JCreateNode node = new JCreateNode();
+        JCreateNode node = new JCreateNode(makeCPU(makeChipConfig()));
         ArgumentManager config = new ArgumentManager();
         config.handleArguments(args);
         node.setupArgs(config);

--- a/java/se/sics/mspsim/platform/sentillausb/SentillaUSBNode.java
+++ b/java/se/sics/mspsim/platform/sentillausb/SentillaUSBNode.java
@@ -45,6 +45,7 @@ import se.sics.mspsim.chip.FileStorage;
 import se.sics.mspsim.chip.Leds;
 import se.sics.mspsim.chip.M25P80;
 import se.sics.mspsim.core.IOPort;
+import se.sics.mspsim.core.MSP430;
 import se.sics.mspsim.core.USARTSource;
 import se.sics.mspsim.platform.sky.CC2420Node;
 import se.sics.mspsim.util.ArgumentManager;
@@ -70,8 +71,8 @@ public class SentillaUSBNode extends CC2420Node {
     boolean redLed;
     boolean greenLed;
 
-    public SentillaUSBNode() {
-        super("Sentilla USB");
+    public SentillaUSBNode(MSP430 cpu) {
+        super("Sentilla USB", cpu);
         setMode(MODE_LEDS_OFF);
     }
 
@@ -143,7 +144,7 @@ public class SentillaUSBNode extends CC2420Node {
     }
 
     public static void main(String[] args) throws IOException {
-        SentillaUSBNode node = new SentillaUSBNode();
+        SentillaUSBNode node = new SentillaUSBNode(makeCPU(makeChipConfig()));
         ArgumentManager config = new ArgumentManager();
         config.handleArguments(args);
         node.setupArgs(config);

--- a/java/se/sics/mspsim/platform/sky/CC2420Node.java
+++ b/java/se/sics/mspsim/platform/sky/CC2420Node.java
@@ -5,6 +5,7 @@ import se.sics.mspsim.chip.PacketListener;
 import se.sics.mspsim.config.MSP430f1611Config;
 import se.sics.mspsim.core.IOPort;
 import se.sics.mspsim.core.MSP430;
+import se.sics.mspsim.core.MSP430Config;
 import se.sics.mspsim.core.PortListener;
 import se.sics.mspsim.core.USART;
 import se.sics.mspsim.core.USARTListener;
@@ -46,9 +47,13 @@ public abstract class CC2420Node extends GenericNode implements PortListener, US
 
     protected String flashFile;
 
-    public CC2420Node(String id) {
-        /* this should be a config for the MSP430x1611 */
-        super(id, new MSP430f1611Config());
+    public static MSP430Config makeChipConfig() {
+        // FIXME: this should be a config for the MSP430x1611.
+        return new MSP430f1611Config();
+    }
+
+    public CC2420Node(String id, MSP430 cpu) {
+        super(id, cpu);
     }
 
     public void setDebug(boolean debug) {

--- a/java/se/sics/mspsim/platform/sky/MoteIVNode.java
+++ b/java/se/sics/mspsim/platform/sky/MoteIVNode.java
@@ -3,6 +3,7 @@ import se.sics.mspsim.chip.Button;
 import se.sics.mspsim.chip.Leds;
 import se.sics.mspsim.chip.SHT11;
 import se.sics.mspsim.core.IOPort;
+import se.sics.mspsim.core.MSP430;
 
 public abstract class MoteIVNode extends CC2420Node {
 
@@ -35,8 +36,8 @@ public abstract class MoteIVNode extends CC2420Node {
 
   public SkyGui gui;
 
-  public MoteIVNode(String id) {
-    super(id);
+  public MoteIVNode(String id, MSP430 cpu) {
+    super(id, cpu);
     setMode(MODE_LEDS_OFF);
   }
 

--- a/java/se/sics/mspsim/platform/sky/SkyNode.java
+++ b/java/se/sics/mspsim/platform/sky/SkyNode.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import se.sics.mspsim.chip.FileStorage;
 import se.sics.mspsim.chip.M25P80;
 import se.sics.mspsim.core.IOPort;
+import se.sics.mspsim.core.MSP430;
 import se.sics.mspsim.core.USARTSource;
 import se.sics.mspsim.util.ArgumentManager;
 
@@ -58,8 +59,8 @@ public class SkyNode extends MoteIVNode {
    * Creates a new <code>SkyNode</code> instance.
    *
    */
-  public SkyNode() {
-    super("Tmote Sky");
+  public SkyNode(MSP430 cpu) {
+    super("Tmote Sky", cpu);
   }
 
   public M25P80 getFlash() {
@@ -99,10 +100,9 @@ public class SkyNode extends MoteIVNode {
   }
 
   public static void main(String[] args) throws IOException {
-    SkyNode node = new SkyNode();
+    SkyNode node = new SkyNode(makeCPU(makeChipConfig()));
     ArgumentManager config = new ArgumentManager();
     config.handleArguments(args);
     node.setupArgs(config);
   }
-
 }

--- a/java/se/sics/mspsim/platform/sky/TelosNode.java
+++ b/java/se/sics/mspsim/platform/sky/TelosNode.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import se.sics.mspsim.chip.AT45DB;
 import se.sics.mspsim.chip.FileStorage;
 import se.sics.mspsim.core.IOPort;
+import se.sics.mspsim.core.MSP430;
 import se.sics.mspsim.core.USARTSource;
 import se.sics.mspsim.util.ArgumentManager;
 
@@ -64,8 +65,8 @@ public class TelosNode extends MoteIVNode {
    * Creates a new <code>TelosNode</code> instance.
    *
    */
-  public TelosNode() {
-    super("Telos");
+  public TelosNode(MSP430 cpu) {
+    super("Telos", cpu);
   }
 
   public AT45DB getFlash() {
@@ -101,7 +102,7 @@ public class TelosNode extends MoteIVNode {
   }
 
   public static void main(String[] args) throws IOException {
-    TelosNode node = new TelosNode();
+    TelosNode node = new TelosNode(makeCPU(makeChipConfig()));
     ArgumentManager config = new ArgumentManager();
     config.handleArguments(args);
     node.setupArgs(config);

--- a/java/se/sics/mspsim/platform/ti/Exp1101Node.java
+++ b/java/se/sics/mspsim/platform/ti/Exp1101Node.java
@@ -7,6 +7,8 @@ import se.sics.mspsim.config.MSP430f5437Config;
 import se.sics.mspsim.core.EmulationException;
 import se.sics.mspsim.core.IOPort;
 import se.sics.mspsim.core.IOUnit;
+import se.sics.mspsim.core.MSP430;
+import se.sics.mspsim.core.MSP430Config;
 import se.sics.mspsim.core.PortListener;
 import se.sics.mspsim.core.USARTListener;
 import se.sics.mspsim.core.USARTSource;
@@ -33,8 +35,12 @@ public class Exp1101Node extends GenericNode implements PortListener, USARTListe
 
     public CC1101 radio;
 
-    public Exp1101Node() {
-        super("Exp1101", new MSP430f5437Config());
+    public static MSP430Config makeChipConfig() {
+        return new MSP430f5437Config();
+    }
+
+    public Exp1101Node(MSP430 cpu) {
+        super("Exp1101", cpu);
     }
 
     @Override
@@ -105,7 +111,7 @@ public class Exp1101Node extends GenericNode implements PortListener, USARTListe
     }
 
     public static void main(String[] args) throws IOException {
-        Exp1101Node node = new Exp1101Node();
+        Exp1101Node node = new Exp1101Node(makeCPU(makeChipConfig()));
         ArgumentManager config = new ArgumentManager();
         config.handleArguments(args);
         node.setupArgs(config);

--- a/java/se/sics/mspsim/platform/ti/Exp1120Node.java
+++ b/java/se/sics/mspsim/platform/ti/Exp1120Node.java
@@ -7,6 +7,8 @@ import se.sics.mspsim.config.MSP430f5437Config;
 import se.sics.mspsim.core.EmulationException;
 import se.sics.mspsim.core.IOPort;
 import se.sics.mspsim.core.IOUnit;
+import se.sics.mspsim.core.MSP430;
+import se.sics.mspsim.core.MSP430Config;
 import se.sics.mspsim.core.PortListener;
 import se.sics.mspsim.core.USARTListener;
 import se.sics.mspsim.core.USARTSource;
@@ -33,8 +35,12 @@ public class Exp1120Node extends GenericNode implements PortListener, USARTListe
 
         public CC1120 radio;
 
-        public Exp1120Node() {
-                super("Exp1120", new MSP430f5437Config());
+        public static MSP430Config makeChipConfig() {
+                return new MSP430f5437Config();
+        }
+
+        public Exp1120Node(MSP430 cpu) {
+                super("Exp1120", cpu);
         }
 
         @Override
@@ -105,7 +111,7 @@ public class Exp1120Node extends GenericNode implements PortListener, USARTListe
         }
 
         public static void main(String[] args) throws IOException {
-                Exp1120Node node = new Exp1120Node();
+                Exp1120Node node = new Exp1120Node(makeCPU(makeChipConfig()));
                 ArgumentManager config = new ArgumentManager();
                 config.handleArguments(args);
                 node.setupArgs(config);

--- a/java/se/sics/mspsim/platform/ti/Exp5438Node.java
+++ b/java/se/sics/mspsim/platform/ti/Exp5438Node.java
@@ -6,6 +6,8 @@ import se.sics.mspsim.config.MSP430f5437Config;
 import se.sics.mspsim.core.EmulationException;
 import se.sics.mspsim.core.IOPort;
 import se.sics.mspsim.core.IOUnit;
+import se.sics.mspsim.core.MSP430;
+import se.sics.mspsim.core.MSP430Config;
 import se.sics.mspsim.core.PortListener;
 import se.sics.mspsim.core.USARTListener;
 import se.sics.mspsim.core.USARTSource;
@@ -38,9 +40,13 @@ public class Exp5438Node extends GenericNode implements PortListener, USARTListe
 
     public CC2420 radio;
 
-    public Exp5438Node() {
-        /* TODO XXX MSP430F5438 */
-        super("Exp5438", new MSP430f5437Config());
+    public static MSP430Config makeChipConfig() {
+        // TODO: MSP430F5438
+        return new MSP430f5437Config();
+    }
+
+    public Exp5438Node(MSP430 cpu) {
+        super("Exp5438", cpu);
     }
 
     @Override
@@ -119,7 +125,7 @@ public class Exp5438Node extends GenericNode implements PortListener, USARTListe
     }
 
     public static void main(String[] args) throws IOException {
-        Exp5438Node node = new Exp5438Node();
+        Exp5438Node node = new Exp5438Node(makeCPU(makeChipConfig()));
         ArgumentManager config = new ArgumentManager();
         config.handleArguments(args);
         node.setupArgs(config);

--- a/java/se/sics/mspsim/platform/ti/Trxeb1120Node.java
+++ b/java/se/sics/mspsim/platform/ti/Trxeb1120Node.java
@@ -6,6 +6,8 @@ import se.sics.mspsim.config.MSP430f5437Config;
 import se.sics.mspsim.core.EmulationException;
 import se.sics.mspsim.core.IOPort;
 import se.sics.mspsim.core.IOUnit;
+import se.sics.mspsim.core.MSP430;
+import se.sics.mspsim.core.MSP430Config;
 import se.sics.mspsim.core.PortListener;
 import se.sics.mspsim.core.USARTListener;
 import se.sics.mspsim.core.USARTSource;
@@ -35,9 +37,12 @@ public class Trxeb1120Node extends GenericNode implements PortListener, USARTLis
 
         private final boolean withEnc;
 
-        public Trxeb1120Node(boolean withEnc) {
-                super("Trxeb1120", new MSP430f5437Config());
+        public static MSP430Config makeChipConfig() {
+                return new MSP430f5437Config();
+        }
 
+        public Trxeb1120Node(boolean withEnc, MSP430 cpu) {
+                super("Trxeb1120", cpu);
                 this.withEnc = withEnc;
         }
 

--- a/java/se/sics/mspsim/platform/ti/Trxeb2520Node.java
+++ b/java/se/sics/mspsim/platform/ti/Trxeb2520Node.java
@@ -7,6 +7,8 @@ import se.sics.mspsim.config.MSP430f5437Config;
 import se.sics.mspsim.core.EmulationException;
 import se.sics.mspsim.core.IOPort;
 import se.sics.mspsim.core.IOUnit;
+import se.sics.mspsim.core.MSP430;
+import se.sics.mspsim.core.MSP430Config;
 import se.sics.mspsim.core.PortListener;
 import se.sics.mspsim.core.USARTListener;
 import se.sics.mspsim.core.USARTSource;
@@ -37,8 +39,12 @@ public class Trxeb2520Node extends GenericNode implements PortListener, USARTLis
 
         public CC2520 radio;
 
-        public Trxeb2520Node() {
-                super("Trxeb2520", new MSP430f5437Config());
+    public static MSP430Config makeChipConfig() {
+        return new MSP430f5437Config();
+    }
+
+        public Trxeb2520Node(MSP430 cpu) {
+                super("Trxeb2520", cpu);
         }
 
         @Override
@@ -107,7 +113,7 @@ public class Trxeb2520Node extends GenericNode implements PortListener, USARTLis
         }
 
         public static void main(String[] args) throws IOException {
-                Trxeb2520Node node = new Trxeb2520Node();
+                Trxeb2520Node node = new Trxeb2520Node(makeCPU(makeChipConfig()));
                 ArgumentManager config = new ArgumentManager();
                 config.handleArguments(args);
                 node.setupArgs(config);

--- a/java/se/sics/mspsim/platform/tyndall/TyndallNode.java
+++ b/java/se/sics/mspsim/platform/tyndall/TyndallNode.java
@@ -6,6 +6,8 @@ import se.sics.mspsim.config.MSP430f5437Config;
 import se.sics.mspsim.core.EmulationException;
 import se.sics.mspsim.core.IOPort;
 import se.sics.mspsim.core.IOUnit;
+import se.sics.mspsim.core.MSP430;
+import se.sics.mspsim.core.MSP430Config;
 import se.sics.mspsim.core.PortListener;
 import se.sics.mspsim.core.USARTListener;
 import se.sics.mspsim.core.USARTSource;
@@ -45,9 +47,12 @@ public class TyndallNode extends GenericNode implements PortListener, USARTListe
     //private String flashFile;
     public CC2420 radio;
 
+    public static MSP430Config makeChipConfig() {
+        return new MSP430f5437Config();
+    }
 
-    public TyndallNode() {
-        super("Tyndall", new MSP430f5437Config());
+    public TyndallNode(MSP430 cpu) {
+        super("Tyndall", cpu);
     }
 
 //    public M25P80 getFlash() {
@@ -169,7 +174,7 @@ public class TyndallNode extends GenericNode implements PortListener, USARTListe
     }
 
     public static void main(String[] args) throws IOException {
-        TyndallNode node = new TyndallNode();
+        TyndallNode node = new TyndallNode(TyndallNode.makeCPU(TyndallNode.makeChipConfig()));
         ArgumentManager config = new ArgumentManager();
         config.handleArguments(args);
         node.setupArgs(config);

--- a/java/se/sics/mspsim/platform/wismote/WismoteNode.java
+++ b/java/se/sics/mspsim/platform/wismote/WismoteNode.java
@@ -44,6 +44,8 @@ import se.sics.mspsim.config.MSP430f5437Config;
 import se.sics.mspsim.core.EmulationException;
 import se.sics.mspsim.core.IOPort;
 import se.sics.mspsim.core.IOUnit;
+import se.sics.mspsim.core.MSP430;
+import se.sics.mspsim.core.MSP430Config;
 import se.sics.mspsim.core.PortListener;
 import se.sics.mspsim.core.USARTListener;
 import se.sics.mspsim.core.USARTSource;
@@ -95,8 +97,12 @@ public class WismoteNode extends GenericNode implements PortListener, USARTListe
     private WismoteGui gui;
     private DS2411 ds2411;
 
-    public WismoteNode() {
-        super("Wismote", new MSP430f5437Config());
+    public static MSP430Config makeChipConfig() {
+        return new MSP430f5437Config();
+    }
+
+    public WismoteNode(MSP430 cpu) {
+        super("Wismote", cpu);
     }
 
     public Leds getLeds() {
@@ -231,7 +237,7 @@ public class WismoteNode extends GenericNode implements PortListener, USARTListe
     }
 
     public static void main(String[] args) throws IOException {
-        WismoteNode node = new WismoteNode();
+        WismoteNode node = new WismoteNode(WismoteNode.makeCPU(WismoteNode.makeChipConfig()));
         ArgumentManager config = new ArgumentManager();
         config.handleArguments(args);
         node.setupArgs(config);

--- a/java/se/sics/mspsim/platform/z1/Z1Node.java
+++ b/java/se/sics/mspsim/platform/z1/Z1Node.java
@@ -10,6 +10,8 @@ import se.sics.mspsim.config.MSP430f2617Config;
 import se.sics.mspsim.core.EmulationException;
 import se.sics.mspsim.core.IOPort;
 import se.sics.mspsim.core.IOUnit;
+import se.sics.mspsim.core.MSP430;
+import se.sics.mspsim.core.MSP430Config;
 import se.sics.mspsim.core.PortListener;
 import se.sics.mspsim.core.USARTListener;
 import se.sics.mspsim.core.USARTSource;
@@ -69,8 +71,12 @@ public class Z1Node extends GenericNode implements PortListener, USARTListener {
     private M25P80 flash;
     private String flashFile;
 
-    public Z1Node() {
-        super("Z1", new MSP430f2617Config());
+    public static MSP430Config makeChipConfig() {
+        return new MSP430f2617Config();
+    }
+
+    public Z1Node(MSP430 cpu) {
+        super("Z1", cpu);
         setMode(MODE_LEDS_OFF);
     }
 
@@ -227,7 +233,7 @@ public class Z1Node extends GenericNode implements PortListener, USARTListener {
     }
 
     public static void main(String[] args) throws IOException {
-        Z1Node node = new Z1Node();
+        Z1Node node = new Z1Node(makeCPU(makeChipConfig()));
         ArgumentManager config = new ArgumentManager();
         config.handleArguments(args);
         node.setupArgs(config);


### PR DESCRIPTION
All subclasses of Chip, such as flash,
requires a cpu for construction. Factor
out the CPU creation, so SkyNode & friends
can get the flash as a parameter to the
constructor.
