### PR TITLE
gradle: add spotless plugin

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+Language: Java
+BasedOnStyle: LLVM
+ColumnLimit: 100
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,15 @@ jobs:
           distribution: 'zulu'
       - name: Verify gradle-wrapper checksum
         uses: gradle/wrapper-validation-action@v1
+      - name: install macOS software
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install make clang-format
+          # Homebrew prefix is different for x86-64 and aarch64.
+          export HOMEBREW_PREFIX=/usr/local
+          # Put Homebrew installed make first in PATH so "make" is version 4.x.
+          echo "export PATH=$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$PATH" >> ~/.profile
+          echo "export PATH=$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$PATH" >> ~/.bashrc
       - name: Build Cooja and Documentation
         uses: gradle/gradle-build-action@v2
         with:
@@ -57,15 +66,6 @@ jobs:
         with:
           key: compilation-${{ runner.os }}
           max-size: 160M
-      - name: install macOS software
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install make
-          # Homebrew prefix is different for x86-64 and aarch64.
-          export HOMEBREW_PREFIX=/usr/local
-          # Put Homebrew installed make first in PATH so "make" is version 4.x.
-          echo "export PATH=$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$PATH" >> ~/.profile
-          echo "export PATH=$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$PATH" >> ~/.bashrc
       - name: Run Contiki-NG simulation tests
         run: |
           [ "$(uname)" = "Linux" ] || source ~/.bashrc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,8 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           brew install make clang-format
+          # Prevent Gradle from picking up Java 8 on Github CI runner.
+          echo "org.gradle.java.home=$JAVA_HOME_17_X64" > contiki-ng/tools/cooja/gradle.properties
           # Homebrew prefix is different for x86-64 and aarch64.
           export HOMEBREW_PREFIX=/usr/local
           # Put Homebrew installed make first in PATH so "make" is version 4.x.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,8 @@ jobs:
         run: |
           brew install make clang-format
           # Prevent Gradle from picking up Java 8 on Github CI runner.
-          echo "org.gradle.java.home=$JAVA_HOME_17_X64" > contiki-ng/tools/cooja/gradle.properties
+          mkdir -p $HOME/.gradle
+          echo "org.gradle.java.home=$JAVA_HOME_17_X64" > $HOME/.gradle/gradle.properties
           # Homebrew prefix is different for x86-64 and aarch64.
           export HOMEBREW_PREFIX=/usr/local
           # Put Homebrew installed make first in PATH so "make" is version 4.x.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'application'
+  id 'application'
+  id 'com.diffplug.spotless' version '6.22.0'
 }
 
 group = 'org.contikios.cooja'
@@ -9,6 +10,28 @@ def javaVersion = 21
 java {
   toolchain {
     languageVersion = JavaLanguageVersion.of(javaVersion)
+  }
+}
+
+spotless {
+  java {
+    toggleOffOn()
+    removeUnusedImports()
+    importOrder()
+    // trimTrailingWhitespace()
+    // cleanthat()
+    // formatAnnotations()
+
+    // Use a different clang-format binary with -PclangFormat=clang-format-15.
+    def clangFormatBinary = (String) project.findProperty('clangFormat') ?: 'clang-format'
+    def clangOutput = new ByteArrayOutputStream()
+    exec {
+      commandLine clangFormatBinary, '--version'
+      standardOutput = clangOutput
+    }
+    def clangVersion = (String) (clangOutput.toString() =~ /\d+\.\d+\.\d+/)[0]
+    // FIXME: enable clangFormat in the future.
+//    clangFormat(clangVersion).pathToExe(clangFormatBinary).style('file')
   }
 }
 


### PR DESCRIPTION
This adds the build support for formatting-checks
in CI. Run with:

./gradlew spotlessCheck -PclangFormat=clang-format-15

to use a different clang-format binary.

No checks are enabled by default with the build commands
currently used by Contiki-NG and this repository.