### PR TITLE
Move setupNodePorts into constructor

### DIFF
--- a/java/se/sics/mspsim/platform/jcreate/JCreateNode.java
+++ b/java/se/sics/mspsim/platform/jcreate/JCreateNode.java
@@ -40,7 +40,7 @@
  */
 
 package se.sics.mspsim.platform.jcreate;
-import se.sics.mspsim.chip.FileStorage;
+
 import se.sics.mspsim.chip.Leds;
 import se.sics.mspsim.chip.M25P80;
 import se.sics.mspsim.chip.MMA7260QT;
@@ -101,13 +101,6 @@ public class JCreateNode extends CC2420Node<M25P80> {
     @Override
     protected void flashWrite(IOPort source, int data) {
         flash.portWrite(source, data);
-    }
-
-    @Override
-    public void setupNodePorts() {
-        if (flashFile != null) {
-            getFlash().setStorage(new FileStorage(flashFile));
-        }
     }
 
     @Override

--- a/java/se/sics/mspsim/platform/jcreate/JCreateNode.java
+++ b/java/se/sics/mspsim/platform/jcreate/JCreateNode.java
@@ -74,7 +74,6 @@ public class JCreateNode extends CC2420Node {
         this.flash = flash;
         registry.registerComponent("xmem", flash);
         setMode(MODE_LEDS_OFF);
-        super.setupNodePorts();
         leds = new Leds(cpu, LEDS);
         accelerometer = new MMA7260QT(cpu);
         ADC12 adc = cpu.getIOUnit(ADC12.class, "ADC12");

--- a/java/se/sics/mspsim/platform/jcreate/JCreateNode.java
+++ b/java/se/sics/mspsim/platform/jcreate/JCreateNode.java
@@ -53,7 +53,7 @@ import se.sics.mspsim.platform.sky.CC2420Node;
 /**
  * Emulation of Sentilla JCreate Mote
  */
-public class JCreateNode extends CC2420Node {
+public class JCreateNode extends CC2420Node<M25P80> {
 
     public static final int MODE_LEDS_OFF = 0;
     public static final int MODE_MAX = 9;
@@ -65,14 +65,11 @@ public class JCreateNode extends CC2420Node {
 
     private final Leds leds;
     private final MMA7260QT accelerometer;
-    private final M25P80 flash;
 
     private JCreateGui gui;
 
     public JCreateNode(MSP430 cpu, M25P80 flash) {
-        super("Sentilla JCreate", cpu);
-        this.flash = flash;
-        registry.registerComponent("xmem", flash);
+        super("Sentilla JCreate", cpu, flash);
         setMode(MODE_LEDS_OFF);
         leds = new Leds(cpu, LEDS);
         accelerometer = new MMA7260QT(cpu);
@@ -88,10 +85,6 @@ public class JCreateNode extends CC2420Node {
 
     public MMA7260QT getAccelerometer() {
         return accelerometer;
-    }
-
-    public M25P80 getFlash() {
-        return flash;
     }
 
     // USART Listener

--- a/java/se/sics/mspsim/platform/sentillausb/SentillaUSBNode.java
+++ b/java/se/sics/mspsim/platform/sentillausb/SentillaUSBNode.java
@@ -40,7 +40,7 @@
  */
 
 package se.sics.mspsim.platform.sentillausb;
-import se.sics.mspsim.chip.FileStorage;
+
 import se.sics.mspsim.chip.Leds;
 import se.sics.mspsim.chip.M25P80;
 import se.sics.mspsim.core.IOPort;
@@ -92,13 +92,6 @@ public class SentillaUSBNode extends CC2420Node<M25P80> {
     @Override
     protected void flashWrite(IOPort source, int data) {
         flash.portWrite(source, data);
-    }
-
-    @Override
-    public void setupNodePorts() {
-        if (flashFile != null) {
-            getFlash().setStorage(new FileStorage(flashFile));
-        }
     }
 
     @Override

--- a/java/se/sics/mspsim/platform/sentillausb/SentillaUSBNode.java
+++ b/java/se/sics/mspsim/platform/sentillausb/SentillaUSBNode.java
@@ -74,7 +74,6 @@ public class SentillaUSBNode extends CC2420Node {
         this.flash = flash;
         registry.registerComponent("xmem", flash);
         setMode(MODE_LEDS_OFF);
-        super.setupNodePorts();
         leds = new Leds(cpu, LEDS);
     }
 

--- a/java/se/sics/mspsim/platform/sentillausb/SentillaUSBNode.java
+++ b/java/se/sics/mspsim/platform/sentillausb/SentillaUSBNode.java
@@ -51,7 +51,7 @@ import se.sics.mspsim.platform.sky.CC2420Node;
 /**
  * Emulation of Sentilla Gateway USB Mote
  */
-public class SentillaUSBNode extends CC2420Node {
+public class SentillaUSBNode extends CC2420Node<M25P80> {
 
     public static final int MODE_LEDS_OFF = 0;
     public static final int MODE_LEDS_1 = 1;
@@ -62,7 +62,6 @@ public class SentillaUSBNode extends CC2420Node {
     public static final int GREEN_LED = 0x20;
     public static final int RED_LED = 0x10;
 
-    private final M25P80 flash;
     private SentillaUSBGui gui;
 
     private final Leds leds;
@@ -70,19 +69,13 @@ public class SentillaUSBNode extends CC2420Node {
     boolean greenLed;
 
     public SentillaUSBNode(MSP430 cpu, M25P80 flash) {
-        super("Sentilla USB", cpu);
-        this.flash = flash;
-        registry.registerComponent("xmem", flash);
+        super("Sentilla USB", cpu, flash);
         setMode(MODE_LEDS_OFF);
         leds = new Leds(cpu, LEDS);
     }
 
     public Leds getLeds() {
         return leds;
-    }
-
-    public M25P80 getFlash() {
-        return flash;
     }
 
     // USART Listener

--- a/java/se/sics/mspsim/platform/sky/CC2420Node.java
+++ b/java/se/sics/mspsim/platform/sky/CC2420Node.java
@@ -54,21 +54,6 @@ public abstract class CC2420Node extends GenericNode implements PortListener, US
 
     public CC2420Node(String id, MSP430 cpu) {
         super(id, cpu);
-    }
-
-    public void setDebug(boolean debug) {
-        cpu.setDebug(debug);
-    }
-
-    public boolean getDebug() {
-        return cpu.getDebug();
-    }
-
-    public void setNodeID(int id) {
-        ds2411.setMACID(id & 0xff, id & 0xff, id & 0xff, (id >> 8) & 0xff, id & 0xff, id & 0xff);
-    }
-
-    public void setupNodePorts() {
         ds2411 = new DS2411(cpu);
 
         port1 = cpu.getIOUnit(IOPort.class, "P1");
@@ -84,20 +69,34 @@ public abstract class CC2420Node extends GenericNode implements PortListener, US
         port5 = cpu.getIOUnit(IOPort.class, "P5");
         port5.addPortListener(this);
 
-        USART usart0 = cpu.getIOUnit(USART.class, "USART0");
+        var usart0 = cpu.getIOUnit(USART.class, "USART0");
         radio = new CC2420(cpu);
         radio.setCCAPort(port1, CC2420_CCA);
         radio.setFIFOPPort(port1, CC2420_FIFOP);
         radio.setFIFOPort(port1, CC2420_FIFO);
-
+        // FIXME: move closer to allocation.
         usart0.addUSARTListener(this);
         radio.setSFDPort(port4, CC2420_SFD);
 
-        USART usart = cpu.getIOUnit(USART.class, "USART1");
+        var usart = cpu.getIOUnit(USART.class, "USART1");
         if (usart != null) {
             registry.registerComponent("serialio", usart);
         }
     }
+
+    public void setDebug(boolean debug) {
+        cpu.setDebug(debug);
+    }
+
+    public boolean getDebug() {
+        return cpu.getDebug();
+    }
+
+    public void setNodeID(int id) {
+        ds2411.setMACID(id & 0xff, id & 0xff, id & 0xff, (id >> 8) & 0xff, id & 0xff, id & 0xff);
+    }
+
+    public void setupNodePorts() {}
 
     @Override
     public void setupNode() {

--- a/java/se/sics/mspsim/platform/sky/CC2420Node.java
+++ b/java/se/sics/mspsim/platform/sky/CC2420Node.java
@@ -1,6 +1,7 @@
 package se.sics.mspsim.platform.sky;
 import se.sics.mspsim.chip.CC2420;
 import se.sics.mspsim.chip.DS2411;
+import se.sics.mspsim.chip.ExternalFlash;
 import se.sics.mspsim.chip.PacketListener;
 import se.sics.mspsim.config.MSP430f1611Config;
 import se.sics.mspsim.core.IOPort;
@@ -17,7 +18,7 @@ import se.sics.mspsim.ui.SerialMon;
 import se.sics.mspsim.util.NetworkConnection;
 import se.sics.mspsim.util.OperatingModeStatistics;
 
-public abstract class CC2420Node extends GenericNode implements PortListener, USARTListener {
+public abstract class CC2420Node<FlashType extends ExternalFlash> extends GenericNode implements PortListener, USARTListener {
 
     // Port 2.
     public static final int DS2411_DATA_PIN = 4;
@@ -45,6 +46,7 @@ public abstract class CC2420Node extends GenericNode implements PortListener, US
     public CC2420 radio;
     public DS2411 ds2411;
 
+    protected final FlashType flash;
     protected String flashFile;
 
     public static MSP430Config makeChipConfig() {
@@ -52,8 +54,10 @@ public abstract class CC2420Node extends GenericNode implements PortListener, US
         return new MSP430f1611Config();
     }
 
-    public CC2420Node(String id, MSP430 cpu) {
+    public CC2420Node(String id, MSP430 cpu, FlashType flash) {
         super(id, cpu);
+        this.flash = flash;
+        registry.registerComponent("xmem", flash);
         ds2411 = new DS2411(cpu);
 
         port1 = cpu.getIOUnit(IOPort.class, "P1");
@@ -82,6 +86,10 @@ public abstract class CC2420Node extends GenericNode implements PortListener, US
         if (usart != null) {
             registry.registerComponent("serialio", usart);
         }
+    }
+
+    public FlashType getFlash() {
+        return flash;
     }
 
     public void setDebug(boolean debug) {

--- a/java/se/sics/mspsim/platform/sky/CC2420Node.java
+++ b/java/se/sics/mspsim/platform/sky/CC2420Node.java
@@ -2,6 +2,7 @@ package se.sics.mspsim.platform.sky;
 import se.sics.mspsim.chip.CC2420;
 import se.sics.mspsim.chip.DS2411;
 import se.sics.mspsim.chip.ExternalFlash;
+import se.sics.mspsim.chip.FileStorage;
 import se.sics.mspsim.chip.PacketListener;
 import se.sics.mspsim.config.MSP430f1611Config;
 import se.sics.mspsim.core.IOPort;
@@ -104,7 +105,11 @@ public abstract class CC2420Node<FlashType extends ExternalFlash> extends Generi
         ds2411.setMACID(id & 0xff, id & 0xff, id & 0xff, (id >> 8) & 0xff, id & 0xff, id & 0xff);
     }
 
-    public void setupNodePorts() {}
+    public void setupNodePorts() {
+        if (flashFile != null) {
+            getFlash().setStorage(new FileStorage(flashFile));
+        }
+    }
 
     @Override
     public void setupNode() {

--- a/java/se/sics/mspsim/platform/sky/CC2420Node.java
+++ b/java/se/sics/mspsim/platform/sky/CC2420Node.java
@@ -105,12 +105,6 @@ public abstract class CC2420Node<FlashType extends ExternalFlash> extends Generi
         ds2411.setMACID(id & 0xff, id & 0xff, id & 0xff, (id >> 8) & 0xff, id & 0xff, id & 0xff);
     }
 
-    public void setupNodePorts() {
-        if (flashFile != null) {
-            getFlash().setStorage(new FileStorage(flashFile));
-        }
-    }
-
     @Override
     public void setupNode() {
         // create a filename for the flash file
@@ -130,7 +124,9 @@ public abstract class CC2420Node<FlashType extends ExternalFlash> extends Generi
 
         this.flashFile = fileName;
 
-        setupNodePorts();
+        if (flashFile != null) {
+            getFlash().setStorage(new FileStorage(flashFile));
+        }
 
         if (stats != null) {
             stats.addMonitor(this);

--- a/java/se/sics/mspsim/platform/sky/MoteIVNode.java
+++ b/java/se/sics/mspsim/platform/sky/MoteIVNode.java
@@ -1,6 +1,7 @@
 package se.sics.mspsim.platform.sky;
 import se.sics.mspsim.chip.Button;
 import se.sics.mspsim.chip.ExternalFlash;
+import se.sics.mspsim.chip.FileStorage;
 import se.sics.mspsim.chip.Leds;
 import se.sics.mspsim.chip.SHT11;
 import se.sics.mspsim.core.IOPort;
@@ -65,6 +66,13 @@ public abstract class MoteIVNode<FlashType extends ExternalFlash> extends CC2420
   @Deprecated
   public void setButton(boolean buttonPressed) {
       button.setPressed(buttonPressed);
+  }
+
+  @Override
+  public void setupNodePorts() {
+    if (flashFile != null) {
+      getFlash().setStorage(new FileStorage(flashFile));
+    }
   }
 
   @Override

--- a/java/se/sics/mspsim/platform/sky/MoteIVNode.java
+++ b/java/se/sics/mspsim/platform/sky/MoteIVNode.java
@@ -1,7 +1,6 @@
 package se.sics.mspsim.platform.sky;
 import se.sics.mspsim.chip.Button;
 import se.sics.mspsim.chip.ExternalFlash;
-import se.sics.mspsim.chip.FileStorage;
 import se.sics.mspsim.chip.Leds;
 import se.sics.mspsim.chip.SHT11;
 import se.sics.mspsim.core.IOPort;
@@ -58,13 +57,6 @@ public abstract class MoteIVNode<FlashType extends ExternalFlash> extends CC2420
   @Deprecated
   public void setButton(boolean buttonPressed) {
       button.setPressed(buttonPressed);
-  }
-
-  @Override
-  public void setupNodePorts() {
-    if (flashFile != null) {
-      getFlash().setStorage(new FileStorage(flashFile));
-    }
   }
 
   @Override

--- a/java/se/sics/mspsim/platform/sky/MoteIVNode.java
+++ b/java/se/sics/mspsim/platform/sky/MoteIVNode.java
@@ -7,7 +7,7 @@ import se.sics.mspsim.chip.SHT11;
 import se.sics.mspsim.core.IOPort;
 import se.sics.mspsim.core.MSP430;
 
-public abstract class MoteIVNode<FlashType extends ExternalFlash> extends CC2420Node {
+public abstract class MoteIVNode<FlashType extends ExternalFlash> extends CC2420Node<FlashType> {
 
   public static final int MODE_LEDS_OFF = 0;
   public static final int MODE_LEDS_1 = 1;
@@ -28,8 +28,6 @@ public abstract class MoteIVNode<FlashType extends ExternalFlash> extends CC2420
   public static final int GREEN_LED = 0x20;
   public static final int RED_LED = 0x10;
 
-  protected final FlashType flash;
-
   public boolean redLed;
   public boolean blueLed;
   public boolean greenLed;
@@ -41,18 +39,12 @@ public abstract class MoteIVNode<FlashType extends ExternalFlash> extends CC2420
   public SkyGui gui;
 
   public MoteIVNode(String id, MSP430 cpu, FlashType flash) {
-    super(id, cpu);
-    this.flash = flash;
-    registry.registerComponent("xmem", flash);
+    super(id, cpu, flash);
     setMode(MODE_LEDS_OFF);
     leds = new Leds(cpu, LEDS);
     button = new Button("Button", cpu, port2, BUTTON_PIN, true);
     sht11 = new SHT11(cpu);
     sht11.setDataPort(port1, SHT11_DATA_PIN);
-  }
-
-  public FlashType getFlash() {
-    return flash;
   }
 
   public Leds getLeds() {

--- a/java/se/sics/mspsim/platform/sky/MoteIVNode.java
+++ b/java/se/sics/mspsim/platform/sky/MoteIVNode.java
@@ -1,11 +1,12 @@
 package se.sics.mspsim.platform.sky;
 import se.sics.mspsim.chip.Button;
+import se.sics.mspsim.chip.ExternalFlash;
 import se.sics.mspsim.chip.Leds;
 import se.sics.mspsim.chip.SHT11;
 import se.sics.mspsim.core.IOPort;
 import se.sics.mspsim.core.MSP430;
 
-public abstract class MoteIVNode extends CC2420Node {
+public abstract class MoteIVNode<FlashType extends ExternalFlash> extends CC2420Node {
 
   public static final int MODE_LEDS_OFF = 0;
   public static final int MODE_LEDS_1 = 1;
@@ -26,6 +27,8 @@ public abstract class MoteIVNode extends CC2420Node {
   public static final int GREEN_LED = 0x20;
   public static final int RED_LED = 0x10;
 
+  protected final FlashType flash;
+
   public boolean redLed;
   public boolean blueLed;
   public boolean greenLed;
@@ -36,13 +39,19 @@ public abstract class MoteIVNode extends CC2420Node {
 
   public SkyGui gui;
 
-  public MoteIVNode(String id, MSP430 cpu) {
+  public MoteIVNode(String id, MSP430 cpu, FlashType flash) {
     super(id, cpu);
+    this.flash = flash;
+    registry.registerComponent("xmem", flash);
     setMode(MODE_LEDS_OFF);
     leds = new Leds(cpu, LEDS);
     button = new Button("Button", cpu, port2, BUTTON_PIN, true);
     sht11 = new SHT11(cpu);
     sht11.setDataPort(port1, SHT11_DATA_PIN);
+  }
+
+  public FlashType getFlash() {
+    return flash;
   }
 
   public Leds getLeds() {

--- a/java/se/sics/mspsim/platform/sky/MoteIVNode.java
+++ b/java/se/sics/mspsim/platform/sky/MoteIVNode.java
@@ -30,8 +30,8 @@ public abstract class MoteIVNode extends CC2420Node {
   public boolean blueLed;
   public boolean greenLed;
 
-  private Leds leds;
-  private Button button;
+  private final Leds leds;
+  private final Button button;
   public SHT11 sht11;
 
   public SkyGui gui;
@@ -39,6 +39,10 @@ public abstract class MoteIVNode extends CC2420Node {
   public MoteIVNode(String id, MSP430 cpu) {
     super(id, cpu);
     setMode(MODE_LEDS_OFF);
+    leds = new Leds(cpu, LEDS);
+    button = new Button("Button", cpu, port2, BUTTON_PIN, true);
+    sht11 = new SHT11(cpu);
+    sht11.setDataPort(port1, SHT11_DATA_PIN);
   }
 
   public Leds getLeds() {
@@ -52,16 +56,6 @@ public abstract class MoteIVNode extends CC2420Node {
   @Deprecated
   public void setButton(boolean buttonPressed) {
       button.setPressed(buttonPressed);
-  }
-
-  @Override
-  public void setupNodePorts() {
-    super.setupNodePorts();
-
-    leds = new Leds(cpu, LEDS);
-    button = new Button("Button", cpu, port2, BUTTON_PIN, true);
-    sht11 = new SHT11(cpu);
-    sht11.setDataPort(port1, SHT11_DATA_PIN);
   }
 
   @Override

--- a/java/se/sics/mspsim/platform/sky/SkyNode.java
+++ b/java/se/sics/mspsim/platform/sky/SkyNode.java
@@ -60,7 +60,6 @@ public class SkyNode extends MoteIVNode {
     super("Tmote Sky", cpu);
     this.flash = flash;
     registry.registerComponent("xmem", flash);
-    super.setupNodePorts();
   }
 
   public M25P80 getFlash() {

--- a/java/se/sics/mspsim/platform/sky/SkyNode.java
+++ b/java/se/sics/mspsim/platform/sky/SkyNode.java
@@ -49,21 +49,13 @@ import se.sics.mspsim.core.USARTSource;
 /**
  * Emulation of Sky Mote
  */
-public class SkyNode extends MoteIVNode {
-  private final M25P80 flash;
-
+public class SkyNode extends MoteIVNode<M25P80> {
   /**
    * Creates a new <code>SkyNode</code> instance.
    *
    */
   public SkyNode(MSP430 cpu, M25P80 flash) {
-    super("Tmote Sky", cpu);
-    this.flash = flash;
-    registry.registerComponent("xmem", flash);
-  }
-
-  public M25P80 getFlash() {
-    return flash;
+    super("Tmote Sky", cpu, flash);
   }
 
   // USART Listener

--- a/java/se/sics/mspsim/platform/sky/SkyNode.java
+++ b/java/se/sics/mspsim/platform/sky/SkyNode.java
@@ -40,7 +40,7 @@
  */
 
 package se.sics.mspsim.platform.sky;
-import se.sics.mspsim.chip.FileStorage;
+
 import se.sics.mspsim.chip.M25P80;
 import se.sics.mspsim.core.IOPort;
 import se.sics.mspsim.core.MSP430;
@@ -72,12 +72,5 @@ public class SkyNode extends MoteIVNode<M25P80> {
   @Override
   protected void flashWrite(IOPort source, int data) {
     flash.portWrite(source, data);
-  }
-
-  @Override
-  public void setupNodePorts() {
-    if (flashFile != null) {
-      getFlash().setStorage(new FileStorage(flashFile));
-    }
   }
 }

--- a/java/se/sics/mspsim/platform/sky/TelosNode.java
+++ b/java/se/sics/mspsim/platform/sky/TelosNode.java
@@ -67,7 +67,6 @@ public class TelosNode extends MoteIVNode {
     super("Telos", cpu);
     this.flash = flash;
     // FIXME: should the flash be registered in the registry?
-    super.setupNodePorts();
   }
 
   public AT45DB getFlash() {

--- a/java/se/sics/mspsim/platform/sky/TelosNode.java
+++ b/java/se/sics/mspsim/platform/sky/TelosNode.java
@@ -51,26 +51,17 @@ import se.sics.mspsim.core.USARTSource;
  * <p>
  * TODO: Cleanup the MoteIVNode, SkyNode and TelosNode
  */
-public class TelosNode extends MoteIVNode {
-
+public class TelosNode extends MoteIVNode<AT45DB> {
   // P4.4 - Output: SPI Flash Chip Select
   public static final int FLASH_RESET = (1<<3);
   public static final int FLASH_CS = (1<<4);
-
-  private final AT45DB flash;
 
   /**
    * Creates a new <code>TelosNode</code> instance.
    *
    */
   public TelosNode(MSP430 cpu, AT45DB flash) {
-    super("Telos", cpu);
-    this.flash = flash;
-    // FIXME: should the flash be registered in the registry?
-  }
-
-  public AT45DB getFlash() {
-    return flash;
+    super("Telos", cpu, flash);
   }
 
   @Override

--- a/java/se/sics/mspsim/platform/sky/TelosNode.java
+++ b/java/se/sics/mspsim/platform/sky/TelosNode.java
@@ -76,11 +76,4 @@ public class TelosNode extends MoteIVNode<AT45DB> {
     radio.dataReceived(source, data);
     flash.dataReceived(source, data);
   }
-
-  @Override
-  public void setupNodePorts() {
-    if (flashFile != null) {
-      getFlash().setStorage(new FileStorage(flashFile));
-    }
-  }
 }

--- a/java/se/sics/mspsim/platform/ti/Exp1101Node.java
+++ b/java/se/sics/mspsim/platform/ti/Exp1101Node.java
@@ -38,6 +38,32 @@ public class Exp1101Node extends GenericNode implements PortListener, USARTListe
 
     public Exp1101Node(MSP430 cpu) {
         super("Exp1101", cpu);
+        port1 = cpu.getIOUnit(IOPort.class, "P1");
+        port1.addPortListener(this);
+        port3 = cpu.getIOUnit(IOPort.class, "P3");
+        port3.addPortListener(this);
+        port4 = cpu.getIOUnit(IOPort.class, "P4");
+        port4.addPortListener(this);
+        port5 = cpu.getIOUnit(IOPort.class, "P5");
+        port5.addPortListener(this);
+        port7 = cpu.getIOUnit(IOPort.class, "P7");
+        port7.addPortListener(this);
+        port8 = cpu.getIOUnit(IOPort.class, "P8");
+        port8.addPortListener(this);
+
+        if (cpu.getIOUnit("USCI B0") instanceof USARTSource usart0) {
+            radio = new CC1101(cpu);
+            radio.setGDO0(port1, CC1101_GDO0);
+            radio.setGDO2(port1, CC1101_GDO2);
+            usart0.addUSARTListener(this);
+        } else {
+            throw new EmulationException("Could not setup exp1101 mote - missing USCI B0");
+        }
+
+        IOUnit usart = cpu.getIOUnit("USCI A1");
+        if (usart instanceof USARTSource) {
+            registry.registerComponent("serialio", usart);
+        }
     }
 
     @Override
@@ -58,40 +84,8 @@ public class Exp1101Node extends GenericNode implements PortListener, USARTListe
                 }
     }
 
-    private void setupNodePorts() {
-        port1 = cpu.getIOUnit(IOPort.class, "P1");
-        port1.addPortListener(this);
-        port3 = cpu.getIOUnit(IOPort.class, "P3");
-        port3.addPortListener(this);
-        port4 = cpu.getIOUnit(IOPort.class, "P4");
-        port4.addPortListener(this);
-        port5 = cpu.getIOUnit(IOPort.class, "P5");
-        port5.addPortListener(this);
-        port7 = cpu.getIOUnit(IOPort.class, "P7");
-        port7.addPortListener(this);
-        port8 = cpu.getIOUnit(IOPort.class, "P8");
-        port8.addPortListener(this);
-
-        IOUnit usart0 = cpu.getIOUnit("USCI B0");
-        if (usart0 instanceof USARTSource) {
-            radio = new CC1101(cpu);
-                        radio.setGDO0(port1, CC1101_GDO0);
-                        radio.setGDO2(port1, CC1101_GDO2);
-            ((USARTSource) usart0).addUSARTListener(this);
-        } else {
-            throw new EmulationException("Could not setup exp1101 mote - missing USCI B0");
-        }
-
-        IOUnit usart = cpu.getIOUnit("USCI A1");
-        if (usart instanceof USARTSource) {
-            registry.registerComponent("serialio", usart);
-        }
-    }
-
     @Override
     public void setupNode() {
-        setupNodePorts();
-
         if (!config.getPropertyAsBoolean("nogui", true)) {
             // Add some windows for listening to serial output
             IOUnit usart = cpu.getIOUnit("USCI A1");

--- a/java/se/sics/mspsim/platform/ti/Exp1120Node.java
+++ b/java/se/sics/mspsim/platform/ti/Exp1120Node.java
@@ -37,7 +37,33 @@ public class Exp1120Node extends GenericNode implements PortListener, USARTListe
         }
 
         public Exp1120Node(MSP430 cpu) {
-                super("Exp1120", cpu);
+          super("Exp1120", cpu);
+          port1 = cpu.getIOUnit(IOPort.class, "P1");
+          port1.addPortListener(this);
+          port3 = cpu.getIOUnit(IOPort.class, "P3");
+          port3.addPortListener(this);
+          port4 = cpu.getIOUnit(IOPort.class, "P4");
+          port4.addPortListener(this);
+          port5 = cpu.getIOUnit(IOPort.class, "P5");
+          port5.addPortListener(this);
+          port7 = cpu.getIOUnit(IOPort.class, "P7");
+          port7.addPortListener(this);
+          port8 = cpu.getIOUnit(IOPort.class, "P8");
+          port8.addPortListener(this);
+
+          if (cpu.getIOUnit("USCI B0") instanceof USARTSource usart0) {
+            radio = new CC1120(cpu);
+            radio.setGDO0(port1, CC1120_GDO0);
+            radio.setGDO2(port1, CC1120_GDO2);
+            usart0.addUSARTListener(this);
+          } else {
+            throw new EmulationException("Error creating Exp1120Node: no USCI B0");
+          }
+
+          var usart = cpu.getIOUnit("USCI A1");
+          if (usart instanceof USARTSource) {
+            registry.registerComponent("serialio", usart);
+          }
         }
 
         @Override
@@ -58,40 +84,8 @@ public class Exp1120Node extends GenericNode implements PortListener, USARTListe
                 }
         }
 
-        private void setupNodePorts() {
-                port1 = cpu.getIOUnit(IOPort.class, "P1");
-                port1.addPortListener(this);
-                port3 = cpu.getIOUnit(IOPort.class, "P3");
-                port3.addPortListener(this);
-                port4 = cpu.getIOUnit(IOPort.class, "P4");
-                port4.addPortListener(this);
-                port5 = cpu.getIOUnit(IOPort.class, "P5");
-                port5.addPortListener(this);
-                port7 = cpu.getIOUnit(IOPort.class, "P7");
-                port7.addPortListener(this);
-                port8 = cpu.getIOUnit(IOPort.class, "P8");
-                port8.addPortListener(this);
-
-                IOUnit usart0 = cpu.getIOUnit("USCI B0");
-                if (usart0 instanceof USARTSource) {
-                        radio = new CC1120(cpu);
-                        radio.setGDO0(port1, CC1120_GDO0);
-                        radio.setGDO2(port1, CC1120_GDO2);
-                        ((USARTSource) usart0).addUSARTListener(this);
-                } else {
-                        throw new EmulationException("Error creating Exp1120Node: no USCI B0");
-                }
-
-                IOUnit usart = cpu.getIOUnit("USCI A1");
-                if (usart instanceof USARTSource) {
-                        registry.registerComponent("serialio", usart);
-                }
-        }
-
         @Override
         public void setupNode() {
-                setupNodePorts();
-
                 if (!config.getPropertyAsBoolean("nogui", true)) {
                         // Add some windows for listening to serial output
                         IOUnit usart = cpu.getIOUnit("USCI A1");

--- a/java/se/sics/mspsim/platform/tyndall/TyndallNode.java
+++ b/java/se/sics/mspsim/platform/tyndall/TyndallNode.java
@@ -53,6 +53,35 @@ public class TyndallNode extends GenericNode implements PortListener, USARTListe
         super("Tyndall", cpu);
 //        this.flash = flash;
 //        registry.registerComponent("xmem", flash);
+        port1 = cpu.getIOUnit(IOPort.class, "P1");
+        port1.addPortListener(this);
+        port3 = cpu.getIOUnit(IOPort.class, "P3");
+        port3.addPortListener(this);
+        port4 = cpu.getIOUnit(IOPort.class, "P4");
+        port4.addPortListener(this);
+        port5 = cpu.getIOUnit(IOPort.class, "P5");
+        port5.addPortListener(this);
+        port7 = cpu.getIOUnit(IOPort.class, "P7");
+        port7.addPortListener(this);
+        port8 = cpu.getIOUnit(IOPort.class, "P8");
+        port8.addPortListener(this);
+
+        if (cpu.getIOUnit("USCI B0") instanceof USARTSource usart0) {
+            radio = new CC2420(cpu);
+            radio.setCCAPort(port8, CC2420_CCA);
+            radio.setFIFOPPort(port8, CC2420_FIFOP);
+            radio.setFIFOPort(port8, CC2420_FIFO);
+
+            usart0.addUSARTListener(this);
+            radio.setSFDPort(port8, CC2420_SFD);
+        } else {
+            throw new EmulationException("Could not setup tyndall mote - missing USCI B0");
+        }
+
+        var usart = cpu.getIOUnit("USCI A0");
+        if (usart instanceof USARTSource) {
+            registry.registerComponent("serialio", usart);
+        }
     }
 
 //    public M25P80 getFlash() {
@@ -93,37 +122,6 @@ public class TyndallNode extends GenericNode implements PortListener, USARTListe
 //        if (flashFile != null) {
 //            getFlash().setStorage(new FileStorage(flashFile));
 //        }
-
-        port1 = cpu.getIOUnit(IOPort.class, "P1");
-        port1.addPortListener(this);
-        port3 = cpu.getIOUnit(IOPort.class, "P3");
-        port3.addPortListener(this);
-        port4 = cpu.getIOUnit(IOPort.class, "P4");
-        port4.addPortListener(this);
-        port5 = cpu.getIOUnit(IOPort.class, "P5");
-        port5.addPortListener(this);
-        port7 = cpu.getIOUnit(IOPort.class, "P7");
-        port7.addPortListener(this);
-        port8 = cpu.getIOUnit(IOPort.class, "P8");
-        port8.addPortListener(this);
-
-        IOUnit usart0 = cpu.getIOUnit("USCI B0");
-        if (usart0 instanceof USARTSource) {
-            radio = new CC2420(cpu);
-            radio.setCCAPort(port8, CC2420_CCA);
-            radio.setFIFOPPort(port8, CC2420_FIFOP);
-            radio.setFIFOPort(port8, CC2420_FIFO);
-
-            ((USARTSource) usart0).addUSARTListener(this);
-            radio.setSFDPort(port8, CC2420_SFD);
-        } else {
-            throw new EmulationException("Could not setup tyndall mote - missing USCI B0");
-        }
-
-        IOUnit usart = cpu.getIOUnit("USCI A0");
-        if (usart instanceof USARTSource) {
-            registry.registerComponent("serialio", usart);
-        }
     }
 
     @Override


### PR DESCRIPTION
Move most of the code into the constructors of each node.

This is already almost a 400 line patch, so more changes coming in the next PR instead.