### PR TITLE
Replace log4j with SLF4J+Logback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ repositories {
 
 dependencies {
   implementation files('lib/jipv6.jar')
+  // https://mvnrepository.com/artifact/ch.qos.logback/logback-classic
+  implementation 'ch.qos.logback:logback-classic:1.4.5'
   // https://mvnrepository.com/artifact/com.github.cliftonlabs/json-simple
   implementation 'com.github.cliftonlabs:json-simple:4.0.1'
   // https://mvnrepository.com/artifact/de.sciss/syntaxpane
@@ -26,14 +28,14 @@ dependencies {
   implementation 'info.picocli:picocli:4.7.0'
   // https://mvnrepository.com/artifact/info.picocli/picocli-codegen
   annotationProcessor 'info.picocli:picocli-codegen:4.7.0'
-  // https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core
-  implementation 'org.apache.logging.log4j:log4j-core:2.19.0'
   // https://mvnrepository.com/artifact/org.jdom/jdom2
   implementation 'org.jdom:jdom2:2.0.6.1'
   // https://mvnrepository.com/artifact/org.jfree/jfreechart
   implementation 'org.jfree:jfreechart:1.5.4'
   // https://mvnrepository.com/artifact/org.openjdk.nashorn/nashorn-core
   implementation 'org.openjdk.nashorn:nashorn-core:15.4'
+  // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
+  implementation 'org.slf4j:slf4j-api:2.0.6'
   // https://mvnrepository.com/artifact/org.swinglabs.swingx/swingx-autocomplete
   implementation 'org.swinglabs.swingx:swingx-autocomplete:1.6.5-1'
 }
@@ -133,6 +135,7 @@ run {
     }
   }
   systemProperty 'picocli.disable.closures', "true"
+  systemProperty 'logback.configurationFile', 'logback.xml'
   // Enable assertions with "-Passertions".
   enableAssertions = project.hasProperty('assertions')
 }

--- a/config/logback.xml
+++ b/config/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%level [%thread] [%file:%line] - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="cooja" level="INFO"/>
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -2,6 +2,31 @@
 
 ## Cooja User Interface Changes
 
+### Switched from Log4J 2 to SLF4J and Logback
+
+This removes the `--log4j2` and `--logname` parameters. Set the system property
+`logback.configurationFile` to use a different logback configuration.
+
+Plugins need to change calls to `logger.fatal` to instead call `logger.error`,
+and change the logger construction from
+```
+private static final Logger logger = LogManager.getLogger(MyClass.class);
+```
+to
+```
+private static final Logger logger = LoggerFactory.getLogger(MyClass.class);
+```
+Plugins also need to update their imports, change
+```
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+```
+to
+```
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+```
+
 ### Removed `-nogui` and `-quickstart` parameters
 
 Graphical/headless mode is now controlled by separate parameter (`--[no-]gui`),

--- a/examples/project_new_plugin/java/MyDummyPlugin.java
+++ b/examples/project_new_plugin/java/MyDummyPlugin.java
@@ -40,8 +40,6 @@ import javax.swing.JButton;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
@@ -50,6 +48,8 @@ import org.contikios.cooja.PluginType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.TimeEvent;
 import org.contikios.cooja.VisPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is a simple example COOJA plugin.
@@ -66,7 +66,7 @@ import org.contikios.cooja.VisPlugin;
 @ClassDescription("Example Plugin") /* Description shown in menu */
 @PluginType(PluginType.SIM_PLUGIN)
 public class MyDummyPlugin extends VisPlugin {
-  private static final Logger logger = LogManager.getLogger(MyDummyPlugin.class);
+  private static final Logger logger = LoggerFactory.getLogger(MyDummyPlugin.class);
 
   private Simulation sim;
   private Observer msObserver;

--- a/examples/project_new_radiomedium/java/DummyRadioMedium.java
+++ b/examples/project_new_radiomedium/java/DummyRadioMedium.java
@@ -29,22 +29,22 @@
  */
 
 import java.util.Collection;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jdom2.Element;
 
 import org.contikios.cooja.*;
 import org.contikios.cooja.interfaces.*;
 import org.contikios.cooja.radiomediums.AbstractRadioMedium;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Dummy radio medium.
  *
- * @author Fredrik Österlind
+ * @author Fredrik Osterlind
  */
 @ClassDescription("Dummy Radio Medium")
 public class DummyRadioMedium extends AbstractRadioMedium {
-  private static final Logger logger = LogManager.getLogger(Cooja.class);
+  private static final Logger logger = LoggerFactory.getLogger(Cooja.class);
 
   public DummyRadioMedium(Simulation simulation) {
     super(simulation);

--- a/java/org/contikios/cooja/Breakpoint.java
+++ b/java/org/contikios/cooja/Breakpoint.java
@@ -35,16 +35,16 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.util.StringUtils;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Generic parts of a breakpoint. Based on MspBreakpoint.
  */
 public abstract class Breakpoint implements Watchpoint {
-  private static final Logger logger = LogManager.getLogger(Breakpoint.class);
+  private static final Logger logger = LoggerFactory.getLogger(Breakpoint.class);
 
   protected final WatchpointMote mote;
 
@@ -218,7 +218,7 @@ public abstract class Breakpoint implements Watchpoint {
     // Update executable address.
     address = mote.getType().getExecutableAddressOf(codeFile, lineNr);
     if (address < 0) {
-      logger.fatal("Could not restore breakpoint, did source code change?");
+      logger.error("Could not restore breakpoint, did source code change?");
       return false;
     }
     createMonitor();

--- a/java/org/contikios/cooja/COOJAProject.java
+++ b/java/org/contikios/cooja/COOJAProject.java
@@ -33,8 +33,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * COOJA Project.
@@ -43,7 +43,7 @@ import org.apache.logging.log4j.LogManager;
  * @author Moritz Strübe
  */
 public class COOJAProject {
-	private static final Logger logger = LogManager.getLogger(COOJAProject.class);
+	private static final Logger logger = LoggerFactory.getLogger(COOJAProject.class);
 
 	public static File[] searchProjects(File folder, int depth){
 		if(depth == 0){

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -56,8 +56,6 @@ import java.util.zip.GZIPOutputStream;
 import javax.swing.JDesktopPane;
 import javax.swing.JFrame;
 import javax.swing.JMenu;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.MoteType.MoteTypeCreationException;
 import org.contikios.cooja.VisPlugin.PluginRequiresVisualizationException;
 import org.contikios.cooja.contikimote.ContikiMoteType;
@@ -83,6 +81,8 @@ import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Main file of COOJA Simulator. Typically, contains a visualizer for the
@@ -113,7 +113,7 @@ public class Cooja {
    */
   public static final String CONTIKI_NG_BUILD_VERSION = "2022071901";
 
-  private static final Logger logger = LogManager.getLogger(Cooja.class);
+  private static final Logger logger = LoggerFactory.getLogger(Cooja.class);
 
   private static final String PATH_CONFIG_IDENTIFIER = "[CONFIG_DIR]";
 
@@ -491,7 +491,7 @@ public class Cooja {
                 }
               }
             } catch (Exception e) {
-              logger.fatal("Error when trying to read JAR-file in " + projectDir + ": " + e);
+              logger.error("Error when trying to read JAR-file in " + projectDir + ": " + e);
               throw new ClassLoaderCreationException("Error when trying to read JAR-file in " + projectDir, e);
             }
           }
@@ -1173,7 +1173,7 @@ public class Cooja {
       try (var in = new FileInputStream(externalToolsUserSettingsFile)) {
         settings.load(in);
       } catch (IOException e1) {
-        logger.fatal("Error when reading user settings from: " + externalToolsUserSettingsFile);
+        logger.error("Error when reading user settings from: " + externalToolsUserSettingsFile);
         System.exit(1);
       }
       var en = settings.keys();
@@ -1187,7 +1187,7 @@ public class Cooja {
     try {
       gui = makeCooja();
     } catch (Exception e) {
-      logger.fatal(e.getMessage());
+      logger.error(e.getMessage());
       System.exit(1);
     }
     // Check if simulator should be quick-started.
@@ -1201,7 +1201,7 @@ public class Cooja {
                 ? Cooja.gui.doLoadConfig(simConfig)
                 : gui.createSimulation(simConfig, gui.readSimulationConfig(simConfig), true, simConfig.randomSeed());
       } catch (Exception e) {
-        logger.fatal("Exception when loading simulation: ", e);
+        logger.error("Exception when loading simulation: ", e);
       }
       if (sim == null) {
         autoQuit = true;

--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -99,8 +99,6 @@ import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 import javax.swing.filechooser.FileNameExtensionFilter;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.dialogs.AddMoteDialog;
 import org.contikios.cooja.dialogs.BufferSettings;
 import org.contikios.cooja.dialogs.CreateSimDialog;
@@ -113,10 +111,12 @@ import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.util.Annotations;
 import org.jdom2.Element;
 import org.jdom2.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** The graphical user interface for Cooja. */
 public class GUI {
-  private static final Logger logger = LogManager.getLogger(GUI.class);
+  private static final Logger logger = LoggerFactory.getLogger(GUI.class);
   static final String WINDOW_TITLE = "Cooja: The Contiki Network Simulator";
 
   static JFrame frame;
@@ -589,7 +589,7 @@ public class GUI {
           file = new File(file.getParent(), file.getName() + ".csc");
         }
         if (!file.exists() || !file.canRead()) {
-          logger.fatal("No read access to file: " + file);
+          logger.error("No read access to file: " + file);
           return;
         }
         doLoadConfigAsync(quick, file);
@@ -1130,7 +1130,7 @@ public class GUI {
     try {
       cooja.parseProjectConfig(true);
     } catch (Cooja.ParseProjectsException e) {
-      logger.fatal("Error when loading extensions: " + e.getMessage(), e);
+      logger.error("Error when loading extensions: " + e.getMessage(), e);
       JOptionPane.showMessageDialog(frame,
               """
                       All Cooja extensions could not load.
@@ -1305,7 +1305,7 @@ public class GUI {
     }
     if (saveFile.exists() && !saveFile.canWrite()) {
       JOptionPane.showMessageDialog(frame, "No write access to " + saveFile, "Save failed", JOptionPane.ERROR_MESSAGE);
-      logger.fatal("No write access to file: " + saveFile.getAbsolutePath());
+      logger.error("No write access to file: " + saveFile.getAbsolutePath());
       return null;
     }
     cooja.saveSimulationConfig(saveFile);
@@ -1839,7 +1839,7 @@ public class GUI {
             }
             cooja.getSimulation().addMoteType(newMoteType);
           } catch (Exception e1) {
-            logger.fatal("Exception when creating mote type", e1);
+            logger.error("Exception when creating mote type", e1);
             showErrorDialog("Mote type creation error", e1, false);
             newMoteType = null;
           }
@@ -1885,7 +1885,7 @@ public class GUI {
           positioner = constr.newInstance(newMoteInfo.numMotes(), newMoteInfo.startX(), newMoteInfo.endX(),
                    newMoteInfo.startY(), newMoteInfo.endY(), newMoteInfo.startZ(), newMoteInfo.endZ());
         } catch (Exception e1) {
-          logger.fatal("Exception when creating " + positionerClass + ": ", e1);
+          logger.error("Exception when creating " + positionerClass + ": ", e1);
           return;
         }
         // Create new motes.

--- a/java/org/contikios/cooja/LogScriptEngine.java
+++ b/java/org/contikios/cooja/LogScriptEngine.java
@@ -45,8 +45,6 @@ import java.util.concurrent.Semaphore;
 import javax.script.CompiledScript;
 import javax.script.ScriptException;
 import javax.swing.JTextArea;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.SimEventCentral.LogOutputEvent;
 import org.contikios.cooja.SimEventCentral.LogOutputListener;
 import org.contikios.cooja.plugins.ScriptRunner;
@@ -55,6 +53,8 @@ import org.contikios.cooja.script.ScriptMote;
 import org.contikios.cooja.script.ScriptParser;
 import org.openjdk.nashorn.api.scripting.NashornScriptEngine;
 import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Loads and executes a Contiki test script.
@@ -65,7 +65,7 @@ import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
  * @author Fredrik Osterlind
  */
 public class LogScriptEngine {
-  private static final Logger logger = LogManager.getLogger(LogScriptEngine.class);
+  private static final Logger logger = LoggerFactory.getLogger(LogScriptEngine.class);
   private static final long DEFAULT_TIMEOUT = 20*60*1000*Simulation.MILLISECOND; /* 1200s = 20 minutes */
 
   private final NashornScriptEngine engine = (NashornScriptEngine) new NashornScriptEngineFactory().getScriptEngine();
@@ -90,7 +90,7 @@ public class LogScriptEngine {
 
         stepScript();
       } catch (UndeclaredThrowableException e) {
-        logger.fatal("Exception: " + e.getMessage(), e);
+        logger.error("Exception: " + e.getMessage(), e);
         if (Cooja.isVisualized()) {
           Cooja.showErrorDialog(e.getMessage(), e, false);
         }
@@ -125,7 +125,7 @@ public class LogScriptEngine {
         logWriter.write("Random seed: " + simulation.getRandomSeed() + "\n");
         logWriter.flush();
       } catch (IOException e) {
-        logger.fatal("Could not create {}: {}", logFile, e.toString());
+        logger.error("Could not create {}: {}", logFile, e.toString());
         throw new RuntimeException(e);
       }
       return;
@@ -167,7 +167,7 @@ public class LogScriptEngine {
       logWriter.write(msg);
       logWriter.flush();
     } catch (IOException e) {
-      logger.fatal("Error when writing to test log file: " + msg, e);
+      logger.error("Error when writing to test log file: " + msg, e);
     }
   }
 
@@ -241,7 +241,7 @@ public class LogScriptEngine {
     try {
       semaphoreScript.acquire();
     } catch (InterruptedException e) {
-      logger.fatal("Error when creating engine: " + e.getMessage(), e);
+      logger.error("Error when creating engine: " + e.getMessage(), e);
       return false;
     }
     // Setup script variables.
@@ -261,7 +261,7 @@ public class LogScriptEngine {
       try {
         rv = (int) Objects.requireNonNullElse(script.eval(), 1);
       } catch (Exception e) {
-        logger.fatal("Script error:", e);
+        logger.error("Script error:", e);
         if (Cooja.isVisualized()) {
           Cooja.showErrorDialog("Script error", e, false);
         }

--- a/java/org/contikios/cooja/MoteInterfaceHandler.java
+++ b/java/org/contikios/cooja/MoteInterfaceHandler.java
@@ -32,8 +32,6 @@ package org.contikios.cooja;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.interfaces.Battery;
 import org.contikios.cooja.interfaces.Beeper;
 import org.contikios.cooja.interfaces.Button;
@@ -47,6 +45,8 @@ import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.interfaces.SerialPort;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The mote interface handler holds all interfaces for a specific mote.
@@ -54,7 +54,7 @@ import org.jdom2.Element;
  * @author Fredrik Osterlind
  */
 public class MoteInterfaceHandler {
-  private static final Logger logger = LogManager.getLogger(MoteInterfaceHandler.class);
+  private static final Logger logger = LoggerFactory.getLogger(MoteInterfaceHandler.class);
 
   private final ArrayList<MoteInterface> moteInterfaces = new ArrayList<>();
 
@@ -82,7 +82,7 @@ public class MoteInterfaceHandler {
       try {
         moteInterfaces.add(interfaceClass.getConstructor(Mote.class).newInstance(mote));
       } catch (Exception e) {
-        logger.fatal("Exception when calling constructor of " + interfaceClass, e);
+        logger.error("Exception when calling constructor of " + interfaceClass, e);
         throw new MoteType.MoteTypeCreationException("Exception when calling constructor of " + interfaceClass, e);
       }
     }

--- a/java/org/contikios/cooja/ProjectConfig.java
+++ b/java/org/contikios/cooja/ProjectConfig.java
@@ -37,8 +37,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Properties;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A project configuration may hold the configuration for one or several project
@@ -89,7 +89,7 @@ import org.apache.logging.log4j.LogManager;
  * @author Fredrik Osterlind
  */
 public class ProjectConfig {
-  private static final Logger logger = LogManager.getLogger(ProjectConfig.class);
+  private static final Logger logger = LoggerFactory.getLogger(ProjectConfig.class);
 
   /**
    * User extension configuration filename.
@@ -211,7 +211,7 @@ public class ProjectConfig {
       }
 
     } catch (Exception e) {
-      logger.fatal("Exception when searching in project directory history: " + e);
+      logger.error("Exception when searching in project directory history: " + e);
       return null;
     }
 

--- a/java/org/contikios/cooja/RadioConnection.java
+++ b/java/org/contikios/cooja/RadioConnection.java
@@ -32,10 +32,10 @@ package org.contikios.cooja;
 
 import java.util.ArrayList;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.interfaces.Radio;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A radio connection represents a connection between a single source radio and 
@@ -55,7 +55,7 @@ import org.contikios.cooja.interfaces.Radio;
  * @author Fredrik Osterlind
  */
 public class RadioConnection {
-  private static final Logger logger = LogManager.getLogger(RadioConnection.class);
+  private static final Logger logger = LoggerFactory.getLogger(RadioConnection.class);
 
   private static int ID = 0; /* Unique radio connection ID. For internal use */
   private final int id;
@@ -116,7 +116,7 @@ public class RadioConnection {
   public void removeDestination(Radio radio) {
     int idx = allDestinations.indexOf(radio);
     if (idx < 0) {
-      logger.fatal("Radio is not a connection destination: " + radio);
+      logger.error("Radio is not a connection destination: " + radio);
       return;
     }
     
@@ -134,7 +134,7 @@ public class RadioConnection {
    */
   public void addDestination(Radio radio, Long delay) {
     if (isDestination(radio)) {
-      logger.fatal("Radio is already a destination: " + radio);
+      logger.error("Radio is already a destination: " + radio);
       return;
     }
     allDestinations.add(radio);
@@ -150,7 +150,7 @@ public class RadioConnection {
   public long getDestinationDelay(Radio radio) {
     int idx = allDestinations.indexOf(radio);
     if (idx < 0) {
-      logger.fatal("Radio is not a connection destination: " + radio);
+      logger.error("Radio is not a connection destination: " + radio);
       return 0;
     }
     return allDestinationDelays.get(idx);
@@ -167,7 +167,7 @@ public class RadioConnection {
    */
   public void addInterfered(Radio radio) {
     if (isInterfered(radio)) {
-      logger.fatal("Radio is already interfered: " + radio);
+      logger.error("Radio is already interfered: " + radio);
       return;
     }
 

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -38,8 +38,6 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingDeque;
 import javax.swing.JTextArea;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.Cooja.PluginConstructionException;
 import org.contikios.cooja.Cooja.SimulationCreationException;
 import org.contikios.cooja.radiomediums.DirectedGraphMedium;
@@ -51,6 +49,8 @@ import org.contikios.cooja.util.EventTriggers;
 import org.contikios.cooja.util.EventTriggers.AddRemove;
 import org.contikios.mrm.MRM;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A simulation consists of a number of motes and mote types.
@@ -106,7 +106,7 @@ public final class Simulation {
 
   private final RadioMedium currentRadioMedium;
 
-  private static final Logger logger = LogManager.getLogger(Simulation.class);
+  private static final Logger logger = LoggerFactory.getLogger(Simulation.class);
 
   private volatile boolean isRunning = false;
   private volatile boolean isShutdown = false;
@@ -256,7 +256,7 @@ public final class Simulation {
         } catch (SimulationStop e) {
           logger.info("Simulation stopped: {}", e.getMessage());
         } catch (RuntimeException e) {
-          logger.fatal("Simulation stopped due to error: " + e.getMessage(), e);
+          logger.error("Simulation stopped due to error: " + e.getMessage(), e);
           if (Cooja.isVisualized()) {
             String errorTitle = "Simulation error";
             if (nextEvent != null && nextEvent.event instanceof MoteTimeEvent moteTimeEvent) {
@@ -325,7 +325,7 @@ public final class Simulation {
               throw new MoteType.MoteTypeCreationException("Could not create: " + moteTypeClassName);
             }
             if (!moteType.setConfigXML(this, element.getChildren(), Cooja.isVisualized())) {
-              logger.fatal("Mote type was not created: " + element.getText().trim());
+              logger.error("Mote type was not created: " + element.getText().trim());
               throw new MoteType.MoteTypeCreationException("Mote type was not created: " + element.getText().trim());
             }
             addMoteType(moteType);
@@ -397,7 +397,7 @@ public final class Simulation {
   private void createMote(MoteType moteType, Element root) throws MoteType.MoteTypeCreationException {
     var mote = moteType.generateMote(this);
     if (!mote.setConfigXML(this, root.getChildren(), Cooja.isVisualized())) {
-      logger.fatal("Mote was not created: " + root.getText().trim());
+      logger.error("Mote was not created: " + root.getText().trim());
       throw new MoteType.MoteTypeCreationException("Could not configure mote " + moteType);
     }
     addMote(mote);
@@ -428,7 +428,7 @@ public final class Simulation {
 
       var pluginClass = ExtensionManager.getPluginClass(cooja, pluginClassName);
       if (pluginClass == null) {
-        logger.fatal("Plugin class " + pluginClassName + " not registered as a plugin");
+        logger.error("Plugin class " + pluginClassName + " not registered as a plugin");
         return new SimulationCreationException("Plugin class " + pluginClassName + " not registered as a plugin", null);
       }
       // Skip plugins that require visualization in headless mode.

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -51,8 +51,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.ResourceScope;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.AbstractionLevelDescription;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
@@ -88,6 +86,8 @@ import org.contikios.cooja.mote.memory.MemoryInterface.Symbol;
 import org.contikios.cooja.mote.memory.MemoryLayout;
 import org.contikios.cooja.mote.memory.SectionMoteMemory;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Cooja mote type holds the native library used to communicate with an
@@ -112,7 +112,7 @@ import org.jdom2.Element;
 @AbstractionLevelDescription("OS level")
 public class ContikiMoteType extends BaseContikiMoteType {
 
-  private static final Logger logger = LogManager.getLogger(ContikiMoteType.class);
+  private static final Logger logger = LoggerFactory.getLogger(ContikiMoteType.class);
   private static int fileCounter = 1;
 
   /**

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiCFS.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiCFS.java
@@ -42,8 +42,6 @@ import javax.swing.JButton;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.Mote;
@@ -51,6 +49,8 @@ import org.contikios.cooja.MoteInterface;
 
 import org.contikios.cooja.interfaces.PolledAfterActiveTicks;
 import org.contikios.cooja.mote.memory.VarMemory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Contiki FileSystem (CFS) interface (such as external flash).
@@ -69,7 +69,7 @@ import org.contikios.cooja.mote.memory.VarMemory;
  */
 @ClassDescription("Filesystem (CFS)")
 public class ContikiCFS implements MoteInterface, PolledAfterActiveTicks {
-  private static final Logger logger = LogManager.getLogger(ContikiCFS.class);
+  private static final Logger logger = LoggerFactory.getLogger(ContikiCFS.class);
 
   public static final int FILESYSTEM_SIZE = 4000; /* Configure CFS size here and in cfs-cooja.c */
   private final Mote mote;
@@ -121,7 +121,7 @@ public class ContikiCFS implements MoteInterface, PolledAfterActiveTicks {
    */
   public boolean setFilesystemData(byte[] data) {
     if (data.length > FILESYSTEM_SIZE) {
-      logger.fatal("Error. Filesystem data too large, skipping");
+      logger.error("Error. Filesystem data too large, skipping");
       return false;
     }
 

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiClock.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiClock.java
@@ -31,8 +31,6 @@ package org.contikios.cooja.contikimote.interfaces;
 
 import javax.swing.JPanel;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.Simulation;
@@ -41,6 +39,8 @@ import org.contikios.cooja.interfaces.Clock;
 import org.contikios.cooja.interfaces.PolledAfterAllTicks;
 import org.contikios.cooja.interfaces.PolledBeforeActiveTicks;
 import org.contikios.cooja.mote.memory.VarMemory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Clock mote interface. Controls Contiki time.
@@ -61,7 +61,7 @@ import org.contikios.cooja.mote.memory.VarMemory;
  * @author Fredrik Osterlind
  */
 public class ContikiClock extends Clock implements PolledBeforeActiveTicks, PolledAfterAllTicks {
-  private static final Logger logger = LogManager.getLogger(ContikiClock.class);
+  private static final Logger logger = LoggerFactory.getLogger(ContikiClock.class);
 
   private final ContikiMote mote;
   private final VarMemory moteMem;
@@ -109,7 +109,7 @@ public class ContikiClock extends Clock implements PolledBeforeActiveTicks, Poll
   
   @Override
   public void setDeviation(double deviation) {
-    logger.fatal("Can't change deviation");
+    logger.error("Can't change deviation");
   }
 
   @Override

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiEEPROM.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiEEPROM.java
@@ -51,8 +51,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.Mote;
@@ -61,6 +59,8 @@ import org.jdom2.Element;
 
 import org.contikios.cooja.interfaces.PolledAfterActiveTicks;
 import org.contikios.cooja.mote.memory.VarMemory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Contiki EEPROM interface
@@ -80,7 +80,7 @@ import org.contikios.cooja.mote.memory.VarMemory;
  */
 @ClassDescription("EEPROM")
 public class ContikiEEPROM implements MoteInterface, PolledAfterActiveTicks {
-  private static final Logger logger = LogManager.getLogger(ContikiEEPROM.class);
+  private static final Logger logger = LoggerFactory.getLogger(ContikiEEPROM.class);
 
   public static final int EEPROM_SIZE = 1024; /* Configure EEPROM size here and in eeprom.c. Should really be multiple of 16 */
   private final Mote mote;
@@ -131,7 +131,7 @@ public class ContikiEEPROM implements MoteInterface, PolledAfterActiveTicks {
    */
   public boolean setEEPROMData(byte[] data) {
     if (data.length > EEPROM_SIZE) {
-      logger.fatal("Error. EEPROM data too large, skipping");
+      logger.error("Error. EEPROM data too large, skipping");
       return false;
     }
 

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiRS232.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiRS232.java
@@ -33,8 +33,6 @@ package org.contikios.cooja.contikimote.interfaces;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.ArrayDeque;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteTimeEvent;
@@ -43,6 +41,8 @@ import org.contikios.cooja.contikimote.ContikiMote;
 import org.contikios.cooja.dialogs.SerialUI;
 import org.contikios.cooja.interfaces.PolledAfterActiveTicks;
 import org.contikios.cooja.mote.memory.VarMemory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Contiki mote serial port and log interfaces.
@@ -63,7 +63,7 @@ import org.contikios.cooja.mote.memory.VarMemory;
  */
 @ClassDescription("Serial port")
 public class ContikiRS232 extends SerialUI implements PolledAfterActiveTicks {
-  private static final Logger logger = LogManager.getLogger(ContikiRS232.class);
+  private static final Logger logger = LoggerFactory.getLogger(ContikiRS232.class);
 
   private final ContikiMote mote;
   private final VarMemory moteMem;
@@ -107,7 +107,7 @@ public class ContikiRS232 extends SerialUI implements PolledAfterActiveTicks {
       int oldSize = moteMem.getIntValueOf("simSerialReceivingLength");
       int newSize = oldSize + dataToAppend.length;
       if (newSize > SERIAL_BUF_SIZE) {
-        logger.fatal("ContikiRS232: dropping rs232 data #1, buffer full: " + oldSize + " -> " + newSize);
+        logger.error("ContikiRS232: dropping rs232 data #1, buffer full: " + oldSize + " -> " + newSize);
         mote.requestImmediateWakeup();
         return;
       }
@@ -163,7 +163,7 @@ public class ContikiRS232 extends SerialUI implements PolledAfterActiveTicks {
         int oldSize = moteMem.getIntValueOf("simSerialReceivingLength");
         int newSize = oldSize + dataToAppend.length;
         if (newSize > SERIAL_BUF_SIZE) {
-        	logger.fatal("ContikiRS232: dropping rs232 data #2, buffer full: " + oldSize + " -> " + newSize);
+        	logger.error("ContikiRS232: dropping rs232 data #2, buffer full: " + oldSize + " -> " + newSize);
         	mote.requestImmediateWakeup();
         	return;
         }
@@ -216,7 +216,7 @@ public class ContikiRS232 extends SerialUI implements PolledAfterActiveTicks {
         int oldSize = moteMem.getIntValueOf("simSerialReceivingLength");
         int newSize = oldSize + dataToAppend.length;
         if (newSize > SERIAL_BUF_SIZE) {
-        	logger.fatal("ContikiRS232: dropping rs232 data #3, buffer full: " + oldSize + " -> " + newSize);
+        	logger.error("ContikiRS232: dropping rs232 data #3, buffer full: " + oldSize + " -> " + newSize);
         	mote.requestImmediateWakeup();
         	return;
         }

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiRadio.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiRadio.java
@@ -33,8 +33,6 @@ package org.contikios.cooja.contikimote.interfaces;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jdom2.Element;
 
 import org.contikios.cooja.COOJARadioPacket;
@@ -48,6 +46,9 @@ import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.mote.memory.VarMemory;
 import org.contikios.cooja.radiomediums.UDGM;
 import org.contikios.cooja.util.CCITT_CRC;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Packet radio transceiver mote interface.
  * <p>
@@ -86,7 +87,7 @@ public class ContikiRadio extends Radio implements PolledAfterActiveTicks {
 
   private final VarMemory myMoteMemory;
 
-  private static final Logger logger = LogManager.getLogger(ContikiRadio.class);
+  private static final Logger logger = LoggerFactory.getLogger(ContikiRadio.class);
 
   /**
    * Project default transmission bitrate (kbps).

--- a/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
+++ b/java/org/contikios/cooja/dialogs/AbstractCompileDialog.java
@@ -65,8 +65,6 @@ import javax.swing.KeyStroke;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.filechooser.FileNameExtensionFilter;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.MoteInterface;
@@ -74,6 +72,8 @@ import org.contikios.cooja.interfaces.MoteID;
 import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.mote.BaseContikiMoteType;
 import org.contikios.cooja.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Abstract configure mote type dialog used by Contiki-based mote type implementations.
@@ -89,7 +89,7 @@ import org.contikios.cooja.util.StringUtils;
  * @author Fredrik Osterlind
  */
 public abstract class AbstractCompileDialog extends JDialog {
-  private static final Logger logger = LogManager.getLogger(AbstractCompileDialog.class);
+  private static final Logger logger = LoggerFactory.getLogger(AbstractCompileDialog.class);
 
   protected final static Dimension LABEL_DIMENSION = new Dimension(170, 25);
 
@@ -238,7 +238,7 @@ public abstract class AbstractCompileDialog extends JDialog {
                   false
               );
             } catch (Exception ex) {
-              logger.fatal("Exception when compiling: " + ex.getMessage());
+              logger.error("Exception when compiling: " + ex.getMessage());
               taskOutput.addMessage(ex.getMessage(), MessageList.ERROR);
               ex.printStackTrace();
               compilationFailureAction.actionPerformed(null);
@@ -256,7 +256,7 @@ public abstract class AbstractCompileDialog extends JDialog {
             moteType.getCompilationEnvironment(), new File(contikiField.getText()).getParentFile(),
             null, null, new MessageListUI(), true);
       } catch (Exception e1) {
-        logger.fatal("Clean failed: " + e1.getMessage(), e1);
+        logger.error("Clean failed: " + e1.getMessage(), e1);
       }
     });
 

--- a/java/org/contikios/cooja/dialogs/MessageListUI.java
+++ b/java/org/contikios/cooja/dialogs/MessageListUI.java
@@ -59,9 +59,9 @@ import javax.swing.JPopupMenu;
 import javax.swing.JSeparator;
 import javax.swing.ListModel;
 import javax.swing.ListSelectionModel;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.Cooja;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -72,7 +72,7 @@ import org.contikios.cooja.Cooja;
  */
 public class MessageListUI extends JList<MessageContainer> implements MessageList {
 
-  private static final Logger logger = LogManager.getLogger(MessageListUI.class);
+  private static final Logger logger = LoggerFactory.getLogger(MessageListUI.class);
 
   private final Color[] foregrounds = new Color[] { null, Color.red };
   private final Color[] backgrounds = new Color[] { null, null };
@@ -270,7 +270,7 @@ public class MessageListUI extends JList<MessageContainer> implements MessageLis
             if (hideNormal && msg.type() == NORMAL) {
               continue;
             }
-            logger.info(msg);
+            logger.info(msg.toString());
           }
           logger.info("\n");
         });

--- a/java/org/contikios/cooja/dialogs/ProjectDirectoriesDialog.java
+++ b/java/org/contikios/cooja/dialogs/ProjectDirectoriesDialog.java
@@ -58,12 +58,12 @@ import javax.swing.ListSelectionModel;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.COOJAProject;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.ProjectConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This dialog allows a user to manage Cooja extensions: extensions to COOJA that 
@@ -72,7 +72,7 @@ import org.contikios.cooja.ProjectConfig;
  * @author Fredrik Osterlind
  */
 public class ProjectDirectoriesDialog extends JDialog {
-	private static final Logger logger = LogManager.getLogger(ProjectDirectoriesDialog.class);
+	private static final Logger logger = LoggerFactory.getLogger(ProjectDirectoriesDialog.class);
 
   private final Cooja gui;
 
@@ -179,7 +179,7 @@ public class ProjectDirectoriesDialog extends JDialog {
           var myDialog = new ConfigViewer(ProjectDirectoriesDialog.this, config);
           myDialog.setVisible(true);
         } catch (Exception ex) {
-          logger.fatal("Error when merging config: " + ex.getMessage(), ex);
+          logger.error("Error when merging config: " + ex.getMessage(), ex);
         }
       });
 			buttonPane.add(button);

--- a/java/org/contikios/cooja/dialogs/SerialUI.java
+++ b/java/org/contikios/cooja/dialogs/SerialUI.java
@@ -50,17 +50,17 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-import org.contikios.cooja.util.EventTriggers;
 import org.jdom2.Element;
 
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.interfaces.Log;
 import org.contikios.cooja.interfaces.SerialPort;
+import org.contikios.cooja.util.EventTriggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class SerialUI extends Log implements SerialPort {
-  private static final Logger logger = LogManager.getLogger(SerialUI.class);
+  private static final Logger logger = LoggerFactory.getLogger(SerialUI.class);
 
   private final static int MAX_LENGTH = 16*1024;
 
@@ -223,7 +223,7 @@ public abstract class SerialUI extends Log implements SerialPort {
   public void releaseInterfaceVisualizer(JPanel panel) {
     Observer observer = (Observer) panel.getClientProperty("intf_obs");
     if (observer == null) {
-      logger.fatal("Error when releasing panel, observer is null");
+      logger.error("Error when releasing panel, observer is null");
       return;
     }
 

--- a/java/org/contikios/cooja/emulatedmote/Radio802154.java
+++ b/java/org/contikios/cooja/emulatedmote/Radio802154.java
@@ -29,13 +29,13 @@
  */
 package org.contikios.cooja.emulatedmote;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.RadioPacket;
 import org.contikios.cooja.interfaces.CustomDataRadio;
 import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.Radio;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * 802.15.4 radio class for COOJA.
@@ -47,7 +47,7 @@ public abstract class Radio802154 extends Radio implements CustomDataRadio {
 
     private final static boolean DEBUG = false;
     
-    private static final Logger logger = LogManager.getLogger(Radio802154.class);
+    private static final Logger logger = LoggerFactory.getLogger(Radio802154.class);
 
     protected long lastEventTime = 0;
 

--- a/java/org/contikios/cooja/emulatedmote/Radio802154PacketConverter.java
+++ b/java/org/contikios/cooja/emulatedmote/Radio802154PacketConverter.java
@@ -29,11 +29,11 @@
  */
 
 package org.contikios.cooja.emulatedmote;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.ConvertedRadioPacket;
 import org.contikios.cooja.RadioPacket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Converts radio packets between X-MAC/802.15.4 nodes and COOJA.
@@ -44,7 +44,7 @@ import org.contikios.cooja.RadioPacket;
  */
 
 public class Radio802154PacketConverter {
-    private static final Logger logger = LogManager.getLogger(Radio802154PacketConverter.class);
+    private static final Logger logger = LoggerFactory.getLogger(Radio802154PacketConverter.class);
 
     public static final boolean WITH_PREAMBLE = true;
     public static final boolean WITH_SYNCH = true;

--- a/java/org/contikios/cooja/interfaces/ApplicationRadio.java
+++ b/java/org/contikios/cooja/interfaces/ApplicationRadio.java
@@ -41,13 +41,13 @@ import javax.swing.JFormattedTextField;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteTimeEvent;
 import org.contikios.cooja.RadioPacket;
 import org.contikios.cooja.Simulation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Application radio.
@@ -59,7 +59,7 @@ import org.contikios.cooja.Simulation;
  * @author Fredrik Osterlind
  */
 public class ApplicationRadio extends Radio implements NoiseSourceRadio, DirectionalAntennaRadio {
-  private static final Logger logger = LogManager.getLogger(ApplicationRadio.class);
+  private static final Logger logger = LoggerFactory.getLogger(ApplicationRadio.class);
 
   private final Simulation simulation;
   private final Mote mote;

--- a/java/org/contikios/cooja/interfaces/Mote2MoteRelations.java
+++ b/java/org/contikios/cooja/interfaces/Mote2MoteRelations.java
@@ -33,19 +33,16 @@ package org.contikios.cooja.interfaces;
 import java.util.ArrayList;
 import java.util.Observable;
 import java.util.Observer;
-
 import javax.swing.BoxLayout;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.ui.ColorUtils;
 import org.contikios.cooja.util.EventTriggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Mote2Mote Relations is used to show mote relations in simulated
@@ -73,7 +70,7 @@ import org.contikios.cooja.util.EventTriggers;
  */
 @ClassDescription("Mote2Mote Relations")
 public class Mote2MoteRelations extends Observable implements MoteInterface {
-  private static final Logger logger = LogManager.getLogger(Mote2MoteRelations.class);
+  private static final Logger logger = LoggerFactory.getLogger(Mote2MoteRelations.class);
   private final Mote mote;
 
   private final ArrayList<Mote> relations = new ArrayList<>();
@@ -205,7 +202,7 @@ public class Mote2MoteRelations extends Observable implements MoteInterface {
   public void releaseInterfaceVisualizer(JPanel panel) {
     Observer observer = (Observer) panel.getClientProperty("intf_obs");
     if (observer == null) {
-      logger.fatal("Error when releasing panel, observer is null");
+      logger.error("Error when releasing panel, observer is null");
       return;
     }
     this.deleteObserver(observer);

--- a/java/org/contikios/cooja/interfaces/MoteAttributes.java
+++ b/java/org/contikios/cooja/interfaces/MoteAttributes.java
@@ -38,14 +38,14 @@ import java.util.Observer;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.plugins.skins.AttributeVisualizerSkin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * MoteAttributes used to store mote attributes for debugging and statistics
@@ -78,7 +78,7 @@ import org.contikios.cooja.plugins.skins.AttributeVisualizerSkin;
  */
 @ClassDescription("Mote Attributes")
 public class MoteAttributes extends Observable implements MoteInterface {
-  private static final Logger logger = LogManager.getLogger(MoteAttributes.class);
+  private static final Logger logger = LoggerFactory.getLogger(MoteAttributes.class);
   private final Mote mote;
 
   private final HashMap<String, Object> attributes = new HashMap<>();

--- a/java/org/contikios/cooja/interfaces/Radio.java
+++ b/java/org/contikios/cooja/interfaces/Radio.java
@@ -37,8 +37,6 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
@@ -46,6 +44,8 @@ import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.RadioPacket;
 import org.contikios.cooja.contikimote.interfaces.ContikiRadio;
 import org.contikios.cooja.util.EventTriggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A mote radio transceiver.
@@ -58,7 +58,7 @@ import org.contikios.cooja.util.EventTriggers;
  */
 @ClassDescription("Radio")
 public abstract class Radio extends Observable implements MoteInterface {
-  private static final Logger logger = LogManager.getLogger(Radio.class);
+  private static final Logger logger = LoggerFactory.getLogger(Radio.class);
 
   protected final EventTriggers<RadioEvent, Radio> radioEventTriggers = new EventTriggers<>();
 
@@ -279,7 +279,7 @@ public abstract class Radio extends Observable implements MoteInterface {
   public void releaseInterfaceVisualizer(JPanel panel) {
     Observer observer = (Observer) panel.getClientProperty("intf_obs");
     if (observer == null) {
-      logger.fatal("Error when releasing panel, observer is null");
+      logger.error("Error when releasing panel, observer is null");
       return;
     }
 

--- a/java/org/contikios/cooja/mote/BaseContikiMoteType.java
+++ b/java/org/contikios/cooja/mote/BaseContikiMoteType.java
@@ -50,8 +50,6 @@ import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.Simulation;
@@ -88,12 +86,14 @@ import org.contikios.cooja.mspmote.interfaces.SkyFlash;
 import org.contikios.cooja.mspmote.interfaces.SkyTemperature;
 import org.contikios.cooja.util.StringUtils;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The common parts of mote types based on compiled Contiki-NG targets.
  */
 public abstract class BaseContikiMoteType extends AbstractApplicationMoteType {
-  private static final Logger logger = LogManager.getLogger(BaseContikiMoteType.class);
+  private static final Logger logger = LoggerFactory.getLogger(BaseContikiMoteType.class);
 
   /** Static translation map from name -> class for builtin interfaces. */
   protected static final Map<String, Class<? extends MoteInterface>> builtinInterfaces = Map.ofEntries(
@@ -310,7 +310,7 @@ public abstract class BaseContikiMoteType extends AbstractApplicationMoteType {
           moteInterfaceClasses.add(clazz);
         }
         case "contikibasedir", "contikicoredir", "projectdir", "compilefile", "process", "sensor", "coreinterface" -> {
-          logger.fatal("Old Cooja mote type detected, aborting..");
+          logger.error("Old Cooja mote type detected, aborting..");
           return false;
         }
       }

--- a/java/org/contikios/cooja/mote/memory/SectionMoteMemory.java
+++ b/java/org/contikios/cooja/mote/memory/SectionMoteMemory.java
@@ -32,9 +32,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 /**
  * Represents a mote memory consisting of non-overlapping memory sections with
@@ -49,7 +49,7 @@ import org.apache.logging.log4j.LogManager;
  * @author Enrico Jorns
  */
 public class SectionMoteMemory implements MemoryInterface {
-  private static final Logger logger = LogManager.getLogger(SectionMoteMemory.class);
+  private static final Logger logger = LoggerFactory.getLogger(SectionMoteMemory.class);
   private static final boolean DEBUG = logger.isDebugEnabled();
 
   private final Map<String, MemoryInterface> sections = new HashMap<>();

--- a/java/org/contikios/cooja/motes/ImportAppMoteType.java
+++ b/java/org/contikios/cooja/motes/ImportAppMoteType.java
@@ -42,8 +42,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.Cooja;
 import org.jdom2.Element;
 
@@ -53,6 +51,8 @@ import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.dialogs.ImportAppMoteDialog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Fredrik Osterlind
@@ -60,7 +60,7 @@ import org.contikios.cooja.dialogs.ImportAppMoteDialog;
 @ClassDescription("Import Java mote")
 @AbstractionLevelDescription("Application level")
 public class ImportAppMoteType extends AbstractApplicationMoteType {
-  private static final Logger logger = LogManager.getLogger(ImportAppMoteType.class);
+  private static final Logger logger = LoggerFactory.getLogger(ImportAppMoteType.class);
 
   private File moteClassPath = null;
   private String moteClassName = null;

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -34,8 +34,6 @@ import java.awt.Component;
 import java.io.File;
 import java.io.PrintStream;
 import java.util.Map;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.Simulation.SimulationStop;
 import org.contikios.cooja.WatchpointMote;
 import org.contikios.cooja.ContikiError;
@@ -49,6 +47,8 @@ import org.contikios.cooja.motes.AbstractEmulatedMote;
 import org.contikios.cooja.mspmote.plugins.CodeVisualizerSkin;
 import org.contikios.cooja.mspmote.plugins.MspBreakpoint;
 import org.contikios.cooja.plugins.Visualizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.sics.mspsim.cli.CommandContext;
 import se.sics.mspsim.cli.CommandHandler;
 import se.sics.mspsim.cli.LineListener;
@@ -74,7 +74,7 @@ import org.contikios.cooja.mspmote.interfaces.MspClock;
  * @author Fredrik Osterlind
  */
 public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteMemory> implements WatchpointMote {
-  private static final Logger logger = LogManager.getLogger(MspMote.class);
+  private static final Logger logger = LoggerFactory.getLogger(MspMote.class);
 
   private final static int EXECUTE_DURATION_US = 1; /* We always execute in 1 us steps */
 
@@ -100,7 +100,7 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
     myCpu.setMonitorExec(true);
     myCpu.setTrace(0); /* TODO Enable */
     myCpu.getLogger().addLogListener(new LogListener() {
-      private final Logger mlogger = LogManager.getLogger("MSPSim");
+      private final Logger mlogger = LoggerFactory.getLogger("MSPSim");
       @Override
       public void log(Loggable source, String message) {
         mlogger.debug(getID() + ": " + source.getID() + ": " + message);

--- a/java/org/contikios/cooja/mspmote/MspMoteType.java
+++ b/java/org/contikios/cooja/mspmote/MspMoteType.java
@@ -33,10 +33,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
-
 import java.util.Map;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.dialogs.AbstractCompileDialog;
 import org.contikios.cooja.mote.BaseContikiMoteType;
 import org.contikios.cooja.mote.memory.MemoryInterface.Symbol;
@@ -48,6 +45,8 @@ import se.sics.mspsim.platform.GenericNode;
 import se.sics.mspsim.util.DebugInfo;
 import se.sics.mspsim.util.ELF;
 import se.sics.mspsim.util.MapEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * MSP430-based mote types emulated in MSPSim.
@@ -58,7 +57,7 @@ import se.sics.mspsim.util.MapEntry;
  */
 @ClassDescription("Msp Mote Type")
 public abstract class MspMoteType extends BaseContikiMoteType {
-  private static final Logger logger = LogManager.getLogger(MspMoteType.class);
+  private static final Logger logger = LoggerFactory.getLogger(MspMoteType.class);
 
   private boolean loadedDebugInfo = false;
   private HashMap<File, HashMap<Integer, Integer>> debuggingInfo = null; /* cached */
@@ -148,7 +147,7 @@ public abstract class MspMoteType extends BaseContikiMoteType {
     try {
       elf = getELF();
     } catch (Exception e) {
-      logger.fatal("Error when reading firmware:", e);
+      logger.error("Error when reading firmware:", e);
       throw new MoteTypeCreationException("Error when reading firmware: " + e.getMessage());
     }
     node.loadFirmware(elf);

--- a/java/org/contikios/cooja/mspmote/interfaces/CC1101Radio.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/CC1101Radio.java
@@ -30,8 +30,6 @@
 
 package org.contikios.cooja.mspmote.interfaces;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
@@ -42,6 +40,8 @@ import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.mspmote.MspMote;
 import org.contikios.cooja.mspmote.MspMoteTimeEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.sics.mspsim.chip.CC1101;
 import se.sics.mspsim.chip.RFListener;
 import se.sics.mspsim.chip.Radio802154;
@@ -51,7 +51,7 @@ import se.sics.mspsim.chip.Radio802154;
  */
 @ClassDescription("TI CC1101")
 public class CC1101Radio extends Radio implements CustomDataRadio {
-	private static final Logger logger = LogManager.getLogger(CC1101Radio.class);
+	private static final Logger logger = LoggerFactory.getLogger(CC1101Radio.class);
 
 	/**
 	 * Cross-level:
@@ -251,7 +251,7 @@ public class CC1101Radio extends Radio implements CustomDataRadio {
 	@Override
 	public void receiveCustomData(Object data) {
 		if (!(data instanceof Byte)) {
-			logger.fatal("Bad custom data: " + data);
+			logger.error("Bad custom data: " + data);
 			return;
 		}
 		lastIncomingByte = (Byte) data;

--- a/java/org/contikios/cooja/mspmote/interfaces/CC1120Radio.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/CC1120Radio.java
@@ -30,8 +30,6 @@
 
 package org.contikios.cooja.mspmote.interfaces;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
@@ -42,6 +40,8 @@ import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.mspmote.MspMote;
 import org.contikios.cooja.mspmote.MspMoteTimeEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.sics.mspsim.chip.CC1120;
 import se.sics.mspsim.chip.RFListener;
 import se.sics.mspsim.chip.Radio802154;
@@ -51,7 +51,7 @@ import se.sics.mspsim.chip.Radio802154;
  */
 @ClassDescription("TI CC1120")
 public class CC1120Radio extends Radio implements CustomDataRadio {
-	private static final Logger logger = LogManager.getLogger(CC1120Radio.class);
+	private static final Logger logger = LoggerFactory.getLogger(CC1120Radio.class);
 
 	/**
 	 * Cross-level:
@@ -253,7 +253,7 @@ public class CC1120Radio extends Radio implements CustomDataRadio {
 	@Override
 	public void receiveCustomData(Object data) {
 		if (!(data instanceof Byte)) {
-			logger.fatal("Bad custom data: " + data);
+			logger.error("Bad custom data: " + data);
 			return;
 		}
 		lastIncomingByte = (Byte) data;

--- a/java/org/contikios/cooja/mspmote/interfaces/CC2520Radio.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/CC2520Radio.java
@@ -1,8 +1,6 @@
 
 package org.contikios.cooja.mspmote.interfaces;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
@@ -13,6 +11,8 @@ import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.mspmote.MspMote;
 import org.contikios.cooja.mspmote.MspMoteTimeEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.sics.mspsim.chip.CC2520;
 import se.sics.mspsim.chip.RFListener;
 
@@ -23,7 +23,7 @@ import se.sics.mspsim.chip.RFListener;
  */
 @ClassDescription("IEEE CC2520 Radio")
 public class CC2520Radio extends Radio implements CustomDataRadio {
-  private static final Logger logger = LogManager.getLogger(CC2520Radio.class);
+  private static final Logger logger = LoggerFactory.getLogger(CC2520Radio.class);
 
   /**
    * Cross-level:
@@ -173,7 +173,7 @@ public class CC2520Radio extends Radio implements CustomDataRadio {
 
   @Override
   public void setReceivedPacket(RadioPacket packet) {
-    logger.fatal("TODO Implement me!");
+    logger.error("TODO Implement me!");
   }
 
   /* Custom data radio support */
@@ -190,7 +190,7 @@ public class CC2520Radio extends Radio implements CustomDataRadio {
   @Override
   public void receiveCustomData(Object data) {
     if (!(data instanceof Byte)) {
-      logger.fatal("Bad custom data: " + data);
+      logger.error("Bad custom data: " + data);
       return;
     }
     lastIncomingByte = (Byte) data;

--- a/java/org/contikios/cooja/mspmote/interfaces/GCRCoder.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/GCRCoder.java
@@ -30,8 +30,8 @@
 
 package org.contikios.cooja.mspmote.interfaces;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Ported from contiki-2.x/core/lib/gcr.[ch].
@@ -39,7 +39,7 @@ import org.apache.logging.log4j.LogManager;
  * @author Fredrik Osterlind
  */
 public class GCRCoder {
-  private static final Logger logger = LogManager.getLogger(GCRCoder.class);
+  private static final Logger logger = LoggerFactory.getLogger(GCRCoder.class);
 
   /*
    * GCR conversion table - used for converting ordinary byte to 10-bits (or 4
@@ -151,7 +151,7 @@ public class GCRCoder {
       // Try to decode byte
       gcr_decode(0xff & data[i]);
       if (!gcr_valid()) {
-        logger.fatal("GCR decoding failed, dropping packet");
+        logger.error("GCR decoding failed, dropping packet");
         return null;
       }
 

--- a/java/org/contikios/cooja/mspmote/interfaces/Msp802154BitErrorRadio.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/Msp802154BitErrorRadio.java
@@ -32,14 +32,14 @@ package org.contikios.cooja.mspmote.interfaces;
 
 import java.util.Random;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.radiomediums.AbstractRadioMedium;
 
 import org.contikios.cooja.mspmote.MspMoteTimeEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -53,7 +53,7 @@ import org.contikios.cooja.mspmote.MspMoteTimeEvent;
  */
 @ClassDescription("IEEE 802.15.4 Bit Error Radio")
 public class Msp802154BitErrorRadio extends Msp802154Radio {
-  private static final Logger logger = LogManager.getLogger(Msp802154Radio.class);
+  private static final Logger logger = LoggerFactory.getLogger(Msp802154Radio.class);
 
   private static final double NOISE_FLOOR = AbstractRadioMedium.SS_WEAK;
   private static final double GOOD_SIGNAL = NOISE_FLOOR + 15.0;
@@ -331,7 +331,7 @@ public class Msp802154BitErrorRadio extends Msp802154Radio {
   @Override
   public void receiveCustomData(Object data) {
     if (!(data instanceof Byte)) {
-      logger.fatal("Bad custom data: " + data);
+      logger.error("Bad custom data: " + data);
       return;
     }
     lastIncomingByte = (Byte) data;

--- a/java/org/contikios/cooja/mspmote/interfaces/Msp802154Radio.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/Msp802154Radio.java
@@ -30,8 +30,6 @@
 
 package org.contikios.cooja.mspmote.interfaces;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
@@ -42,6 +40,8 @@ import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.mspmote.MspMote;
 import org.contikios.cooja.mspmote.MspMoteTimeEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.sics.mspsim.chip.CC2420;
 import se.sics.mspsim.chip.RFListener;
 import se.sics.mspsim.chip.Radio802154;
@@ -53,7 +53,7 @@ import se.sics.mspsim.chip.Radio802154;
  */
 @ClassDescription("IEEE 802.15.4 Radio")
 public class Msp802154Radio extends Radio implements CustomDataRadio {
-  private static final Logger logger = LogManager.getLogger(Msp802154Radio.class);
+  private static final Logger logger = LoggerFactory.getLogger(Msp802154Radio.class);
 
   /**
    * Cross-level:
@@ -249,7 +249,7 @@ public class Msp802154Radio extends Radio implements CustomDataRadio {
   @Override
   public void receiveCustomData(Object data) {
     if (!(data instanceof Byte)) {
-      logger.fatal("Bad custom data: " + data);
+      logger.error("Bad custom data: " + data);
       return;
     }
     lastIncomingByte = (Byte) data;

--- a/java/org/contikios/cooja/mspmote/interfaces/MspClock.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/MspClock.java
@@ -30,19 +30,19 @@
 
 package org.contikios.cooja.mspmote.interfaces;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.interfaces.Clock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Fredrik Osterlind
  */
 @ClassDescription("Cycle clock")
 public class MspClock extends Clock {
-  private static final Logger logger = LogManager.getLogger(MspClock.class);
+  private static final Logger logger = LoggerFactory.getLogger(MspClock.class);
 
   private long timeDrift; /* Microseconds */
   private double deviation;
@@ -54,7 +54,7 @@ public class MspClock extends Clock {
 
   @Override
   public void setTime(long newTime) {
-    logger.fatal("Can't change emulated CPU time");
+    logger.error("Can't change emulated CPU time");
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/interfaces/SkyCoffeeFilesystem.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/SkyCoffeeFilesystem.java
@@ -45,8 +45,6 @@ import javax.swing.JPanel;
 import javax.swing.JTable;
 import javax.swing.table.AbstractTableModel;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.coffee.CoffeeFS;
 import org.contikios.coffee.CoffeeFile;
@@ -55,6 +53,8 @@ import org.contikios.cooja.Cooja;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.dialogs.TableColumnAdjuster;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Mote user interface to Coffee manager.
@@ -64,7 +64,7 @@ import org.contikios.cooja.dialogs.TableColumnAdjuster;
  */
 @ClassDescription("Coffee Filesystem")
 public class SkyCoffeeFilesystem implements MoteInterface {
-  private static final Logger logger = LogManager.getLogger(SkyCoffeeFilesystem.class);
+  private static final Logger logger = LoggerFactory.getLogger(SkyCoffeeFilesystem.class);
 
   private final Mote mote;
 
@@ -141,7 +141,7 @@ public class SkyCoffeeFilesystem implements MoteInterface {
           }
 
           if (saveFile.exists() && !saveFile.canWrite()) {
-            logger.fatal("No write access to file: " + saveFile);
+            logger.error("No write access to file: " + saveFile);
             return;
           }
 
@@ -153,7 +153,7 @@ public class SkyCoffeeFilesystem implements MoteInterface {
                 logger.warn("Error when saving to file: " + saveFile.getName());
               }
             } catch (Exception e) {
-              logger.fatal("Coffee exception: " + e.getMessage(), e);
+              logger.error("Coffee exception: " + e.getMessage(), e);
             }
             updateFS();
           }, "coffeeFS.extractFile").start();
@@ -171,7 +171,7 @@ public class SkyCoffeeFilesystem implements MoteInterface {
               logger.info("Removing file: " + files[row].getName());
               coffeeFS.removeFile(files[row].getName());
             } catch (Exception e) {
-              logger.fatal("Coffee exception: " + e.getMessage(), e);
+              logger.error("Coffee exception: " + e.getMessage(), e);
             }
             updateFS();
           }, "coffeeFS.removeFile").start();
@@ -195,7 +195,7 @@ public class SkyCoffeeFilesystem implements MoteInterface {
       SkyFlash flash = mote.getInterfaces().getInterfaceOfType(SkyFlash.class);
       coffeeFS = new CoffeeFS(flash.m24p80);
     } catch (IOException e) {
-      logger.fatal(e.getMessage(), e);
+      logger.error(e.getMessage(), e);
       return;
     }
 
@@ -250,7 +250,7 @@ public class SkyCoffeeFilesystem implements MoteInterface {
         try {
           coffeeFS.insertFile(file);
         } catch (IOException e1) {
-          logger.fatal("Coffee exception when adding file '{}': {}", file.getName(), e1.getMessage(), e1);
+          logger.error("Coffee exception when adding file '{}': {}", file.getName(), e1.getMessage(), e1);
           return;
         }
         updateFS();
@@ -272,7 +272,7 @@ public class SkyCoffeeFilesystem implements MoteInterface {
       updateFS();
       return coffeeFS.extractFile(coffeeFile, new File(diskFilename));
     } catch (RuntimeException | IOException e) {
-      logger.fatal("Error: " + e.getMessage(), e);
+      logger.error("Error: " + e.getMessage(), e);
       return false;
     }
   }
@@ -282,7 +282,7 @@ public class SkyCoffeeFilesystem implements MoteInterface {
       updateFS();
       return coffeeFS.insertFile(diskFilename) != null;
     } catch (RuntimeException | IOException e) {
-      logger.fatal("Error: " + e.getMessage(), e);
+      logger.error("Error: " + e.getMessage(), e);
       return false;
     }
   }

--- a/java/org/contikios/cooja/mspmote/interfaces/SkyFlash.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/SkyFlash.java
@@ -39,20 +39,20 @@ import javax.swing.JButton;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.MoteInterface;
 import org.contikios.cooja.mspmote.MspMote;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Fredrik Osterlind
  */
 @ClassDescription("M25P80 Flash")
 public class SkyFlash implements MoteInterface {
-  private static final Logger logger = LogManager.getLogger(SkyFlash.class);
+  private static final Logger logger = LoggerFactory.getLogger(SkyFlash.class);
 
   protected final CoojaM25P80 m24p80;
 
@@ -92,7 +92,7 @@ public class SkyFlash implements MoteInterface {
       byte[] fileData = readDialogFileBytes(Cooja.getTopParentContainer());
       if (fileData != null) {
         if (fileData.length > CoojaM25P80.SIZE) {
-          logger.fatal("Too large data file: " + fileData.length + " > " + CoojaM25P80.SIZE);
+          logger.error("Too large data file: " + fileData.length + " > " + CoojaM25P80.SIZE);
           return;
         }
         m24p80.seek(0);
@@ -136,7 +136,7 @@ public class SkyFlash implements MoteInterface {
     }
 
     if (saveFile.exists() && !saveFile.canWrite()) {
-      logger.fatal("No write access to file: " + saveFile);
+      logger.error("No write access to file: " + saveFile);
       return;
     }
 
@@ -145,7 +145,7 @@ public class SkyFlash implements MoteInterface {
       outStream.write(data);
       outStream.close();
     } catch (Exception ex) {
-      logger.fatal("Could not write to file: " + saveFile);
+      logger.error("Could not write to file: " + saveFile);
     }
 
   }

--- a/java/org/contikios/cooja/mspmote/plugins/CodeUI.java
+++ b/java/org/contikios/cooja/mspmote/plugins/CodeUI.java
@@ -52,14 +52,14 @@ import javax.swing.text.Highlighter.HighlightPainter;
 
 import de.sciss.syntaxpane.DefaultSyntaxKit;
 import de.sciss.syntaxpane.components.Markers;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.Watchpoint;
 import org.contikios.cooja.WatchpointMote;
 import org.contikios.cooja.util.JSyntaxAddBreakpoint;
 import org.contikios.cooja.util.JSyntaxRemoveBreakpoint;
 import org.contikios.cooja.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Displays source code and allows a user to add and remove breakpoints.
@@ -67,7 +67,7 @@ import org.contikios.cooja.util.StringUtils;
  * @author Fredrik Osterlind
  */
 public class CodeUI extends JPanel {
-  private static final Logger logger = LogManager.getLogger(CodeUI.class);
+  private static final Logger logger = LoggerFactory.getLogger(CodeUI.class);
 
   static {
     DefaultSyntaxKit.initKit();

--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -58,8 +58,6 @@ import javax.swing.SwingUtilities;
 import javax.swing.plaf.basic.BasicComboBoxRenderer;
 import javax.swing.table.AbstractTableModel;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.HasQuickHelp;
 import org.contikios.cooja.util.EventTriggers;
 import org.jdom2.Element;
@@ -79,6 +77,8 @@ import org.contikios.cooja.dialogs.MessageList;
 import org.contikios.cooja.dialogs.MessageListUI;
 import org.contikios.cooja.mspmote.MspMote;
 import org.contikios.cooja.mspmote.MspMoteType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.sics.mspsim.core.EmulationException;
 import se.sics.mspsim.ui.DebugUI;
 import se.sics.mspsim.util.DebugInfo;
@@ -91,7 +91,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
   private static final int SOURCECODE = 0;
   private static final int BREAKPOINTS = 2;
 
-  private static final Logger logger = LogManager.getLogger(MspCodeWatcher.class);
+  private static final Logger logger = LoggerFactory.getLogger(MspCodeWatcher.class);
   private final Simulation simulation;
   private File currentCodeFile = null;
   private int currentLineNumber = -1;
@@ -343,7 +343,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
       currentCodeFile = f;
       currentLineNumber = debugInfo.getLine();
     } catch (Exception e) {
-      logger.fatal("Exception: " + e.getMessage(), e);
+      logger.error("Exception: " + e.getMessage(), e);
       currentCodeFile = null;
       currentLineNumber = -1;
     }
@@ -740,7 +740,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
       try {
         mspMote.getCPU().stepInstructions(1);
       } catch (EmulationException ex) {
-        logger.fatal("Error: ", ex);
+        logger.error("Error: ", ex);
       }
       showCurrentPC();
     }

--- a/java/org/contikios/cooja/mspmote/plugins/MspStackWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspStackWatcher.java
@@ -41,8 +41,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JToggleButton;
 import javax.swing.SwingUtilities;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
@@ -56,6 +54,8 @@ import org.contikios.cooja.SupportedArguments;
 import org.contikios.cooja.VisPlugin;
 import org.contikios.cooja.mspmote.MspMote;
 import org.contikios.cooja.mspmote.MspMoteType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import se.sics.mspsim.core.MSP430;
 import se.sics.mspsim.core.Memory.AccessMode;
 import se.sics.mspsim.core.RegisterMonitor;
@@ -65,7 +65,7 @@ import se.sics.mspsim.ui.StackUI;
 @PluginType(PluginType.PType.MOTE_PLUGIN)
 @SupportedArguments(motes = { MspMote.class })
 public class MspStackWatcher extends VisPlugin implements MotePlugin {
-  private static final Logger logger = LogManager.getLogger(MspStackWatcher.class);
+  private static final Logger logger = LoggerFactory.getLogger(MspStackWatcher.class);
 
   private final Simulation simulation;
   private final MSP430 cpu;

--- a/java/org/contikios/cooja/plugins/BufferListener.java
+++ b/java/org/contikios/cooja/plugins/BufferListener.java
@@ -83,8 +83,6 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.Mote;
@@ -104,6 +102,8 @@ import org.contikios.cooja.util.EventTriggers;
 import org.contikios.cooja.util.IPUtils;
 import org.contikios.cooja.util.StringUtils;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Fredrik Osterlind, Niclas Finne
@@ -111,7 +111,7 @@ import org.jdom2.Element;
 @ClassDescription("Buffer view")
 @PluginType(PluginType.PType.SIM_PLUGIN)
 public class BufferListener extends VisPlugin {
-  private static final Logger logger = LogManager.getLogger(BufferListener.class);
+  private static final Logger logger = LoggerFactory.getLogger(BufferListener.class);
 
   private final static int COLUMN_TIME = 0;
   private final static int COLUMN_FROM = 1;
@@ -604,7 +604,7 @@ public class BufferListener extends VisPlugin {
         }
         Cooja.setExternalToolsSetting("BUFFER_LISTENER_SAVEFILE", saveFile.getPath());
         if (saveFile.exists() && !saveFile.canWrite()) {
-          logger.fatal("No write access to file: " + saveFile);
+          logger.error("No write access to file: " + saveFile);
           return;
         }
         try (var outStream = new PrintWriter(Files.newBufferedWriter(saveFile.toPath(), UTF_8))) {
@@ -624,7 +624,7 @@ public class BufferListener extends VisPlugin {
           }
           outStream.print(sb);
         } catch (Exception ex) {
-          logger.fatal("Could not write to file: " + saveFile);
+          logger.error("Could not write to file: " + saveFile);
         }
       }
     }));
@@ -1763,17 +1763,17 @@ public class BufferListener extends VisPlugin {
         size = Integer.parseInt(infoComponent.getSize());
         if (size < 1 || size > MAX_BUFFER_SIZE) {
           /* Abort */
-          logger.fatal("Bad buffer size " + infoComponent.getSize() + ": min 1, max " + MAX_BUFFER_SIZE);
+          logger.error("Bad buffer size " + infoComponent.getSize() + ": min 1, max " + MAX_BUFFER_SIZE);
           return false;
         }
       } catch (RuntimeException e) {
-        logger.fatal("Failed parsing buffer size " + infoComponent.getSize() + ": " + e.getMessage(), e);
+        logger.error("Failed parsing buffer size " + infoComponent.getSize() + ": " + e.getMessage(), e);
         return false;
       }
       try {
         offset = Long.parseLong(infoComponent.getOffset());
       } catch (RuntimeException e) {
-        logger.fatal("Failed parsing buffer offset " + infoComponent.getOffset() + ": " + e.getMessage(), e);
+        logger.error("Failed parsing buffer offset " + infoComponent.getOffset() + ": " + e.getMessage(), e);
         /* Abort */
         return false;
       }
@@ -1850,17 +1850,17 @@ public class BufferListener extends VisPlugin {
         size = Integer.parseInt(infoComponent.getSize());
         if (size < 1 || size > MAX_BUFFER_SIZE) {
           /* Abort */
-          logger.fatal("Bad buffer size " + infoComponent.getSize() + ": min 1, max " + MAX_BUFFER_SIZE);
+          logger.error("Bad buffer size " + infoComponent.getSize() + ": min 1, max " + MAX_BUFFER_SIZE);
           return false;
         }
       } catch (RuntimeException e) {
-        logger.fatal("Failed parsing buffer size " + infoComponent.getSize() + ": " + e.getMessage(), e);
+        logger.error("Failed parsing buffer size " + infoComponent.getSize() + ": " + e.getMessage(), e);
         return false;
       }
       try {
         offset = Long.parseLong(infoComponent.getOffset());
       } catch (RuntimeException e) {
-        logger.fatal("Failed parsing buffer offset " + infoComponent.getOffset() + ": " + e.getMessage(), e);
+        logger.error("Failed parsing buffer offset " + infoComponent.getOffset() + ": " + e.getMessage(), e);
         /* Abort */
         return false;
       }

--- a/java/org/contikios/cooja/plugins/DGRMConfigurator.java
+++ b/java/org/contikios/cooja/plugins/DGRMConfigurator.java
@@ -52,8 +52,6 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellEditor;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
@@ -67,6 +65,8 @@ import org.contikios.cooja.radiomediums.AbstractRadioMedium;
 import org.contikios.cooja.radiomediums.DGRMDestinationRadio;
 import org.contikios.cooja.radiomediums.DirectedGraphMedium;
 import org.contikios.cooja.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Simple user interface for configuring edges for the Directed Graph
@@ -79,7 +79,7 @@ import org.contikios.cooja.util.StringUtils;
 @PluginType(PluginType.PType.SIM_PLUGIN)
 @SupportedArguments(radioMediums = {DirectedGraphMedium.class})
 public class DGRMConfigurator extends VisPlugin {
-	private static final Logger logger = LogManager.getLogger(DGRMConfigurator.class);
+	private static final Logger logger = LoggerFactory.getLogger(DGRMConfigurator.class);
 
   private final static int IDX_SRC = 0;
   private final static int IDX_DST = 1;
@@ -290,7 +290,7 @@ public class DGRMConfigurator extends VisPlugin {
     }
     File file = fc.getSelectedFile();
     if (file == null || !file.exists() || !file.canRead()) {
-      logger.fatal("No read access to file: " + file);
+      logger.error("No read access to file: " + file);
       return;
     }
     Cooja.setExternalToolsSetting("DGRM_IMPORT_LINKS_FILE", file.getPath());

--- a/java/org/contikios/cooja/plugins/LogListener.java
+++ b/java/org/contikios/cooja/plugins/LogListener.java
@@ -79,8 +79,6 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.HasQuickHelp;
@@ -93,6 +91,8 @@ import org.contikios.cooja.dialogs.TableColumnAdjuster;
 import org.contikios.cooja.dialogs.UpdateAggregator;
 import org.contikios.cooja.util.ArrayQueue;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A simple mote log listener.
@@ -103,7 +103,7 @@ import org.jdom2.Element;
 @ClassDescription("Mote output")
 @PluginType(PluginType.PType.SIM_STANDARD_PLUGIN)
 public class LogListener extends VisPlugin implements HasQuickHelp {
-  private static final Logger logger = LogManager.getLogger(LogListener.class);
+  private static final Logger logger = LoggerFactory.getLogger(LogListener.class);
 
   private final Color[] BG_COLORS = new Color[] {
       new Color(200, 200, 200),
@@ -310,7 +310,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
 
         Cooja.setExternalToolsSetting("LOG_LISTENER_SAVEFILE", saveFile.getPath());
         if (saveFile.exists() && !saveFile.canWrite()) {
-          logger.fatal("No write access to file: " + saveFile);
+          logger.error("No write access to file: " + saveFile);
           return;
         }
 
@@ -322,7 +322,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
                             data.ev.getMessage());
           }
         } catch (Exception ex) {
-          logger.fatal("Could not write to file: " + saveFile);
+          logger.error("Could not write to file: " + saveFile);
         }
       }
     };
@@ -351,7 +351,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
         File saveFile = fc.getSelectedFile();
         Cooja.setExternalToolsSetting("LOG_LISTENER_APPENDFILE", saveFile.getPath());
         if (saveFile.exists() && !saveFile.canWrite()) {
-          logger.fatal("No write access to file: " + saveFile);
+          logger.error("No write access to file: " + saveFile);
           appendToFile = false;
           cb.setSelected(false);
           return;
@@ -835,7 +835,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
         appendStreamFile = file;
         appendToFileWroteHeader = false;
       } catch (Exception ex) {
-        logger.fatal("Append file failed: " + ex.getMessage(), ex);
+        logger.error("Append file failed: " + ex.getMessage(), ex);
         return false;
       }
     }

--- a/java/org/contikios/cooja/plugins/PowerTracker.java
+++ b/java/org/contikios/cooja/plugins/PowerTracker.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Observable;
 import java.util.Observer;
-
 import javax.swing.AbstractAction;
 import javax.swing.Box;
 import javax.swing.JButton;
@@ -52,8 +51,6 @@ import javax.swing.JTable;
 import javax.swing.Timer;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.Mote;
@@ -64,6 +61,8 @@ import org.contikios.cooja.VisPlugin;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.util.EventTriggers;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Tracks radio events to sum up transmission, reception, and radio on times.
@@ -74,7 +73,7 @@ import org.jdom2.Element;
 @ClassDescription("Mote radio duty cycle")
 @PluginType(PluginType.PType.SIM_PLUGIN)
 public class PowerTracker implements Plugin {
-  private static final Logger logger = LogManager.getLogger(PowerTracker.class);
+  private static final Logger logger = LoggerFactory.getLogger(PowerTracker.class);
 
   private static final int POWERTRACKER_UPDATE_INTERVAL = 100; /* ms */
 
@@ -506,7 +505,7 @@ public class PowerTracker implements Plugin {
       removeMote(m);
     }
     if (!moteTrackers.isEmpty()) {
-      logger.fatal("Mote observers not cleaned up correctly");
+      logger.error("Mote observers not cleaned up correctly");
       for (MoteTracker t: moteTrackers.toArray(new MoteTracker[0])) {
         t.dispose();
       }

--- a/java/org/contikios/cooja/plugins/RadioLogger.java
+++ b/java/org/contikios/cooja/plugins/RadioLogger.java
@@ -78,8 +78,6 @@ import javax.swing.RowFilter;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.ConvertedRadioPacket;
 import org.contikios.cooja.Cooja;
@@ -100,6 +98,8 @@ import org.contikios.cooja.plugins.analyzers.PacketAnalyzer;
 import org.contikios.cooja.plugins.analyzers.RadioLoggerAnalyzerSuite;
 import org.contikios.cooja.util.StringUtils;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Radio logger listens to the simulation radio medium and lists all transmitted
@@ -111,7 +111,7 @@ import org.jdom2.Element;
 @PluginType(PluginType.PType.SIM_PLUGIN)
 public class RadioLogger extends VisPlugin {
 
-  private static final Logger logger = LogManager.getLogger(RadioLogger.class);
+  private static final Logger logger = LoggerFactory.getLogger(RadioLogger.class);
 
   private final static int COLUMN_NO = 0;
   private final static int COLUMN_TIME = 1;
@@ -525,7 +525,7 @@ public class RadioLogger extends VisPlugin {
         }
 
         if (saveFile.exists() && !saveFile.canWrite()) {
-          logger.fatal("No write access to file: " + saveFile);
+          logger.error("No write access to file: " + saveFile);
           return;
         }
 
@@ -536,7 +536,7 @@ public class RadioLogger extends VisPlugin {
           }
           outStream.close();
         } catch (Exception ex) {
-          logger.fatal("Could not write to file: " + saveFile);
+          logger.error("Could not write to file: " + saveFile);
         }
       }
     };

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -62,8 +62,6 @@ import javax.swing.event.DocumentListener;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 import javax.swing.filechooser.FileNameExtensionFilter;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.HasQuickHelp;
@@ -74,11 +72,13 @@ import org.contikios.cooja.Simulation;
 import org.contikios.cooja.VisPlugin;
 import org.contikios.cooja.util.StringUtils;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ClassDescription("Simulation script editor")
 @PluginType(PluginType.PType.SIM_CONTROL_PLUGIN)
 public class ScriptRunner implements Plugin, HasQuickHelp {
-  private static final Logger logger = LogManager.getLogger(ScriptRunner.class);
+  private static final Logger logger = LoggerFactory.getLogger(ScriptRunner.class);
 
   private final Cooja gui;
 
@@ -316,7 +316,7 @@ public class ScriptRunner implements Plugin, HasQuickHelp {
     try {
       script = engine.compileScript(getCombinedScripts());
     } catch (ScriptException e) {
-      logger.fatal("Test script error: ", e);
+      logger.error("Test script error: ", e);
       if (Cooja.isVisualized()) {
         Cooja.showErrorDialog("Script error", e, false);
       }

--- a/java/org/contikios/cooja/plugins/TimeLine.java
+++ b/java/org/contikios/cooja/plugins/TimeLine.java
@@ -77,8 +77,6 @@ import javax.swing.Timer;
 import javax.swing.ButtonGroup;
 import javax.swing.JRadioButtonMenuItem;
 import javax.swing.JSeparator;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.HasQuickHelp;
@@ -97,6 +95,8 @@ import org.contikios.cooja.interfaces.Radio.RadioEvent;
 import org.contikios.cooja.motes.AbstractEmulatedMote;
 import org.contikios.cooja.util.EventTriggers;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Shows events such as mote logs, LEDs, and radio transmissions, in a timeline.
@@ -125,7 +125,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
 
   private boolean needZoomOut = false;
 
-  private static final Logger logger = LogManager.getLogger(TimeLine.class);
+  private static final Logger logger = LoggerFactory.getLogger(TimeLine.class);
 
   private int paintedMoteHeight = EVENT_PIXEL_HEIGHT;
   private int paintEventMinWidth = PAINT_MIN_WIDTH_EVENTS;
@@ -286,7 +286,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
         }
 
         if (saveFile.exists() && !saveFile.canWrite()) {
-          logger.fatal("No write access to file");
+          logger.error("No write access to file");
           return;
         }
 
@@ -313,7 +313,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
             }
           }
         } catch (Exception ex) {
-          logger.fatal("Could not write to file: " + saveFile);
+          logger.error("Could not write to file: " + saveFile);
         }
       }
     }));
@@ -1865,7 +1865,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
       } else if (state == RXTXRadioEvent.INTERFERED) {
         return Color.RED;
       } else {
-        logger.fatal("Unknown RXTX event");
+        logger.error("Unknown RXTX event");
         return null;
       }
     }

--- a/java/org/contikios/cooja/plugins/VariableWatcher.java
+++ b/java/org/contikios/cooja/plugins/VariableWatcher.java
@@ -66,8 +66,6 @@ import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultFormatterFactory;
 import javax.swing.text.DocumentFilter;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.HasQuickHelp;
@@ -81,6 +79,8 @@ import org.contikios.cooja.mote.memory.UnknownVariableException;
 import org.contikios.cooja.mote.memory.VarMemory;
 import org.jdesktop.swingx.autocomplete.AutoCompleteDecorator;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Variable Watcher enables a user to watch mote variables during a simulation.
@@ -94,7 +94,7 @@ import org.jdom2.Element;
 @ClassDescription("Variable Watcher")
 @PluginType(PluginType.PType.MOTE_PLUGIN)
 public class VariableWatcher extends VisPlugin implements MotePlugin, HasQuickHelp {
-  private static final Logger logger = LogManager.getLogger(VariableWatcher.class.getName());
+  private static final Logger logger = LoggerFactory.getLogger(VariableWatcher.class.getName());
 
   private final static int LABEL_WIDTH = 170;
   private final static int LABEL_HEIGHT = 15;

--- a/java/org/contikios/cooja/plugins/Visualizer.java
+++ b/java/org/contikios/cooja/plugins/Visualizer.java
@@ -85,8 +85,6 @@ import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 import javax.swing.plaf.basic.BasicInternalFrameUI;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.mote.BaseContikiMoteType;
 import org.contikios.cooja.plugins.skins.DGRMVisualizerSkin;
 import org.contikios.cooja.plugins.skins.LogisticLossVisualizerSkin;
@@ -117,6 +115,8 @@ import org.contikios.cooja.plugins.skins.MoteTypeVisualizerSkin;
 import org.contikios.cooja.plugins.skins.PositionVisualizerSkin;
 import org.contikios.cooja.plugins.skins.TrafficVisualizerSkin;
 import org.contikios.cooja.plugins.skins.UDGMVisualizerSkin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Simulation visualizer supporting different visualizers
@@ -136,7 +136,7 @@ import org.contikios.cooja.plugins.skins.UDGMVisualizerSkin;
 @ClassDescription("Network")
 @PluginType(PluginType.PType.SIM_STANDARD_PLUGIN)
 public class Visualizer extends VisPlugin implements HasQuickHelp {
-  private static final Logger logger = LogManager.getLogger(Visualizer.class);
+  private static final Logger logger = LoggerFactory.getLogger(Visualizer.class);
 
   public static final int MOTE_RADIUS = 8;
   private static final Color[] DEFAULT_MOTE_COLORS = {Color.WHITE};
@@ -273,13 +273,13 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
           item.addItemListener(e1 -> {
             var menuItem = ((JCheckBoxMenuItem) e1.getItem());
             if (menuItem == null) {
-              logger.fatal("No menu item");
+              logger.error("No menu item");
               return;
             }
 
             var skinClass1 = (Class<VisualizerSkin>) menuItem.getClientProperty("skinclass");
             if (skinClass1 == null) {
-              logger.fatal("Unknown visualizer skin class");
+              logger.error("Unknown visualizer skin class");
               return;
             }
 
@@ -296,7 +296,7 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
                 }
               }
               if (skinToDeactivate == null) {
-                logger.fatal("Unknown visualizer to deactivate: " + skinClass1);
+                logger.error("Unknown visualizer to deactivate: " + skinClass1);
                 return;
               }
               skinToDeactivate.setInactive();
@@ -574,7 +574,7 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
                   menu.add(menuItem);
                 }
               } catch (InvocationTargetException | NoSuchMethodException | InstantiationException | IllegalAccessException e1) {
-                logger.fatal("Error: " + e1.getMessage(), e1);
+                logger.error("Error: " + e1.getMessage(), e1);
               }
             }
           }
@@ -608,7 +608,7 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
               menu.add(menuItem);
             }
           } catch (InvocationTargetException | NoSuchMethodException | InstantiationException | IllegalAccessException e1) {
-            logger.fatal("Error: " + e1.getMessage(), e1);
+            logger.error("Error: " + e1.getMessage(), e1);
           }
         }
 
@@ -763,7 +763,7 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
           return;
         }
         // TODO: implement drag and drop.
-        logger.fatal("Drag and drop not implemented: " + file);
+        logger.error("Drag and drop not implemented: " + file);
       }
 
       private boolean acceptOrRejectDrag(DropTargetDragEvent dtde) {

--- a/java/org/contikios/cooja/plugins/analyzers/IEEE802154Analyzer.java
+++ b/java/org/contikios/cooja/plugins/analyzers/IEEE802154Analyzer.java
@@ -2,14 +2,14 @@ package org.contikios.cooja.plugins.analyzers;
 
 import java.io.IOException;
 import java.io.File;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class IEEE802154Analyzer extends PacketAnalyzer {
 
-  private static final Logger logger = LogManager.getLogger(IEEE802154Analyzer.class);
+  private static final Logger logger = LoggerFactory.getLogger(IEEE802154Analyzer.class);
 
   // Addressing modes
   public static final int NO_ADDRESS = 0;

--- a/java/org/contikios/cooja/plugins/analyzers/PcapExporter.java
+++ b/java/org/contikios/cooja/plugins/analyzers/PcapExporter.java
@@ -4,11 +4,11 @@ import java.io.DataOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.File;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PcapExporter {
-  private static final Logger logger = LogManager.getLogger(PcapExporter.class);
+  private static final Logger logger = LoggerFactory.getLogger(PcapExporter.class);
 
   DataOutputStream out;
 

--- a/java/org/contikios/cooja/plugins/skins/AttributeVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/AttributeVisualizerSkin.java
@@ -36,8 +36,6 @@ import java.awt.Graphics;
 import java.awt.Point;
 import java.util.Observer;
 import java.util.function.BiConsumer;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
 import org.contikios.cooja.Simulation;
@@ -47,6 +45,8 @@ import org.contikios.cooja.plugins.Visualizer;
 import org.contikios.cooja.plugins.VisualizerSkin;
 import org.contikios.cooja.ui.ColorUtils;
 import org.contikios.cooja.util.EventTriggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Visualizer skin for mote attributes.
@@ -56,7 +56,7 @@ import org.contikios.cooja.util.EventTriggers;
  */
 @ClassDescription("Mote attributes")
 public class AttributeVisualizerSkin implements VisualizerSkin {
-  private static final Logger logger = LogManager.getLogger(AttributeVisualizerSkin.class);
+  private static final Logger logger = LoggerFactory.getLogger(AttributeVisualizerSkin.class);
 
   private Simulation simulation = null;
   private Visualizer visualizer = null;

--- a/java/org/contikios/cooja/plugins/skins/DGRMVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/DGRMVisualizerSkin.java
@@ -35,8 +35,6 @@ import java.awt.Graphics;
 import java.awt.Point;
 import java.util.Set;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
@@ -49,12 +47,14 @@ import org.contikios.cooja.plugins.VisualizerSkin;
 import org.contikios.cooja.radiomediums.DGRMDestinationRadio;
 import org.contikios.cooja.radiomediums.DestinationRadio;
 import org.contikios.cooja.radiomediums.DirectedGraphMedium;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ClassDescription("Radio environment (DGRM)")
 @SupportedArguments(radioMediums = {DirectedGraphMedium.class})
 public class DGRMVisualizerSkin implements VisualizerSkin {
 
-  private static final Logger logger = LogManager.getLogger(DGRMVisualizerSkin.class);
+  private static final Logger logger = LoggerFactory.getLogger(DGRMVisualizerSkin.class);
 
   private Simulation simulation = null;
   private Visualizer visualizer = null;
@@ -62,7 +62,7 @@ public class DGRMVisualizerSkin implements VisualizerSkin {
   @Override
   public void setActive(Simulation simulation, Visualizer vis) {
     if (!(simulation.getRadioMedium() instanceof DirectedGraphMedium)) {
-      logger.fatal("Cannot activate DGRM skin for unknown radio medium: " + simulation.getRadioMedium());
+      logger.error("Cannot activate DGRM skin for unknown radio medium: " + simulation.getRadioMedium());
       return;
     }
     this.simulation = simulation;

--- a/java/org/contikios/cooja/plugins/skins/LogisticLossVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/LogisticLossVisualizerSkin.java
@@ -38,8 +38,6 @@ import java.awt.Point;
 import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
 import java.util.Set;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
@@ -50,6 +48,8 @@ import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.plugins.Visualizer;
 import org.contikios.cooja.plugins.VisualizerSkin;
 import org.contikios.cooja.radiomediums.LogisticLoss;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Visualizer skin for configuring the LogisticLoss radio medium.
@@ -67,7 +67,7 @@ import org.contikios.cooja.radiomediums.LogisticLoss;
 @SupportedArguments(radioMediums = {LogisticLoss.class})
 public class LogisticLossVisualizerSkin implements VisualizerSkin {
 
-  private static final Logger logger = LogManager.getLogger(LogisticLossVisualizerSkin.class);
+  private static final Logger logger = LoggerFactory.getLogger(LogisticLossVisualizerSkin.class);
 
   private static final Color COLOR_TX = new Color(0, 255, 0, 100);
   private static final Color COLOR_INT = new Color(50, 50, 50, 100);
@@ -79,7 +79,7 @@ public class LogisticLossVisualizerSkin implements VisualizerSkin {
   @Override
   public void setActive(Simulation simulation, Visualizer vis) {
     if (!(simulation.getRadioMedium() instanceof LogisticLoss)) {
-      logger.fatal("Cannot activate LogisticLoss skin for unknown radio medium: " + simulation.getRadioMedium());
+      logger.error("Cannot activate LogisticLoss skin for unknown radio medium: " + simulation.getRadioMedium());
       return;
     }
     this.simulation = simulation;

--- a/java/org/contikios/cooja/plugins/skins/UDGMVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/UDGMVisualizerSkin.java
@@ -54,8 +54,6 @@ import static javax.swing.WindowConstants.DO_NOTHING_ON_CLOSE;
 import javax.swing.event.InternalFrameAdapter;
 import javax.swing.event.InternalFrameEvent;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
@@ -67,6 +65,8 @@ import org.contikios.cooja.plugins.Visualizer;
 import org.contikios.cooja.plugins.Visualizer.SimulationMenuAction;
 import org.contikios.cooja.plugins.VisualizerSkin;
 import org.contikios.cooja.radiomediums.UDGM;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Visualizer skin for configuring the Unit Disk Graph radio medium (UDGM).
@@ -86,7 +86,7 @@ import org.contikios.cooja.radiomediums.UDGM;
 @SupportedArguments(radioMediums = {UDGM.class})
 public class UDGMVisualizerSkin implements VisualizerSkin {
 
-  private static final Logger logger = LogManager.getLogger(UDGMVisualizerSkin.class);
+  private static final Logger logger = LoggerFactory.getLogger(UDGMVisualizerSkin.class);
 
   private static final Color COLOR_TX = new Color(0, 255, 0, 100);
   private static final Color COLOR_INT = new Color(50, 50, 50, 100);
@@ -101,7 +101,7 @@ public class UDGMVisualizerSkin implements VisualizerSkin {
   @Override
   public void setActive(Simulation simulation, Visualizer vis) {
     if (!(simulation.getRadioMedium() instanceof UDGM)) {
-      logger.fatal("Cannot activate UDGM skin for unknown radio medium: " + simulation.getRadioMedium());
+      logger.error("Cannot activate UDGM skin for unknown radio medium: " + simulation.getRadioMedium());
       return;
     }
     this.simulation = simulation;

--- a/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
+++ b/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
@@ -38,8 +38,6 @@ import java.util.Map.Entry;
 import java.util.Observable;
 import java.util.Observer;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.RadioConnection;
 import org.contikios.cooja.RadioMedium;
@@ -51,6 +49,8 @@ import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.util.EventTriggers;
 import org.contikios.cooja.util.ScnObservable;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -69,7 +69,7 @@ import org.jdom2.Element;
  * @author Fredrik Osterlind
  */
 public abstract class AbstractRadioMedium implements RadioMedium {
-	private static final Logger logger = LogManager.getLogger(AbstractRadioMedium.class);
+	private static final Logger logger = LoggerFactory.getLogger(AbstractRadioMedium.class);
 	
 	/* Signal strengths in dBm.
 	 * Approx. values measured on TmoteSky */
@@ -218,7 +218,7 @@ public abstract class AbstractRadioMedium implements RadioMedium {
 		@Override
 		public void update(Observable obs, Object obj) {
       if (!(obs instanceof Radio radio)) {
-				logger.fatal("Radio event dispatched by non-radio object");
+				logger.error("Radio event dispatched by non-radio object");
 				return;
 			}
 			final Radio.RadioEvent event = radio.getLastEvent();
@@ -238,7 +238,7 @@ public abstract class AbstractRadioMedium implements RadioMedium {
 				case HW_OFF: {
           // This radio must not be a connection source.
           if (getActiveConnectionFrom(radio) != null) {
-            logger.fatal("Connection source turned off radio: " + radio);
+            logger.error("Connection source turned off radio: " + radio);
           }
 
 					/* Remove any radio connections from this radio */
@@ -336,14 +336,14 @@ public abstract class AbstractRadioMedium implements RadioMedium {
 					/* Connection */
 					RadioConnection connection = getActiveConnectionFrom(radio);
 					if (connection == null) {
-						logger.fatal("No radio connection found");
+						logger.error("No radio connection found");
 						return;
 					}
 					
 					/* Custom data object */
 					Object data = ((CustomDataRadio) radio).getLastCustomDataTransmitted();
 					if (data == null) {
-						logger.fatal("No custom data objecTransmissiont to forward");
+						logger.error("No custom data objecTransmissiont to forward");
 						return;
 					}
 					
@@ -385,7 +385,7 @@ public abstract class AbstractRadioMedium implements RadioMedium {
 					/* Radio packet */
 					RadioPacket packet = radio.getLastPacketTransmitted();
 					if (packet == null) {
-						logger.fatal("No radio packet to forward");
+						logger.error("No radio packet to forward");
 						return;
 					}
 					
@@ -421,7 +421,7 @@ public abstract class AbstractRadioMedium implements RadioMedium {
 				}
 				break;
 				default:
-					logger.fatal("Unsupported radio event: " + event);
+					logger.error("Unsupported radio event: " + event);
 			}
 		}
 	};

--- a/java/org/contikios/cooja/radiomediums/DirectedGraphMedium.java
+++ b/java/org/contikios/cooja/radiomediums/DirectedGraphMedium.java
@@ -36,8 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.util.EventTriggers;
 import org.jdom2.Element;
 
@@ -46,6 +44,8 @@ import org.contikios.cooja.Mote;
 import org.contikios.cooja.RadioConnection;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.interfaces.Radio;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Directed Graph Radio Medium.
@@ -61,7 +61,7 @@ import org.contikios.cooja.interfaces.Radio;
  */
 @ClassDescription("Directed Graph Radio Medium (DGRM)")
 public class DirectedGraphMedium extends AbstractRadioMedium {
-  private static final Logger logger = LogManager.getLogger(DirectedGraphMedium.class);
+  private static final Logger logger = LoggerFactory.getLogger(DirectedGraphMedium.class);
 
   private final Random random;
 
@@ -92,7 +92,7 @@ public class DirectedGraphMedium extends AbstractRadioMedium {
 
   public void removeEdge(Edge edge) {
     if (!edges.contains(edge)) {
-      logger.fatal("Cannot remove edge: " + edge);
+      logger.error("Cannot remove edge: " + edge);
       return;
     }
     edges.remove(edge);
@@ -239,7 +239,7 @@ public class DirectedGraphMedium extends AbstractRadioMedium {
       analyzeEdges();
     }
     if (edgesDirty) {
-      logger.fatal("Error when analyzing edges, aborting new radio connection");
+      logger.error("Error when analyzing edges, aborting new radio connection");
       return new RadioConnection(source);
     }
 
@@ -403,7 +403,7 @@ public class DirectedGraphMedium extends AbstractRadioMedium {
           }
         }
         if (source == null || dest == null) {
-          logger.fatal("Failed loading DGRM links, aborting");
+          logger.error("Failed loading DGRM links, aborting");
           return false;
         } else {
           addEdge(new Edge(source, dest));

--- a/java/org/contikios/cooja/radiomediums/LogisticLoss.java
+++ b/java/org/contikios/cooja/radiomediums/LogisticLoss.java
@@ -34,8 +34,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Random;
 import java.util.Map;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.Cooja;
 import org.jdom2.Element;
 import org.contikios.cooja.ClassDescription;
@@ -45,6 +43,8 @@ import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.plugins.Visualizer;
 import org.contikios.cooja.plugins.skins.LogisticLossVisualizerSkin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The LogisticLoss radio medium aims to be more realistic as the UDGM radio medium
@@ -99,7 +99,7 @@ import org.contikios.cooja.plugins.skins.LogisticLossVisualizerSkin;
  */
 @ClassDescription("LogisticLoss Medium")
 public class LogisticLoss extends AbstractRadioMedium {
-    private static final Logger logger = LogManager.getLogger(LogisticLoss.class);
+    private static final Logger logger = LoggerFactory.getLogger(LogisticLoss.class);
 
     /* Success ratio of TX. If this fails, no radios receive the packet */
     public double SUCCESS_RATIO_TX = 1.0;

--- a/java/org/contikios/cooja/radiomediums/UDGM.java
+++ b/java/org/contikios/cooja/radiomediums/UDGM.java
@@ -32,8 +32,6 @@ package org.contikios.cooja.radiomediums;
 
 import java.util.Collection;
 import java.util.Random;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.contikios.cooja.Cooja;
 import org.jdom2.Element;
 
@@ -44,6 +42,8 @@ import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.plugins.Visualizer;
 import org.contikios.cooja.plugins.skins.UDGMVisualizerSkin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Unit Disk Graph Radio Medium abstracts radio transmission range as circles.
@@ -76,7 +76,7 @@ import org.contikios.cooja.plugins.skins.UDGMVisualizerSkin;
  */
 @ClassDescription("Unit Disk Graph Medium (UDGM): Distance Loss")
 public class UDGM extends AbstractRadioMedium {
-  private static final Logger logger = LogManager.getLogger(UDGM.class);
+  private static final Logger logger = LoggerFactory.getLogger(UDGM.class);
 
   public double SUCCESS_RATIO_TX = 1.0; /* Success ratio of TX. If this fails, no radios receive the packet */
   public double SUCCESS_RATIO_RX = 1.0; /* Success ratio of RX. If this fails, the single affected receiver does not receive the packet */

--- a/java/org/contikios/cooja/serialsocket/SerialSocketClient.java
+++ b/java/org/contikios/cooja/serialsocket/SerialSocketClient.java
@@ -59,8 +59,6 @@ import javax.swing.JSeparator;
 import javax.swing.JTextField;
 import javax.swing.border.EtchedBorder;
 import javax.swing.text.NumberFormatter;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jdom2.Element;
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
@@ -71,6 +69,8 @@ import org.contikios.cooja.PluginType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.VisPlugin;
 import org.contikios.cooja.interfaces.SerialPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Socket to simulated serial port forwarder. Client version.
@@ -81,7 +81,7 @@ import org.contikios.cooja.interfaces.SerialPort;
 @ClassDescription("Serial Socket (CLIENT)")
 @PluginType(PluginType.PType.MOTE_PLUGIN)
 public class SerialSocketClient implements Plugin, MotePlugin {
-  private static final Logger logger = LogManager.getLogger(SerialSocketClient.class);
+  private static final Logger logger = LoggerFactory.getLogger(SerialSocketClient.class);
 
   private static final String SERVER_DEFAULT_HOST = "localhost";
   private static final int SERVER_DEFAULT_PORT = 1234;

--- a/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
+++ b/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
@@ -63,12 +63,6 @@ import javax.swing.SwingUtilities;
 import javax.swing.Timer;
 import javax.swing.border.EtchedBorder;
 import javax.swing.text.NumberFormatter;
-
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-import org.contikios.cooja.util.EventTriggers;
-import org.jdom2.Element;
-
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Cooja;
 import org.contikios.cooja.Mote;
@@ -79,6 +73,10 @@ import org.contikios.cooja.Simulation;
 import org.contikios.cooja.VisPlugin;
 import org.contikios.cooja.interfaces.SerialPort;
 import org.contikios.cooja.util.CmdUtils;
+import org.contikios.cooja.util.EventTriggers;
+import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Socket to simulated serial port forwarder. Server version.
@@ -89,7 +87,7 @@ import org.contikios.cooja.util.CmdUtils;
 @ClassDescription("Serial Socket (SERVER)")
 @PluginType(PluginType.PType.MOTE_PLUGIN)
 public class SerialSocketServer implements Plugin, MotePlugin {
-  private static final Logger logger = LogManager.getLogger(SerialSocketServer.class);
+  private static final Logger logger = LoggerFactory.getLogger(SerialSocketServer.class);
 
   private final static int STATUSBAR_WIDTH = 350;
 

--- a/java/org/contikios/cooja/util/JSyntaxAddBreakpoint.java
+++ b/java/org/contikios/cooja/util/JSyntaxAddBreakpoint.java
@@ -38,13 +38,13 @@ import javax.swing.JMenuItem;
 
 import de.sciss.syntaxpane.actions.DefaultSyntaxAction;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.WatchpointMote;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JSyntaxAddBreakpoint extends DefaultSyntaxAction {
-  private static final Logger logger = LogManager.getLogger(JSyntaxAddBreakpoint.class);
+  private static final Logger logger = LoggerFactory.getLogger(JSyntaxAddBreakpoint.class);
 
   public JSyntaxAddBreakpoint() {
     super("addbreakpoint");

--- a/java/org/contikios/cooja/util/JSyntaxRemoveBreakpoint.java
+++ b/java/org/contikios/cooja/util/JSyntaxRemoveBreakpoint.java
@@ -37,14 +37,14 @@ import javax.swing.Action;
 import javax.swing.JMenuItem;
 
 import de.sciss.syntaxpane.actions.DefaultSyntaxAction;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.Watchpoint;
 import org.contikios.cooja.WatchpointMote;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JSyntaxRemoveBreakpoint extends DefaultSyntaxAction {
-  private static final Logger logger = LogManager.getLogger(JSyntaxRemoveBreakpoint.class);
+  private static final Logger logger = LoggerFactory.getLogger(JSyntaxRemoveBreakpoint.class);
 
   public JSyntaxRemoveBreakpoint() {
     super("removebreakpoint");

--- a/java/org/contikios/mrm/AngleInterval.java
+++ b/java/org/contikios/mrm/AngleInterval.java
@@ -33,9 +33,9 @@ package org.contikios.mrm;
 import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
 import java.util.Vector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 /**
  * This class represents an angle interval.
@@ -43,7 +43,7 @@ import org.apache.logging.log4j.LogManager;
  * @author Fredrik Osterlind
  */
 class AngleInterval {
-  private static final Logger logger = LogManager.getLogger(AngleInterval.class);
+  private static final Logger logger = LoggerFactory.getLogger(AngleInterval.class);
   
   // Sub intervals all between 0 and 2*PI
   final Vector<Interval> subIntervals;
@@ -146,7 +146,7 @@ class AngleInterval {
     }
     
     if (afterIntersectionIntervals.size() > 2) {
-      logger.fatal("AngleInterval.intersectWith() error!");
+      logger.error("AngleInterval.intersectWith() error!");
     } else if (afterIntersectionIntervals.size() == 2) {
       
       // The interval (y-x) is divided into:

--- a/java/org/contikios/mrm/AreaViewer.java
+++ b/java/org/contikios/mrm/AreaViewer.java
@@ -88,8 +88,6 @@ import javax.swing.Popup;
 import javax.swing.PopupFactory;
 import javax.swing.ProgressMonitor;
 import javax.swing.filechooser.FileNameExtensionFilter;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jdom2.Element;
 
 import org.contikios.cooja.ClassDescription;
@@ -102,6 +100,8 @@ import org.contikios.cooja.interfaces.DirectionalAntennaRadio;
 import org.contikios.cooja.interfaces.Position;
 import org.contikios.cooja.interfaces.Radio;
 import org.contikios.mrm.ChannelModel.TxPair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The class AreaViewer belongs to the MRM package.
@@ -120,7 +120,7 @@ import org.contikios.mrm.ChannelModel.TxPair;
 @PluginType(PluginType.PType.SIM_PLUGIN)
 @SupportedArguments(radioMediums = {MRM.class})
 public class AreaViewer extends VisPlugin {
-  private static final Logger logger = LogManager.getLogger(AreaViewer.class);
+  private static final Logger logger = LoggerFactory.getLogger(AreaViewer.class);
 
   private final JPanel canvas = new JPanel() {
     @Override
@@ -537,7 +537,7 @@ public class AreaViewer extends VisPlugin {
             repaint();
             break;
           default:
-            logger.fatal("Unhandled action command: " + e.getActionCommand());
+            logger.error("Unhandled action command: " + e.getActionCommand());
             break;
         }
       }
@@ -551,7 +551,7 @@ public class AreaViewer extends VisPlugin {
         }
         File file = fileChooser.getSelectedFile();
         if (!filter.accept(file)) {
-          logger.fatal("Non-supported file type, aborting");
+          logger.error("Non-supported file type, aborting");
           return false;
         }
         Toolkit toolkit = Toolkit.getDefaultToolkit();
@@ -565,14 +565,14 @@ public class AreaViewer extends VisPlugin {
             return false;
           }
         } catch (InterruptedException ex) {
-          logger.fatal("Interrupted during image loading, aborting");
+          logger.error("Interrupted during image loading, aborting");
           return false;
         }
 
         // Set virtual size of image.
         var dialog = new ImageSettingsDialog();
         if (!dialog.terminatedOK()) {
-          logger.fatal("User canceled, aborting");
+          logger.error("User canceled, aborting");
           return false;
         }
 
@@ -593,7 +593,7 @@ public class AreaViewer extends VisPlugin {
 
         var parentContainer = Cooja.getTopParentContainer();
         if (parentContainer == null) {
-          logger.fatal("Unknown parent container");
+          logger.error("Unknown parent container");
           return false;
         }
         // Show obstacle finder dialog.
@@ -643,7 +643,7 @@ public class AreaViewer extends VisPlugin {
             if (pm.isCanceled()) {
               return;
             }
-            logger.fatal("Obstacle adding exception: " + ex.getMessage());
+            logger.error("Obstacle adding exception: " + ex.getMessage());
             ex.printStackTrace();
             pm.close();
             return;
@@ -885,7 +885,7 @@ public class AreaViewer extends VisPlugin {
     try {
       tracker.waitForAll();
     } catch (InterruptedException ex) {
-      logger.fatal("Interrupted during image loading, aborting");
+      logger.error("Interrupted during image loading, aborting");
     }
   }
 
@@ -1651,7 +1651,7 @@ public class AreaViewer extends VisPlugin {
         if (pm.isCanceled()) {
           return;
         }
-        logger.fatal("Attenuation aborted: " + ex, ex);
+        logger.error("Attenuation aborted: " + ex, ex);
       }
       pm.close();
     }, "repaintRadioEnvironment");
@@ -2005,7 +2005,7 @@ public class AreaViewer extends VisPlugin {
     if (currentRadioMedium != null && radioMediumActivityObserver != null) {
       currentRadioMedium.deleteRadioTransmissionObserver(radioMediumActivityObserver);
     } else {
-      logger.fatal("Could not remove observer: " + radioMediumActivityObserver);
+      logger.error("Could not remove observer: " + radioMediumActivityObserver);
     }
   }
 
@@ -2171,7 +2171,7 @@ public class AreaViewer extends VisPlugin {
             try {
               tracker.waitForAll();
             } catch (InterruptedException ex) {
-              logger.fatal("Interrupted during image loading, aborting");
+              logger.error("Interrupted during image loading, aborting");
               backgroundImage = null;
             }
           }
@@ -2181,7 +2181,7 @@ public class AreaViewer extends VisPlugin {
         case "back_width" -> backgroundWidth = Double.parseDouble(element.getText());
         case "back_height" -> backgroundHeight = Double.parseDouble(element.getText());
         case "resolution" -> resolutionSlider.setValue(Integer.parseInt(element.getText()));
-        default -> logger.fatal("Unknown configuration value: " + name);
+        default -> logger.error("Unknown configuration value: " + name);
       }
     }
 

--- a/java/org/contikios/mrm/ChannelModel.java
+++ b/java/org/contikios/mrm/ChannelModel.java
@@ -43,8 +43,6 @@ import java.util.Random;
 import java.util.Vector;
 import javax.swing.tree.DefaultMutableTreeNode;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jdom2.Element;
 
 import org.contikios.cooja.Simulation;
@@ -53,6 +51,8 @@ import org.contikios.cooja.interfaces.Radio;
 import org.contikios.cooja.radiomediums.AbstractRadioMedium;
 import org.contikios.cooja.util.EventTriggers;
 import org.contikios.mrm.statistics.GaussianWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The channel model object in MRM is responsible for calulating propagation
@@ -66,7 +66,7 @@ import org.contikios.mrm.statistics.GaussianWrapper;
  * @author Fredrik Osterlind
  */
 public class ChannelModel {
-  private static final Logger logger = LogManager.getLogger(ChannelModel.class);
+  private static final Logger logger = LoggerFactory.getLogger(ChannelModel.class);
 
   private static final double C = 299792458; /* m/s */
 
@@ -312,7 +312,7 @@ public class ChannelModel {
   public Object getParameterValue(Parameter id) {
     Object value = parameters.get(id);
     if (value == null) {
-      logger.fatal("No parameter with id:" + id + ", aborting");
+      logger.error("No parameter with id:" + id + ", aborting");
       return null;
     }
     return value;
@@ -356,7 +356,7 @@ public class ChannelModel {
    */
   public void setParameterValue(Parameter id, Object newValue) {
     if (!parameters.containsKey(id)) {
-      logger.fatal("No parameter with id:" + id + ", aborting");
+      logger.error("No parameter with id:" + id + ", aborting");
       return;
     }
     parameters.put(id, newValue);
@@ -1755,7 +1755,7 @@ public class ChannelModel {
         } else if (paramClass == Integer.class) {
           parameters.put(param, Integer.parseInt(value));
         } else {
-          logger.fatal("Unsupported class type: " + paramClass);
+          logger.error("Unsupported class type: " + paramClass);
         }
       }
     }

--- a/java/org/contikios/mrm/Interval.java
+++ b/java/org/contikios/mrm/Interval.java
@@ -31,8 +31,8 @@
 package org.contikios.mrm;
 
 import java.util.Vector;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class represents an interval. Some operations on these intervals exist,
@@ -42,7 +42,7 @@ import org.apache.logging.log4j.LogManager;
  * @author Fredrik Osterlind
  */
 class Interval {
-  private static final Logger logger = LogManager.getLogger(Interval.class);
+  private static final Logger logger = LoggerFactory.getLogger(Interval.class);
   
   private double lowValue;
   private double highValue;
@@ -127,7 +127,7 @@ class Interval {
         highValue <= interval.getHigh())
       return new Interval(interval.getLow(), highValue);
     
-    logger.fatal("DoubleInterval.intersectWithInterval(), error!");
+    logger.error("DoubleInterval.intersectWithInterval(), error!");
     return null;
   }
   
@@ -193,7 +193,7 @@ class Interval {
       return returnIntervals;
     }
     
-    logger.fatal("DoubleInterval.subtractInterval(), error!");
+    logger.error("DoubleInterval.subtractInterval(), error!");
     return null;
   }
   

--- a/java/org/contikios/mrm/MRMVisualizerSkin.java
+++ b/java/org/contikios/mrm/MRMVisualizerSkin.java
@@ -34,8 +34,6 @@ import java.awt.Graphics;
 import java.awt.Point;
 import java.util.Set;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 import org.contikios.cooja.ClassDescription;
 import org.contikios.cooja.Mote;
@@ -47,12 +45,14 @@ import org.contikios.cooja.plugins.Visualizer;
 import org.contikios.cooja.plugins.VisualizerSkin;
 import org.contikios.mrm.ChannelModel.RadioPair;
 import org.contikios.mrm.ChannelModel.TxPair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ClassDescription("Radio environment (MRM)")
 @SupportedArguments(radioMediums = {MRM.class})
 public class MRMVisualizerSkin implements VisualizerSkin {
 
-  private static final Logger logger = LogManager.getLogger(MRMVisualizerSkin.class);
+  private static final Logger logger = LoggerFactory.getLogger(MRMVisualizerSkin.class);
 
   private Simulation simulation = null;
   private Visualizer visualizer = null;
@@ -60,7 +60,7 @@ public class MRMVisualizerSkin implements VisualizerSkin {
   @Override
   public void setActive(Simulation simulation, Visualizer vis) {
     if (!(simulation.getRadioMedium() instanceof MRM)) {
-      logger.fatal("Cannot activate MRM skin for unknown radio medium: " + simulation.getRadioMedium());
+      logger.error("Cannot activate MRM skin for unknown radio medium: " + simulation.getRadioMedium());
       return;
     }
     this.simulation = simulation;

--- a/java/org/contikios/mrm/ObstacleWorld.java
+++ b/java/org/contikios/mrm/ObstacleWorld.java
@@ -38,9 +38,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.Vector;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class represents an area with obstacles.
@@ -49,7 +49,7 @@ import org.jdom2.Element;
  * @author Fredrik Osterlind
  */
 class ObstacleWorld {
-  private static final Logger logger = LogManager.getLogger(ObstacleWorld.class);
+  private static final Logger logger = LoggerFactory.getLogger(ObstacleWorld.class);
   
   // All registered obstacles
   private final Vector<Rectangle2D> allObstacles;


### PR DESCRIPTION
This reduces the startup time so Cooja
spends more time in Thread.run() than
in Main.main (47.9% vs 43.7% on
27-cooja-rpl-tsch-orchestra-root-rule-storing).

This also removes a failure on log4j initialization after running native-image.