### PR TITLE
Chip: remove unused getConfiguration

### DIFF
--- a/java/se/sics/mspsim/chip/Beeper.java
+++ b/java/se/sics/mspsim/chip/Beeper.java
@@ -198,11 +198,4 @@ public class Beeper extends Chip {
         return "Volume: " + getVolume() + " Beep: " + (beepOn ? "on" : "off")
         + " Sound Enabled: " + isSoundEnabled;
     }
-
-    /* just return some value */
-    @Override
-    public int getConfiguration(int parameter) {
-        return beepOn ? 1 : 0;
-    }
-
 }

--- a/java/se/sics/mspsim/chip/Button.java
+++ b/java/se/sics/mspsim/chip/Button.java
@@ -65,11 +65,6 @@ public class Button extends Chip {
     }
 
     @Override
-    public int getConfiguration(int parameter) {
-        return 0;
-    }
-
-    @Override
     public int getModeMax() {
         return 0;
     }

--- a/java/se/sics/mspsim/chip/CC1101.java
+++ b/java/se/sics/mspsim/chip/CC1101.java
@@ -821,12 +821,6 @@ public class CC1101 extends Radio802154 implements USARTListener {
                 return 0;
         }
 
-        /* return data in register at the correct position */
-        @Override
-        public int getConfiguration(int parameter) {
-                return registers[parameter];
-        }
-
         @Override
         public boolean getChipSelect() {
                 return chipSelect;

--- a/java/se/sics/mspsim/chip/CC1120.java
+++ b/java/se/sics/mspsim/chip/CC1120.java
@@ -1022,12 +1022,6 @@ public class CC1120 extends Radio802154 implements USARTListener {
                 return 0;
         }
 
-        /* return data in register at the correct position */
-        @Override
-        public int getConfiguration(int parameter) {
-                return registers[parameter];
-        }
-
         @Override
         public boolean getChipSelect() {
                 return chipSelect;

--- a/java/se/sics/mspsim/chip/CC2420.java
+++ b/java/se/sics/mspsim/chip/CC2420.java
@@ -1505,11 +1505,4 @@ public class CC2420 extends Radio802154 implements USARTListener {
   @Override
   public void stateChanged(int state) {
   }
-
-  /* return data in register at the correct position */
-  @Override
-  public int getConfiguration(int parameter) {
-      return registers[parameter];
-  }
-
 } // CC2420

--- a/java/se/sics/mspsim/chip/CC2520.java
+++ b/java/se/sics/mspsim/chip/CC2520.java
@@ -1563,13 +1563,6 @@ public class CC2520 extends Radio802154 implements USARTListener, SPIData {
     public void stateChanged(int state) {
     }
 
-    /* return data in register at the correct position */
-    @Override
-    public int getConfiguration(int parameter) {
-        return memory[parameter];
-    }
-
-
     /* For SPI Commands */
     @Override
     public int getSPIData(int offset) {

--- a/java/se/sics/mspsim/chip/DS2411.java
+++ b/java/se/sics/mspsim/chip/DS2411.java
@@ -240,9 +240,4 @@ public class DS2411 extends Chip {
     macID[4] = m;
     macID[5] = n;
   }
-
-  @Override
-  public int getConfiguration(int parameter) {
-      return 0;
-  }
 }

--- a/java/se/sics/mspsim/chip/Enc28J60.java
+++ b/java/se/sics/mspsim/chip/Enc28J60.java
@@ -264,11 +264,6 @@ public class Enc28J60 extends Chip {
         }
 
         @Override
-        public int getConfiguration(int parameter) {
-                return -1;
-        }
-
-        @Override
         public int getModeMax() {
                 return -1;
         }

--- a/java/se/sics/mspsim/chip/ExternalFlash.java
+++ b/java/se/sics/mspsim/chip/ExternalFlash.java
@@ -54,11 +54,5 @@ public abstract class ExternalFlash extends Chip {
         this.storage = storage;
     }
 
-    @Override
-    public int getConfiguration(int param) {
-        return 0;
-    }
-
     public abstract int getSize();
-
 }

--- a/java/se/sics/mspsim/chip/Leds.java
+++ b/java/se/sics/mspsim/chip/Leds.java
@@ -102,10 +102,4 @@ public class Leds extends Chip {
     public String info() {
         return "Leds: " + (ledColors.length <= 8 ? Utils.binary8(leds) : Utils.binary16(leds));
     }
-
-    @Override
-    public int getConfiguration(int parameter) {
-        return 0;
-    }
-
 }

--- a/java/se/sics/mspsim/chip/MMA7260QT.java
+++ b/java/se/sics/mspsim/chip/MMA7260QT.java
@@ -116,11 +116,4 @@ public class MMA7260QT extends Accelerometer {
         + String.format(" [x=%.2f (%d),y=%.2f (%d),z=%.2f (%d)]",
                 getX(), getADCX(), getY(), getADCY(), getZ(), getADCZ());
     }
-
-    /* currently just return the gSelect as configuration */
-    @Override
-    public int getConfiguration(int parameter) {
-        return gSelect;
-    }
-
 }

--- a/java/se/sics/mspsim/chip/SHT11.java
+++ b/java/se/sics/mspsim/chip/SHT11.java
@@ -288,11 +288,4 @@ public class SHT11 extends Chip {
   public int getModeMax() {
     return 0;
   }
-
-  /* no configuration for the SHT11 ? */
-  @Override
-  public int getConfiguration(int parameter) {
-      return 0;
-  }
-
 }

--- a/java/se/sics/mspsim/chip/TR1001.java
+++ b/java/se/sics/mspsim/chip/TR1001.java
@@ -118,9 +118,4 @@ public class TR1001 extends Chip implements RFListener, RFSource {
       }
     }
   }
-
-  @Override
-  public int getConfiguration(int parameter) {
-      return 0;
-  }
 }

--- a/java/se/sics/mspsim/core/Chip.java
+++ b/java/se/sics/mspsim/core/Chip.java
@@ -196,10 +196,6 @@ public abstract class Chip implements Loggable, EventSource {
       }
   }
 
-  /* interface for getting hold of configuration values - typically mapped to some kind of address */
-  public abstract int getConfiguration(int parameter);
-
-
   @Override
   public String getID() {
     return id;

--- a/java/se/sics/mspsim/core/MSP430Core.java
+++ b/java/se/sics/mspsim/core/MSP430Core.java
@@ -2217,11 +2217,6 @@ public class MSP430Core extends Chip implements MSP430Constants {
   }
 
   @Override
-  public int getConfiguration(int parameter) {
-      return 0;
-  }
-
-  @Override
   public String info() {
       StringBuilder buf = new StringBuilder();
       buf.append(" Mode: ").append(getModeName(getMode()))

--- a/java/se/sics/mspsim/platform/GenericNode.java
+++ b/java/se/sics/mspsim/platform/GenericNode.java
@@ -305,9 +305,4 @@ public abstract class GenericNode extends Chip implements Runnable {
     registry.registerComponent("mapTable", map);
     return elf;
   }
-
-  @Override
-  public int getConfiguration(int param) {
-      return 0;
-  }
 }


### PR DESCRIPTION
The method is not used, and a large share
of the implementations return either 0 or 1.

Remove the method.