### PR TITLE
ContikiClock: fix 64-bit variable size

### DIFF
--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiClock.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiClock.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  * <li>clock_time_t simCurrentTime
  * <li>rtimer_clock_t simRtimerCurrentTicks
  * <li>clock_time_t simEtimerNextExpirationTime
- * <li>rtimer_clock_t simEtimerNextExpirationTime
+ * <li>rtimer_clock_t simRtimerNextExpirationTime
  * <li>int simEtimerProcessRunValue
  * <li>int simRtimerProcessRunValue
  * <li>int simEtimerPending
@@ -87,7 +87,7 @@ public class ContikiClock extends Clock implements PolledBeforeActiveTicks, Poll
   public void setTime(long newTime) {
     moteTime = newTime;
     if (moteTime > 0) {
-      moteMem.setIntValueOf("simCurrentTime", (int)(newTime/1000));
+      moteMem.setInt64ValueOf("simCurrentTime", newTime / 1000);
     }
   }
 
@@ -149,7 +149,7 @@ public class ContikiClock extends Clock implements PolledBeforeActiveTicks, Poll
     }
 
     /* Request tick next wakeup time for Etimer */
-    long etimerNextExpirationTime = (long)moteMem.getInt32ValueOf("simEtimerNextExpirationTime") * Simulation.MILLISECOND;
+    long etimerNextExpirationTime = moteMem.getInt64ValueOf("simEtimerNextExpirationTime") * Simulation.MILLISECOND;
     long etimerTimeToNextExpiration = etimerNextExpirationTime - moteTime;
     if (etimerTimeToNextExpiration <= 0) {
       /* logger.warn(mote.getID() + ": Event timer already expired, but has been delayed: " + etimerTimeToNextExpiration); */


### PR DESCRIPTION
The clock_time_t definition in Contiki-NG
has been "unsigned long", which is 32 bits
on most 32-bit architectures, and 64 bits
on most 64-bit architectures.

Assume people are running Cooja on 64-bit
machines for now, and read as a 64-bit
variable. There is a pull request for
Contiki-NG to make the Cooja platform's
clock_time_t an uint64_t, so this commit
will eventually become correct for 32-bit
machines as well.