### PR TITLE
RadioMediums: Inform transmitting motes of interfering transmissions

### DIFF
--- a/java/org/contikios/cooja/radiomediums/DirectedGraphMedium.java
+++ b/java/org/contikios/cooja/radiomediums/DirectedGraphMedium.java
@@ -291,6 +291,7 @@ public class DirectedGraphMedium extends AbstractRadioMedium {
 
       if (dest.radio.isTransmitting()) {
         newConn.addInterfered(dest.radio);
+        dest.radio.interfereAnyReception();
         continue;
       }
 

--- a/java/org/contikios/cooja/radiomediums/DirectedGraphMedium.java
+++ b/java/org/contikios/cooja/radiomediums/DirectedGraphMedium.java
@@ -288,7 +288,12 @@ public class DirectedGraphMedium extends AbstractRadioMedium {
         newConn.addInterfered(dest.radio);
         continue;
       }
-     
+
+      if (dest.radio.isTransmitting()) {
+        newConn.addInterfered(dest.radio);
+        continue;
+      }
+
       if (dest.radio.isReceiving()) {
          /* Fail: radio is already actively receiving */
          /*logger.info(source + ": Fail, receiving");*/

--- a/java/org/contikios/cooja/radiomediums/LogisticLoss.java
+++ b/java/org/contikios/cooja/radiomediums/LogisticLoss.java
@@ -254,6 +254,7 @@ public class LogisticLoss extends AbstractRadioMedium {
                     newConnection.addInterfered(recv);
                 } else if (recv.isTransmitting()) {
                     newConnection.addInterfered(recv);
+                    recv.interfereAnyReception();
                 } else {
                     boolean receiveNewOk = random.nextDouble() < getRxSuccessProbability(sender, recv);
 

--- a/java/org/contikios/cooja/radiomediums/UDGM.java
+++ b/java/org/contikios/cooja/radiomediums/UDGM.java
@@ -219,6 +219,7 @@ public class UDGM extends AbstractRadioMedium {
           newConnection.addInterfered(recv);
         } else if (recv.isTransmitting()) {
           newConnection.addInterfered(recv);
+          recv.interfereAnyReception();
         } else if (recv.isReceiving() ||
             (random.nextDouble() > getRxSuccessProbability(sender, recv))) {
           /* Was receiving, or reception failed: start interfering */

--- a/java/org/contikios/mrm/MRM.java
+++ b/java/org/contikios/mrm/MRM.java
@@ -200,6 +200,7 @@ public class MRM extends AbstractRadioMedium {
           }
         } else if (recv.isTransmitting()) {
           newConnection.addInterfered(recv, recvSignalStrength);
+          recv.interfereAnyReception();
         } else if (recv.isReceiving()) {
           /* Was already receiving: start interfering.
            * Assuming no continuous preambles checking */


### PR DESCRIPTION
If interference occurs while a mote is transmitting, the mote will happily receive subsequent frames. The correct handling would be to only start receiving frames again once the interference is over. This PR fixes this problem.