### PR TITLE
RadioMediums: Keep interference status up to date

### DIFF
--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiRadio.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiRadio.java
@@ -323,8 +323,9 @@ public class ContikiRadio extends Radio implements PolledAfterActiveTicks {
     var currentChannel = getChannel();
     if (currentChannel != oldRadioChannel) {
       oldRadioChannel = currentChannel;
-      lastEvent = RadioEvent.UNKNOWN;
-      radioEventTriggers.trigger(RadioEvent.UNKNOWN, this);
+      isInterfered = false;
+      lastEvent = RadioEvent.CHANNEL_HOP;
+      radioEventTriggers.trigger(RadioEvent.CHANNEL_HOP, this);
     }
 
     /* Ongoing transmission */

--- a/java/org/contikios/cooja/interfaces/Radio.java
+++ b/java/org/contikios/cooja/interfaces/Radio.java
@@ -58,7 +58,7 @@ public abstract class Radio implements MoteInterface {
    * Events that radios should notify observers about.
    */
   public enum RadioEvent {
-    UNKNOWN, HW_OFF, HW_ON,
+    UNKNOWN, HW_OFF, HW_ON, CHANNEL_HOP,
     RECEPTION_STARTED, RECEPTION_FINISHED, RECEPTION_INTERFERED,
     TRANSMISSION_STARTED, TRANSMISSION_FINISHED,
     PACKET_TRANSMITTED, CUSTOM_DATA_TRANSMITTED

--- a/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
+++ b/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
@@ -108,9 +108,19 @@ public abstract class AbstractRadioMedium implements RadioMedium {
       switch (event) {
         case RECEPTION_STARTED:
         case RECEPTION_INTERFERED:
-        case RECEPTION_FINISHED:
           break;
-
+        case RECEPTION_FINISHED:
+        case CHANNEL_HOP: {
+          /* in such cases the radio reverts to "not interfered */
+          for (RadioConnection conn : getActiveConnections()) {
+            if (conn.isInterfered(radio)
+                && (conn.getSource().getChannel() == radio.getChannel())) {
+              /* continue interfering due to transmission on radio's channel */
+              radio.interfereAnyReception();
+            }
+          }
+        }
+        break;
         case UNKNOWN:
         case HW_ON: {
           updateSignalStrengths();


### PR DESCRIPTION
Upon completion of a reception, radios revert their interference status to false. This may be inconsistent with the actual interference status as there may be other ongoing receptions. Similar issues may occur when switching from interfered or non-interfered channels.