### PR TITLE
Remove unused method from LogOutputListener

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -55,6 +55,11 @@ use a double dash for consistency.
 
 ## Cooja API changes for plugins outside the main tree
 
+### Removed removedLogOutput in LogOutputListener
+
+Plugins that need information on when pruning happens can implement the functionality
+internally, either by maintaining a counter, or keeping a full copy of the events.
+
 ### Removed C_SOURCES support in ContikiMoteType
 
 No immediate replacement, report a bug on Cooja in the Contiki-NG repository

--- a/java/org/contikios/cooja/LogScriptEngine.java
+++ b/java/org/contikios/cooja/LogScriptEngine.java
@@ -98,9 +98,6 @@ public class LogScriptEngine {
         simulation.stopSimulation(1);
       }
     }
-    @Override
-    public void removedLogOutput(LogOutputEvent ev) {
-    }
   };
 
   private Semaphore semaphoreScript = null; /* Semaphores blocking script/simulation */

--- a/java/org/contikios/cooja/SimEventCentral.java
+++ b/java/org/contikios/cooja/SimEventCentral.java
@@ -68,14 +68,9 @@ public class SimEventCentral {
 
       // Evict the oldest event if the buffer will get full by the current message.
       if (logOutputEvents.size() > logOutputBufferSize - 1) {
-        LogOutputEvent removed;
         synchronized (logOutputEvents) {
-          removed = logOutputEvents.pollFirst();
-        }
-        if (removed != null) {
-          for (var l : logOutputListeners) {
-            l.removedLogOutput(removed);
-          }
+          // Use pollFirst since it does not throw exceptions like removeFirst when the queue is empty.
+          logOutputEvents.pollFirst();
         }
       }
 
@@ -169,7 +164,6 @@ public class SimEventCentral {
   private int logOutputBufferSize = Integer.parseInt(Cooja.getExternalToolsSetting("BUFFERSIZE_LOGOUTPUT", "" + 40000));
   private final ArrayDeque<LogOutputEvent> logOutputEvents = new ArrayDeque<>();
   public interface LogOutputListener {
-    void removedLogOutput(LogOutputEvent ev);
     void newLogOutput(LogOutputEvent ev);
   }
   /** Log output: notifications and history */
@@ -223,9 +217,6 @@ public class SimEventCentral {
       LogOutputEvent removed = logOutputEvents.pollFirst();
       if (removed == null) {
         break;
-      }
-      for (LogOutputListener l: logOutputListeners) {
-        l.removedLogOutput(removed);
       }
     }
   }

--- a/java/org/contikios/cooja/plugins/LogListener.java
+++ b/java/org/contikios/cooja/plugins/LogListener.java
@@ -582,9 +582,6 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
           appendToFile(appendStreamFile, data.getTime() + "\t" + data.getID() + "\t" + data.ev.getMessage() + "\n");
         }
       }
-      @Override
-      public void removedLogOutput(LogOutputEvent ev) {
-      }
     });
 
     /* UI components */

--- a/java/org/contikios/cooja/plugins/TimeLine.java
+++ b/java/org/contikios/cooja/plugins/TimeLine.java
@@ -430,9 +430,6 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     // Automatically add/delete motes. This listener also observes mote log outputs.
     simulation.getEventCentral().addLogOutputListener(newMotesListener = new LogOutputListener() {
       @Override
-      public void removedLogOutput(LogOutputEvent ev) {
-      }
-      @Override
       public void newLogOutput(LogOutputEvent ev) {
         /* Log output */
         Mote mote = ev.getMote();

--- a/java/org/contikios/cooja/plugins/skins/LogVisualizerSkin.java
+++ b/java/org/contikios/cooja/plugins/skins/LogVisualizerSkin.java
@@ -63,9 +63,6 @@ public class LogVisualizerSkin implements VisualizerSkin {
     public void newLogOutput(LogOutputEvent ev) {
       visualizer.repaint();
     }
-    @Override
-    public void removedLogOutput(LogOutputEvent ev) {
-    }
   };
 
   @Override


### PR DESCRIPTION
There are 4 users of the interface in the tree,
and they all implement an empty body for the
removed method.

Remove the method, so it becomes a
single-method interface.