### PR TITLE
gradle: upgrade to Gradle 8.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Build Cooja and Documentation
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-version: 8.2.1
+          gradle-version: 8.3
           cache-read-only: false
           arguments: jar
       - name: Test MSPSim
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-version: 8.2.1
+          gradle-version: 8.3
           arguments: test

--- a/build.gradle
+++ b/build.gradle
@@ -87,10 +87,11 @@ tasks.withType(AbstractArchiveTask).configureEach {
 }
 
 tasks.register('copyDependencies', Copy) {
-  description = "Copy jar dependencies into ${buildDir}/libs/lib/."
+  def dir = layout.buildDirectory.dir("libs/lib")
+  description = "Copy jar dependencies into ${dir.get()}"
   group = "Build"
   from configurations.runtimeClasspath.files
-  into "build/libs/lib"
+  into dir
 }
 
 // Run Cooja with: java <JVM parameters> -jar build/libs/cooja.jar <Cooja parameters>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This release brings full support for Java 20.

The release notes also mention faster Java
compilation because Gradle keeps the compiler
daemons running between builds, so that will
hopefully help when working on Cooja.