### PR TITLE
Highlight log output

### DIFF
--- a/config/logback.xml
+++ b/config/logback.xml
@@ -1,7 +1,8 @@
 <configuration>
+  <conversionRule conversionWord="highlightdark" converterClass="org.contikios.cooja.util.LogbackColor" />
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%level [%thread] [%file:%line] - %msg%n</pattern>
+      <pattern>%highlightdark(%level [%thread] [%file:%line] - %msg%n)</pattern>
     </encoder>
   </appender>
 

--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1732,8 +1732,9 @@ public class Cooja {
    * When SimConfig contains an identical field, these values are the default
    * values when creating a new simulation in the File menu.
    */
-  public record Config(boolean vis, String externalToolsConfig,
+  public record Config(LogbackColors logColors, boolean vis, String externalToolsConfig,
                        String logDir, String contikiPath, String coojaPath, String javac) {}
 
+  public record LogbackColors(String error, String warn, String info, String fallback) {}
   private record PathIdentifier(String id, String path) {}
 }

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -31,6 +31,7 @@ package org.contikios.cooja;
 import static se.sics.mspsim.Main.createNode;
 import static se.sics.mspsim.Main.getNodeTypeByPlatform;
 
+import ch.qos.logback.core.pattern.color.ANSIConstants;
 import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.io.IOException;
@@ -41,6 +42,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import org.contikios.cooja.Cooja.Config;
+import org.contikios.cooja.Cooja.LogbackColors;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -280,9 +282,12 @@ class Main {
     }
 
     if (options.mspSimPlatform == null) { // Start Cooja.
-        var cfg = new Config(options.gui, options.externalUserConfig,
+      // Use colors that are good on a dark background and readable on a white background.
+      var colors = new LogbackColors(ANSIConstants.BOLD + "91", "96",
+              ANSIConstants.GREEN_FG, ANSIConstants.DEFAULT_FG);
+      var cfg = new Config(colors, options.gui, options.externalUserConfig,
                 options.logDir, options.contikiPath, options.coojaPath, options.javac);
-        Cooja.go(cfg, simConfigs);
+      Cooja.go(cfg, simConfigs);
     } else { // Start MSPSim.
       var config = new ArgumentManager();
       config.handleArguments(options.simulationFiles.toArray(new String[0]));

--- a/java/org/contikios/cooja/util/LogbackColor.java
+++ b/java/org/contikios/cooja/util/LogbackColor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023, RISE Research Institutes of Sweden AB.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.contikios.cooja.util;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.pattern.color.ANSIConstants;
+import ch.qos.logback.core.pattern.color.ForegroundCompositeConverterBase;
+import org.contikios.cooja.Cooja;
+
+/**
+ * Used to alter the highlight colors in the console logs. Uses the configured
+ * log colors of Cooja.
+ */
+public class LogbackColor extends ForegroundCompositeConverterBase<ILoggingEvent> {
+  private static boolean configured;
+  private static String ERROR_COLOR;
+  private static String WARN_COLOR;
+  private static String INFO_COLOR;
+  private static String DEFAULT_COLOR;
+
+  @Override
+  protected String getForegroundColorCode(ILoggingEvent event) {
+    if (Cooja.configuration == null) { // Logging before Cooja initialized.
+      return ANSIConstants.DEFAULT_FG;
+    }
+    if (!configured) {
+      ERROR_COLOR = Cooja.configuration.logColors().error();
+      WARN_COLOR = Cooja.configuration.logColors().warn();
+      INFO_COLOR = Cooja.configuration.logColors().info();
+      DEFAULT_COLOR = Cooja.configuration.logColors().fallback();
+      configured = true;
+    }
+    return switch (event.getLevel().toInt()) {
+      case Level.ERROR_INT -> ERROR_COLOR;
+      case Level.WARN_INT -> WARN_COLOR;
+      case Level.INFO_INT -> INFO_COLOR;
+      default -> DEFAULT_COLOR;
+    };
+  }
+}


### PR DESCRIPTION
Use a custom color scheme that is designed
to be readable on both a black and white console.