### PR TITLE
logback: add space to prevent mixed output

### DIFF
--- a/config/logback.xml
+++ b/config/logback.xml
@@ -2,7 +2,7 @@
   <conversionRule conversionWord="highlightdark" converterClass="org.contikios.cooja.util.LogbackColor" />
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>${logback.layoutPattern:-%highlightdark(%-5level [%thread] [%file:%line] - %msg%n)}</pattern>
+      <pattern>${logback.layoutPattern:-%highlightdark(%-5level [%thread] [%file:%line] - %msg){}%n}</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
Having highlight span over %n makes gradle
sometimes bleed into log output.

Only highlight within the line, and add an annoying space at the end of the line so %n is detected.