### PR TITLE
Create MoteInterfaceHandler earlier

### DIFF
--- a/java/org/contikios/cooja/MoteInterfaceHandler.java
+++ b/java/org/contikios/cooja/MoteInterfaceHandler.java
@@ -73,11 +73,11 @@ public class MoteInterfaceHandler {
   private SerialPort mySerialPort;
 
   /**
-   * Creates new mote interface handler. All given interfaces are created.
+   * Initializes mote interface handler. All given interfaces are created.
    *
    * @param mote Mote
    */
-  public MoteInterfaceHandler(Mote mote) throws MoteType.MoteTypeCreationException {
+  public void init(Mote mote) throws MoteType.MoteTypeCreationException {
     for (var interfaceClass : mote.getType().getMoteInterfaceClasses()) {
       try {
         moteInterfaces.add(interfaceClass.getConstructor(Mote.class).newInstance(mote));

--- a/java/org/contikios/cooja/contikimote/ContikiMote.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMote.java
@@ -35,7 +35,6 @@ import org.contikios.cooja.interfaces.PolledAfterActiveTicks;
 import org.contikios.cooja.interfaces.PolledAfterAllTicks;
 import org.contikios.cooja.interfaces.PolledBeforeActiveTicks;
 import org.contikios.cooja.interfaces.PolledBeforeAllTicks;
-import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.mote.memory.SectionMoteMemory;
 import org.contikios.cooja.Simulation;
@@ -72,7 +71,7 @@ public class ContikiMote extends AbstractWakeupMote<ContikiMoteType, SectionMote
    */
   protected ContikiMote(ContikiMoteType moteType, Simulation sim) throws MoteType.MoteTypeCreationException {
     super(moteType, moteType.createInitialMemory(), sim);
-    moteInterfaces = new MoteInterfaceHandler(this);
+    moteInterfaces.init(this);
     for (var intf : moteInterfaces.getInterfaces()) {
       if (intf instanceof PolledBeforeActiveTicks intf2) {
         polledBeforeActive.add(intf2);

--- a/java/org/contikios/cooja/motes/AbstractApplicationMote.java
+++ b/java/org/contikios/cooja/motes/AbstractApplicationMote.java
@@ -29,7 +29,6 @@
 package org.contikios.cooja.motes;
 
 import java.util.HashMap;
-import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.RadioPacket;
 import org.contikios.cooja.mote.memory.SectionMoteMemory;
@@ -50,7 +49,7 @@ public abstract class AbstractApplicationMote extends AbstractWakeupMote<MoteTyp
   
   public AbstractApplicationMote(MoteType moteType, Simulation sim) throws MoteType.MoteTypeCreationException {
     super(moteType, new SectionMoteMemory(new HashMap<>()), sim);
-    this.moteInterfaces = new MoteInterfaceHandler(this);
+    moteInterfaces.init(this);
     // Observe our own radio for incoming radio packets.
     moteInterfaces.getRadio().getRadioEventTriggers().addTrigger(this, (event, radio) -> {
       if (radio.getLastEvent() == Radio.RadioEvent.RECEPTION_FINISHED) {

--- a/java/org/contikios/cooja/motes/AbstractEmulatedMote.java
+++ b/java/org/contikios/cooja/motes/AbstractEmulatedMote.java
@@ -34,12 +34,24 @@ import org.contikios.cooja.Simulation;
 import org.contikios.cooja.mote.memory.MemoryInterface;
 import org.contikios.cooja.plugins.BufferListener;
 import org.contikios.cooja.plugins.TimeLine;
+import se.sics.mspsim.core.Chip;
 
-public abstract class AbstractEmulatedMote<T extends MoteType, M extends MemoryInterface> extends AbstractWakeupMote<T, M> {
+public abstract class AbstractEmulatedMote<T extends MoteType, C extends Chip, M extends MemoryInterface> extends AbstractWakeupMote<T, M> {
+  protected final C myCpu;
   protected long lastBreakpointCycles = -1;
 
-  protected AbstractEmulatedMote(T moteType, M moteMemory, Simulation sim) {
+  protected AbstractEmulatedMote(T moteType, C cpu, M moteMemory, Simulation sim) {
     super(moteType, moteMemory, sim);
+    myCpu = cpu;
+  }
+
+  /**
+   * Returns the CPU.
+   *
+   * @return CPU
+   */
+  public C getCPU() {
+    return myCpu;
   }
 
   /**

--- a/java/org/contikios/cooja/motes/AbstractEmulatedMote.java
+++ b/java/org/contikios/cooja/motes/AbstractEmulatedMote.java
@@ -44,7 +44,7 @@ public abstract class AbstractEmulatedMote<T extends MoteType, C extends Chip, M
   protected AbstractEmulatedMote(T moteType, C cpu, M moteMemory, Simulation sim) throws MoteType.MoteTypeCreationException {
     super(moteType, moteMemory, sim);
     myCpu = cpu;
-    moteInterfaces = new MoteInterfaceHandler(this);
+    moteInterfaces.init(this);
   }
 
   /**

--- a/java/org/contikios/cooja/motes/AbstractEmulatedMote.java
+++ b/java/org/contikios/cooja/motes/AbstractEmulatedMote.java
@@ -29,6 +29,7 @@
 package org.contikios.cooja.motes;
 
 import org.contikios.cooja.Breakpoint;
+import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.mote.memory.MemoryInterface;
@@ -40,9 +41,10 @@ public abstract class AbstractEmulatedMote<T extends MoteType, C extends Chip, M
   protected final C myCpu;
   protected long lastBreakpointCycles = -1;
 
-  protected AbstractEmulatedMote(T moteType, C cpu, M moteMemory, Simulation sim) {
+  protected AbstractEmulatedMote(T moteType, C cpu, M moteMemory, Simulation sim) throws MoteType.MoteTypeCreationException {
     super(moteType, moteMemory, sim);
     myCpu = cpu;
+    moteInterfaces = new MoteInterfaceHandler(this);
   }
 
   /**

--- a/java/org/contikios/cooja/motes/AbstractWakeupMote.java
+++ b/java/org/contikios/cooja/motes/AbstractWakeupMote.java
@@ -49,7 +49,7 @@ public abstract class AbstractWakeupMote<T extends MoteType, M extends MemoryInt
   protected final T moteType;
   protected final M moteMemory;
 
-  protected MoteInterfaceHandler moteInterfaces;
+  protected final MoteInterfaceHandler moteInterfaces = new MoteInterfaceHandler();
   private long nextWakeupTime = -1;
 
   protected final ArrayList<WatchpointListener> watchpointListeners = new ArrayList<>();

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -69,7 +69,7 @@ import se.sics.mspsim.profiler.SimpleProfiler;
 /**
  * @author Fredrik Osterlind
  */
-public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteMemory> implements WatchpointMote {
+public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MSP430, MspMoteMemory> implements WatchpointMote {
   private static final Logger logger = LoggerFactory.getLogger(MspMote.class);
 
   private final static int EXECUTE_DURATION_US = 1; /* We always execute in 1 us steps */
@@ -81,18 +81,16 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
   }
 
   private final CommandHandler commandHandler = new CommandHandler(System.out, System.err);
-  private final MSP430 myCpu;
   public final ComponentRegistry registry;
 
   /* Stack monitoring variables */
   private boolean stopNextInstruction;
 
   public MspMote(MspMoteType moteType, Simulation sim, GenericNode node) throws MoteType.MoteTypeCreationException {
-    super(moteType, new MspMoteMemory(moteType.getEntries(node), node.getCPU()), sim);
+    super(moteType, node.getCPU(), new MspMoteMemory(moteType.getEntries(node), node.getCPU()), sim);
     registry = node.getRegistry();
     node.setCommandHandler(commandHandler);
     node.setup(new ConfigManager());
-    myCpu = node.getCPU();
     myCpu.setMonitorExec(true);
     myCpu.setTrace(0); /* TODO Enable */
     myCpu.getLogger().addLogListener(new LogListener() {
@@ -178,13 +176,6 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MspMoteM
   public void stopNextInstruction() {
     stopNextInstruction = true;
     getCPU().stop();
-  }
-
-  /**
-   * @return MSP430 CPU
-   */
-  public MSP430 getCPU() {
-    return myCpu;
   }
 
   public CommandHandler getCLICommandHandler() {

--- a/java/org/contikios/cooja/mspmote/MspMote.java
+++ b/java/org/contikios/cooja/mspmote/MspMote.java
@@ -37,7 +37,6 @@ import org.contikios.cooja.Simulation.SimulationStop;
 import org.contikios.cooja.WatchpointMote;
 import org.contikios.cooja.ContikiError;
 import org.contikios.cooja.Cooja;
-import org.contikios.cooja.MoteInterfaceHandler;
 import org.contikios.cooja.MoteType;
 import org.contikios.cooja.Simulation;
 import org.contikios.cooja.Watchpoint;
@@ -108,7 +107,6 @@ public abstract class MspMote extends AbstractEmulatedMote<MspMoteType, MSP430, 
     // Throw exceptions at bad memory access.
     //myCpu.setThrowIfWarning(true);
     myCpu.reset();
-    moteInterfaces = new MoteInterfaceHandler(this);
     registry.removeComponent("windowManager");
     registry.registerComponent("windowManager", new WindowManager() {
       @Override

--- a/java/org/contikios/cooja/plugins/BufferListener.java
+++ b/java/org/contikios/cooja/plugins/BufferListener.java
@@ -1103,7 +1103,7 @@ public class BufferListener extends VisPlugin {
         Arrays.fill(accessedBitpattern, true);
       }
 
-      if (mote instanceof AbstractEmulatedMote<?, ?> emulatedMote) {
+      if (mote instanceof AbstractEmulatedMote<?, ?, ?> emulatedMote) {
         String s = emulatedMote.getPCString();
         sourceStr = s==null?"[unknown]":s;
         stackTrace = withStackTrace ? emulatedMote.getStackTrace() : null;

--- a/java/org/contikios/cooja/plugins/MoteInformation.java
+++ b/java/org/contikios/cooja/plugins/MoteInformation.java
@@ -115,7 +115,7 @@ public class MoteInformation extends VisPlugin implements MotePlugin {
     mainPane.add(smallPane);
     
     /* CPU frequency */
-    if (mote instanceof AbstractEmulatedMote<?, ?> emulatedMote) {
+    if (mote instanceof AbstractEmulatedMote<?, ?, ?> emulatedMote) {
       smallPane = new JPanel(new BorderLayout());
       label = new JLabel("CPU frequency");
       label.setPreferredSize(size);

--- a/java/org/contikios/cooja/plugins/TimeLine.java
+++ b/java/org/contikios/cooja/plugins/TimeLine.java
@@ -866,7 +866,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
         @Override
         public void accept(RadioEvent radioEv, Radio radio) {
           String details = null;
-          if (executionDetails && mote instanceof AbstractEmulatedMote<?, ?> emulatedMote) {
+          if (executionDetails && mote instanceof AbstractEmulatedMote<?, ?, ?> emulatedMote) {
             details = emulatedMote.getExecutionDetails();
             if (details != null) {
               details = "<br>" + details.replace("\n", "<br>");
@@ -945,7 +945,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
         public void watchpointTriggered(Watchpoint watchpoint) {
           WatchpointEvent ev = new WatchpointEvent(simulation.getSimulationTime(), watchpoint);
 
-          if (executionDetails && mote instanceof AbstractEmulatedMote<?, ?> emulatedMote) {
+          if (executionDetails && mote instanceof AbstractEmulatedMote<?, ?, ?> emulatedMote) {
             String details = emulatedMote.getExecutionDetails();
             if (details != null) {
               details = "<br>" + details.replace("\n", "<br>");


### PR DESCRIPTION
MoteInterfaceHandler cannot be allocated in AbstractWakeupMote for MspMotes, because mote interfaces (SkyFlash for example) get the CPU to find the flash.

Not sure how to get there long-term, but this reduces the number of places we allocate MoteInterfaceHandler in.