### PR TITLE
MspSerial: fix a potential null-pointer exception

### DIFF
--- a/java/org/contikios/cooja/mspmote/interfaces/MspSerial.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/MspSerial.java
@@ -66,31 +66,31 @@ public class MspSerial extends SerialUI implements SerialPort {
     usart = getUSARTSource(this.mote);
     if (usart != null) {
       usart.addUSARTListener((source, data) -> MspSerial.this.dataReceived(data));
-    }
-    // FIXME: should writeDataEvent be inside usart != null block?
-    writeDataEvent = new MspMoteTimeEvent(this.mote) {
-      @Override
-      public void execute(long t) {
-        super.execute(t);
-        boolean finished = false;
-        byte b = 0;
-        synchronized (incomingData) {
-          if (incomingData.isEmpty() || !usart.isReceiveFlagCleared()) {
-            finished = true;
-          } else { // Write byte to serial port.
-            b = incomingData.remove(0);
+      writeDataEvent = new MspMoteTimeEvent(this.mote) {
+        @Override
+        public void execute(long t) {
+          super.execute(t);
+          boolean finished = false;
+          byte b = 0;
+          synchronized (incomingData) {
+            if (incomingData.isEmpty() || !usart.isReceiveFlagCleared()) {
+              finished = true;
+            } else { // Write byte to serial port.
+              b = incomingData.remove(0);
+            }
+          }
+          if (!finished) {
+            usart.byteReceived(b);
+            mote.requestImmediateWakeup();
+          }
+          if (!incomingData.isEmpty()) {
+            simulation.scheduleEvent(this, t + DELAY_INCOMING_DATA);
           }
         }
-        if (!finished) {
-          usart.byteReceived(b);
-          mote.requestImmediateWakeup();
-        }
-        if (!incomingData.isEmpty()) {
-          simulation.scheduleEvent(this, t+DELAY_INCOMING_DATA);
-        }
-      }
-    };
-
+      };
+    } else {
+      writeDataEvent = null;
+    }
   }
 
   protected USARTSource getUSARTSource(MspMote mote) {
@@ -99,6 +99,7 @@ public class MspSerial extends SerialUI implements SerialPort {
 
   @Override
   public void writeByte(byte b) {
+    if (writeDataEvent == null) return;
     incomingData.add(b);
     if (writeDataEvent.isScheduled()) {
       return;


### PR DESCRIPTION
Stop installing an event handler that is guaranteed to NPE, and stop storing the data when there is
no USART source.