### PR TITLE
Gradle: allow configuration of logback configuration file via system properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,6 @@ run {
     }
   }
   systemProperty 'picocli.disable.closures', "true"
-  systemProperty 'logback.configurationFile', 'logback.xml'
   // Enable assertions with "-Passertions".
   enableAssertions = project.hasProperty('assertions')
   // Prevent Gradle from changing directory to tools/cooja.

--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -14,6 +14,11 @@ by MSPSim.
 This removes the `--log4j2` and `--logname` parameters. Set the system property
 `logback.configurationFile` to use a different logback configuration.
 
+To start Cooja with a custom Logback configuration:
+```
+./gradlew -Dcooja.logback.configurationFile=my-logback-configuration.xml run
+```
+
 Plugins need to change calls to `logger.fatal` to instead call `logger.error`,
 and change the logger construction from
 ```


### PR DESCRIPTION
The hard coded configuration in `build.gradle` override any value set by the caller and the default, if unspecified, is `logback.xml` anyway.