### PR TITLE
Use getChannel() fewer times

### DIFF
--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiRadio.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiRadio.java
@@ -331,8 +331,9 @@ public class ContikiRadio extends Radio implements PolledAfterActiveTicks {
     }
 
     /* Check if radio channel changed */
-    if (getChannel() != oldRadioChannel) {
-      oldRadioChannel = getChannel();
+    var currentChannel = getChannel();
+    if (currentChannel != oldRadioChannel) {
+      oldRadioChannel = currentChannel;
       lastEvent = RadioEvent.UNKNOWN;
       this.setChanged();
       this.notifyObservers();

--- a/java/org/contikios/cooja/interfaces/ApplicationRadio.java
+++ b/java/org/contikios/cooja/interfaces/ApplicationRadio.java
@@ -315,11 +315,8 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
         setChannel(Integer.parseInt(s));
       }
     });
-    if (getChannel() == -1) {
-      channelMenu.setSelectedIndex(0);
-    } else {
-      channelMenu.setSelectedIndex(getChannel());
-    }
+    var currentChannel = getChannel();
+    channelMenu.setSelectedIndex(currentChannel == -1 ? 0 : currentChannel);
     final JFormattedTextField outputPower = new JFormattedTextField(getCurrentOutputPower());
     outputPower.addPropertyChangeListener("value", evt -> setOutputPower(((Number)outputPower.getValue()).doubleValue()));
 
@@ -347,11 +344,8 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
       lastEventLabel.setText("Last event (time=" + lastEventTime + "): " + lastEvent);
       ssLabel.setText("Signal strength (not auto-updated): "
           + String.format("%1.1f", getCurrentSignalStrength()) + " dBm");
-      if (getChannel() == -1) {
-        channelLabel.setText("Current channel: ALL");
-      } else {
-        channelLabel.setText("Current channel: " + getChannel());
-      }
+      var infoChannel = getChannel();
+      channelLabel.setText("Current channel: " + (infoChannel == -1 ? "ALL" : String.valueOf(infoChannel)));
     };
     this.addObserver(observer);
 

--- a/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
+++ b/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
@@ -151,9 +151,9 @@ public abstract class AbstractRadioMedium implements RadioMedium {
 				conn.getSource().setCurrentSignalStrength(SS_STRONG);
 			}
 			for (Radio dstRadio : conn.getDestinations()) {
-				if (conn.getSource().getChannel() >= 0 &&
-						dstRadio.getChannel() >= 0 &&
-						conn.getSource().getChannel() != dstRadio.getChannel()) {
+        var sourceChannel = conn.getSource().getChannel();
+        var dstChannel = dstRadio.getChannel();
+        if (sourceChannel >= 0 && dstChannel >= 0 && sourceChannel != dstChannel) {
 					continue;
 				}
 				if (dstRadio.getCurrentSignalStrength() < SS_STRONG) {
@@ -168,9 +168,9 @@ public abstract class AbstractRadioMedium implements RadioMedium {
 				if (intfRadio.getCurrentSignalStrength() < SS_STRONG) {
 					intfRadio.setCurrentSignalStrength(SS_STRONG);
 				}
-				if (conn.getSource().getChannel() >= 0 &&
-						intfRadio.getChannel() >= 0 &&
-						conn.getSource().getChannel() != intfRadio.getChannel()) {
+        var srcChannel = conn.getSource().getChannel();
+        var intfChannel = intfRadio.getChannel();
+        if (srcChannel >= 0 && intfChannel >= 0 && srcChannel != intfChannel) {
 					continue;
 				}
 				if (!intfRadio.isInterfered()) {

--- a/java/org/contikios/cooja/radiomediums/LogisticLoss.java
+++ b/java/org/contikios/cooja/radiomediums/LogisticLoss.java
@@ -237,11 +237,10 @@ public class LogisticLoss extends AbstractRadioMedium {
         for (DestinationRadio dest: potentialDestinations) {
             Radio recv = dest.radio;
 
-            /* Fail if radios are on different (but configured) channels */ 
-            if (sender.getChannel() >= 0 &&
-                    recv.getChannel() >= 0 &&
-                    sender.getChannel() != recv.getChannel()) {
-
+            /* Fail if radios are on different (but configured) channels */
+            var srcChannel = sender.getChannel();
+            var dstChannel = recv.getChannel();
+            if (srcChannel >= 0 && dstChannel >= 0 && srcChannel != dstChannel) {
                 /* Add the connection in a dormant state;
                    it will be activated later when the radio will be
                    turned on and switched to the right channel. This behavior
@@ -406,10 +405,9 @@ public class LogisticLoss extends AbstractRadioMedium {
                 conn.getSource().setCurrentSignalStrength(SS_STRONG);
             }
             for (Radio dstRadio : conn.getDestinations()) {
-
-                if (conn.getSource().getChannel() >= 0 &&
-                        dstRadio.getChannel() >= 0 &&
-                        conn.getSource().getChannel() != dstRadio.getChannel()) {
+                var srcChannel = conn.getSource().getChannel();
+                var dstChannel = dstRadio.getChannel();
+                if (srcChannel >= 0 && dstChannel >= 0 && srcChannel != dstChannel) {
                     continue;
                 }
 
@@ -423,9 +421,9 @@ public class LogisticLoss extends AbstractRadioMedium {
         /* Set signal strength to below weak on interfered */
         for (RadioConnection conn : conns) {
             for (Radio intfRadio : conn.getInterfered()) {
-                if (conn.getSource().getChannel() >= 0 &&
-                        intfRadio.getChannel() >= 0 &&
-                        conn.getSource().getChannel() != intfRadio.getChannel()) {
+                var srcChannel = conn.getSource().getChannel();
+                var intfChannel = intfRadio.getChannel();
+                if (srcChannel >= 0 && intfChannel >= 0 && srcChannel != intfChannel) {
                     continue;
                 }
 

--- a/java/org/contikios/cooja/radiomediums/UDGM.java
+++ b/java/org/contikios/cooja/radiomediums/UDGM.java
@@ -175,11 +175,10 @@ public class UDGM extends AbstractRadioMedium {
     for (DestinationRadio dest: potentialDestinations) {
       Radio recv = dest.radio;
 
-      /* Fail if radios are on different (but configured) channels */ 
-      if (sender.getChannel() >= 0 &&
-          recv.getChannel() >= 0 &&
-          sender.getChannel() != recv.getChannel()) {
-
+      /* Fail if radios are on different (but configured) channels */
+      var srcChannel = sender.getChannel();
+      var dstChannel = recv.getChannel();
+      if (srcChannel >= 0 && dstChannel >= 0 && srcChannel != dstChannel) {
         /* Add the connection in a dormant state;
            it will be activated later when the radio will be
            turned on and switched to the right channel. This behavior
@@ -281,9 +280,9 @@ public class UDGM extends AbstractRadioMedium {
         conn.getSource().setCurrentSignalStrength(SS_STRONG);
       }
       for (Radio dstRadio : conn.getDestinations()) {
-        if (conn.getSource().getChannel() >= 0 &&
-            dstRadio.getChannel() >= 0 &&
-            conn.getSource().getChannel() != dstRadio.getChannel()) {
+        var srcChannel = conn.getSource().getChannel();
+        var dstChannel = dstRadio.getChannel();
+        if (srcChannel >= 0 && dstChannel >= 0 && srcChannel != dstChannel) {
           continue;
         }
 
@@ -303,9 +302,9 @@ public class UDGM extends AbstractRadioMedium {
     /* Set signal strength to below weak on interfered */
     for (RadioConnection conn : conns) {
       for (Radio intfRadio : conn.getInterfered()) {
-        if (conn.getSource().getChannel() >= 0 &&
-            intfRadio.getChannel() >= 0 &&
-            conn.getSource().getChannel() != intfRadio.getChannel()) {
+        var srcChannel = conn.getSource().getChannel();
+        var intfChannel = intfRadio.getChannel();
+        if (srcChannel >= 0 && intfChannel >= 0 && srcChannel != intfChannel) {
           continue;
         }
 

--- a/java/org/contikios/mrm/MRM.java
+++ b/java/org/contikios/mrm/MRM.java
@@ -158,10 +158,10 @@ public class MRM extends AbstractRadioMedium {
         continue;
       }
 
-      /* Fail if radios are on different (but configured) channels */ 
-      if (sender.getChannel() >= 0 &&
-          recv.getChannel() >= 0 &&
-          sender.getChannel() != recv.getChannel()) {
+      /* Fail if radios are on different (but configured) channels */
+      var srcChannel = sender.getChannel();
+      var dstChannel = recv.getChannel();
+      if (srcChannel >= 0 && dstChannel >= 0 && srcChannel != dstChannel) {
         newConnection.addInterfered(recv);
         continue;
       }
@@ -296,9 +296,9 @@ public class MRM extends AbstractRadioMedium {
     for (RadioConnection conn : conns) {
       for (Radio dstRadio : conn.getDestinations()) {
         double signalStrength = ((MRMRadioConnection) conn).getDestinationSignalStrength(dstRadio);
-        if (conn.getSource().getChannel() >= 0 &&
-            dstRadio.getChannel() >= 0 &&
-            conn.getSource().getChannel() != dstRadio.getChannel()) {
+        var srcChannel = conn.getSource().getChannel();
+        var dstChannel = dstRadio.getChannel();
+        if (srcChannel >= 0 && dstChannel >= 0 && srcChannel != dstChannel) {
           continue;
         }
         if (dstRadio.getCurrentSignalStrength() < signalStrength) {
@@ -310,9 +310,9 @@ public class MRM extends AbstractRadioMedium {
     /* Interfering/colliding radio connections */
     for (RadioConnection conn : conns) {
       for (Radio intfRadio : conn.getInterfered()) {
-        if (conn.getSource().getChannel() >= 0 &&
-            intfRadio.getChannel() >= 0 &&
-            conn.getSource().getChannel() != intfRadio.getChannel()) {
+        var srcChannel = conn.getSource().getChannel();
+        var intfChannel = intfRadio.getChannel();
+        if (srcChannel >= 0 && intfChannel >= 0 && srcChannel != intfChannel) {
           continue;
         }
         double signalStrength = ((MRMRadioConnection) conn).getInterferenceSignalStrength(intfRadio);


### PR DESCRIPTION
The method digs around in the memory on ContikiMote,
so it is more costly than the name suggests.