### PR TITLE
ArrayMemory: remove one constructor

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -434,14 +434,8 @@ public class ContikiMoteType extends BaseContikiMoteType {
                   entry.getValue().size));
         }
       }
-
-      return new ArrayMemory(
-              getStartAddr() + offset,
-              getSize(),
-              MemoryLayout.getNative(),
-              variables);
+      return new ArrayMemory(getStartAddr() + offset, MemoryLayout.getNative(), new byte[getSize()], variables);
     }
-
   }
 
   /**

--- a/java/org/contikios/cooja/mote/memory/ArrayMemory.java
+++ b/java/org/contikios/cooja/mote/memory/ArrayMemory.java
@@ -44,10 +44,6 @@ public class ArrayMemory implements MemoryInterface {
   private final MemoryLayout layout;
   private final Map<String, Symbol> symbols;// XXX Allow to set symbols
 
-  public ArrayMemory(long address, int size, MemoryLayout layout, Map<String, Symbol> symbols) {
-    this(address, layout, new byte[size], symbols);
-  }
-
   public ArrayMemory(long address, MemoryLayout layout, byte[] memory, Map<String, Symbol> symbols) {
     this.startAddress = address;
     this.layout = layout;


### PR DESCRIPTION
Call the other constructor directly from
ContikiMoteType instead.