### PR TITLE
gradle: run from current working dir

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,4 +138,6 @@ run {
   systemProperty 'logback.configurationFile', 'logback.xml'
   // Enable assertions with "-Passertions".
   enableAssertions = project.hasProperty('assertions')
+  // Prevent Gradle from changing directory to tools/cooja.
+  workingDir = System.getProperty("user.dir")
 }

--- a/java/se/sics/mspsim/platform/GenericNode.java
+++ b/java/se/sics/mspsim/platform/GenericNode.java
@@ -116,19 +116,17 @@ public abstract class GenericNode extends Chip implements Runnable {
     }
     /* Ensure auto-run of a start script */
     if (config.getProperty("autorun") == null) {
-      File fp = new File("scripts/autorun.sc");
-      if (fp.exists()) {
-        config.setProperty("autorun", "scripts/autorun.sc");
-      } else {
+      File fp = new File("config/scripts/autorun.sc");
+      if (!fp.exists()) {
         try {
           File dir = new File(GenericNode.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile().getParentFile();
           fp = new File(dir, "resources/main/scripts/autorun.sc");
-          if (fp.exists()) {
-            config.setProperty("autorun", fp.getAbsolutePath());
-          }
         } catch (URISyntaxException e) {
           // Failed to find auto run script
         }
+      }
+      if (fp.exists()) {
+        config.setProperty("autorun", fp.getAbsolutePath());
       }
     }
 

--- a/java/se/sics/mspsim/platform/GenericNode.java
+++ b/java/se/sics/mspsim/platform/GenericNode.java
@@ -118,11 +118,18 @@ public abstract class GenericNode extends Chip implements Runnable {
     if (config.getProperty("autorun") == null) {
       File fp = new File("config/scripts/autorun.sc");
       if (!fp.exists()) {
+        File parent;
         try {
-          File dir = new File(GenericNode.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile().getParentFile();
-          fp = new File(dir, "resources/main/scripts/autorun.sc");
+          parent = new File(GenericNode.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile().getParentFile();
         } catch (URISyntaxException e) {
-          // Failed to find auto run script
+          parent = null;
+        }
+        if (parent != null) {
+          var autoRunScript = "resources/main/scripts/autorun.sc";
+          fp = new File(parent, autoRunScript);
+          if (!fp.exists()) { // Running from gradle, outside project dir.
+            fp = new File(parent.getParentFile(), autoRunScript);
+          }
         }
       }
       if (fp.exists()) {


### PR DESCRIPTION
Stop Gradle from changing working directory
when using gradle run.
    
This removes the need for absolute paths
passed command line options, so:
    
cooja --args="--no-gui 02-ringbufindex.csc"
    
works when standing in tests/07-simulation-base.
