### PR TITLE
MSP430 motes: push getEntries() inwards

### DIFF
--- a/java/org/contikios/cooja/mspmote/Exp5438Mote.java
+++ b/java/org/contikios/cooja/mspmote/Exp5438Mote.java
@@ -29,10 +29,8 @@
 
 package org.contikios.cooja.mspmote;
 
-import java.util.Map;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
-import org.contikios.cooja.mote.memory.MemoryInterface.Symbol;
 import se.sics.mspsim.platform.GenericNode;
 
 /**
@@ -41,9 +39,9 @@ import se.sics.mspsim.platform.GenericNode;
 public class Exp5438Mote extends MspMote {
   private final String description;
   
-  public Exp5438Mote(MspMoteType moteType, Simulation sim, GenericNode node, String desc, Map<String, Symbol> symbols)
+  public Exp5438Mote(MspMoteType moteType, Simulation sim, GenericNode node, String desc)
           throws MoteType.MoteTypeCreationException {
-    super(moteType, sim, node, symbols);
+    super(moteType, sim, node);
     description = desc;
   }
 

--- a/java/org/contikios/cooja/mspmote/Exp5438MoteType.java
+++ b/java/org/contikios/cooja/mspmote/Exp5438MoteType.java
@@ -84,7 +84,7 @@ public class Exp5438MoteType extends MspMoteType {
     } else {
       throw new IllegalStateException("Unknown file extension, cannot figure out what MSPSim node type to use: " + filename);
     }
-    return new Exp5438Mote(this, simulation, exp5438Node, desc, getEntries(exp5438Node));
+    return new Exp5438Mote(this, simulation, exp5438Node, desc);
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -33,7 +33,6 @@ package org.contikios.cooja.mspmote;
 import java.awt.Component;
 import java.io.File;
 import java.io.PrintStream;
-import java.util.Map;
 import org.contikios.cooja.Simulation.SimulationStop;
 import org.contikios.cooja.WatchpointMote;
 import org.contikios.cooja.ContikiError;
@@ -42,7 +41,6 @@ import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.Watchpoint;
-import org.contikios.cooja.mote.memory.MemoryInterface.Symbol;
 import org.contikios.cooja.motes.AbstractEmulatedMote;
 import org.contikios.cooja.mspmote.plugins.CodeVisualizerSkin;
 import org.contikios.cooja.mspmote.plugins.MspBreakpoint;
@@ -91,8 +89,8 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
   /* Stack monitoring variables */
   private boolean stopNextInstruction = false;
 
-  public MspMote(MspMoteType moteType, Simulation sim, GenericNode node, Map<String, Symbol> symbols) throws MoteType.MoteTypeCreationException {
-    super(moteType, new MspMoteMemory(symbols, node.getCPU()), sim);
+  public MspMote(MspMoteType moteType, Simulation sim, GenericNode node) throws MoteType.MoteTypeCreationException {
+    super(moteType, new MspMoteMemory(moteType.getEntries(node), node.getCPU()), sim);
     registry = node.getRegistry();
     node.setCommandHandler(commandHandler);
     node.setup(new ConfigManager());

--- a/java/org/contikios/cooja/mspmote/SkyMote.java
+++ b/java/org/contikios/cooja/mspmote/SkyMote.java
@@ -30,10 +30,8 @@
 
 package org.contikios.cooja.mspmote;
 
-import java.util.Map;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
-import org.contikios.cooja.mote.memory.MemoryInterface.Symbol;
 import se.sics.mspsim.platform.sky.SkyNode;
 
 /**
@@ -42,8 +40,8 @@ import se.sics.mspsim.platform.sky.SkyNode;
 public class SkyMote extends MspMote {
   public final SkyNode skyNode;
 
-  public SkyMote(MspMoteType moteType, Simulation sim, SkyNode node, Map<String, Symbol> symbols) throws MoteType.MoteTypeCreationException {
-    super(moteType, sim, node, symbols);
+  public SkyMote(MspMoteType moteType, Simulation sim, SkyNode node) throws MoteType.MoteTypeCreationException {
+    super(moteType, sim, node);
     skyNode = node;
   }
 

--- a/java/org/contikios/cooja/mspmote/SkyMoteType.java
+++ b/java/org/contikios/cooja/mspmote/SkyMoteType.java
@@ -60,7 +60,7 @@ public class SkyMoteType extends MspMoteType {
   public MspMote generateMote(Simulation simulation) throws MoteTypeCreationException {
     var node = new SkyNode();
     node.setFlash(new CoojaM25P80(node.getCPU()));
-    return new SkyMote(this, simulation, node, getEntries(node));
+    return new SkyMote(this, simulation, node);
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/Z1Mote.java
+++ b/java/org/contikios/cooja/mspmote/Z1Mote.java
@@ -29,19 +29,16 @@
  */
 
 package org.contikios.cooja.mspmote;
-import java.util.Map;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
-import org.contikios.cooja.mote.memory.MemoryInterface.Symbol;
 import se.sics.mspsim.platform.z1.Z1Node;
 
 /**
  * @author Fredrik Osterlind, Niclas Finne
  */
 public class Z1Mote extends MspMote {
-
-    public Z1Mote(MspMoteType moteType, Simulation sim, Z1Node node, Map<String, Symbol> symbols) throws MoteType.MoteTypeCreationException {
-        super(moteType, sim, node, symbols);
+    public Z1Mote(MspMoteType moteType, Simulation sim, Z1Node node) throws MoteType.MoteTypeCreationException {
+        super(moteType, sim, node);
     }
 
     @Override

--- a/java/org/contikios/cooja/mspmote/Z1MoteType.java
+++ b/java/org/contikios/cooja/mspmote/Z1MoteType.java
@@ -71,7 +71,7 @@ public class Z1MoteType extends MspMoteType {
     public MspMote generateMote(Simulation simulation) throws MoteTypeCreationException {
         var node = new Z1Node();
         node.setFlash(new CoojaM25P80(node.getCPU()));
-        return new Z1Mote(this, simulation, node, getEntries(node));
+        return new Z1Mote(this, simulation, node);
     }
 
     @Override


### PR DESCRIPTION
Call getEntries() from the MspMote constructor
instead of all the subclasses.

The reason to not push it further inwards
is for alignment between MspMoteMemory
and SectionMoteMemory.