### PR TITLE
ContikiMoteType: remove C_SOURCES support

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -48,6 +48,11 @@ use a double dash for consistency.
 
 ## Cooja API changes for plugins outside the main tree
 
+### Removed C_SOURCES support in ContikiMoteType
+
+No immediate replacement, report a bug on Cooja in the Contiki-NG repository
+if you need this feature.
+
 ### Removed Observable from Log interface
 
 Call addTrigger/removeTrigger/deleteTriggers on `getLogDataTriggers()` instead.

--- a/java/org/contikios/cooja/COOJAProject.java
+++ b/java/org/contikios/cooja/COOJAProject.java
@@ -135,9 +135,6 @@ public class COOJAProject {
 	public String[] getConfigJARs() {
 		return getStringArray("org.contikios.cooja.Cooja.JARFILES");
 	}
-	public String[] getConfigCSources() {
-		return getStringArray("org.contikios.cooja.contikimote.ContikiMoteType.C_SOURCES");
-	}
 
 	@Override
 	public String toString() {

--- a/java/org/contikios/cooja/ProjectConfig.java
+++ b/java/org/contikios/cooja/ProjectConfig.java
@@ -110,7 +110,6 @@ public class ProjectConfig {
     if (useDefault) {
       var settings = new Properties();
       settings.put("org.contikios.cooja.contikimote.interfaces.ContikiRadio.RADIO_TRANSMISSION_RATE_kbps", "250");
-      settings.put("org.contikios.cooja.contikimote.ContikiMoteType.C_SOURCES", "");
       appendConfig(myConfig, settings);
     }
   }

--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -204,32 +204,11 @@ public class ContikiMoteType extends BaseContikiMoteType {
 
   @Override
   public LinkedHashMap<String, String> getCompilationEnvironment() {
-    var sources = new StringBuilder();
-    var dirs = new StringBuilder();
-    // Check whether Cooja projects include additional sources.
-    String[] coojaSources = getConfig().getStringArrayValue(ContikiMoteType.class, "C_SOURCES");
-    if (coojaSources != null) {
-      for (String s : coojaSources) {
-        if (s.trim().isEmpty()) {
-          continue;
-        }
-        File p = getConfig().getUserProjectDefining(ContikiMoteType.class, "C_SOURCES", s);
-        if (p == null) {
-          logger.warn("Project defining C_SOURCES$" + s + " not found");
-          continue;
-        }
-        sources.append(s).append(" ");
-        dirs.append(p.getPath()).append(" ");
-      }
-    }
-
     // Create the compilation environment.
     String ccFlags = Cooja.getExternalToolsSetting("COMPILER_ARGS", "");
     var env = new LinkedHashMap<String, String>();
     env.put("LIBNAME", "$(BUILD_DIR_BOARD)/" + getIdentifier() + ".cooja");
     env.put("COOJA_VERSION",  Cooja.CONTIKI_NG_BUILD_VERSION);
-    env.put("COOJA_SOURCEDIRS", dirs.toString().replace("\\", "/"));
-    env.put("COOJA_SOURCEFILES", sources.toString());
     env.put("CC", Cooja.getExternalToolsSetting("PATH_C_COMPILER"));
     env.put("EXTRA_CC_ARGS", ccFlags);
     env.put("PATH", System.getenv("PATH"));

--- a/java/org/contikios/cooja/dialogs/ProjectDirectoriesDialog.java
+++ b/java/org/contikios/cooja/dialogs/ProjectDirectoriesDialog.java
@@ -392,9 +392,6 @@ public class ProjectDirectoriesDialog extends JDialog {
       projectInfo.append(sb.append("\n").toString());
       sb.setLength(0);
     }
-		if (project.getConfigCSources() != null) {
-			projectInfo.append("Cooja mote C sources: " + Arrays.toString(project.getConfigCSources()) + "\n");
-		}
 	}
 
 	public COOJAProject[] getProjects() {


### PR DESCRIPTION
This feature complicates both Cooja itself,
and the Contiki-NG build system.