### PR TITLE
Default to use ECMAScript 6

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -1686,7 +1686,8 @@ public class Cooja {
    * values when creating a new simulation in the File menu.
    */
   public record Config(LogbackColors logColors, boolean vis, String externalToolsConfig,
-                       String logDir, String contikiPath, String coojaPath, String javac) {}
+                       String nashornArgs, String logDir,
+                       String contikiPath, String coojaPath, String javac) {}
 
   public record LogbackColors(String error, String warn, String info, String fallback) {}
   private record PathIdentifier(String id, String path) {}

--- a/java/org/contikios/cooja/LogScriptEngine.java
+++ b/java/org/contikios/cooja/LogScriptEngine.java
@@ -68,7 +68,7 @@ public class LogScriptEngine {
   private static final Logger logger = LoggerFactory.getLogger(LogScriptEngine.class);
   private static final long DEFAULT_TIMEOUT = 20*60*1000*Simulation.MILLISECOND; /* 1200s = 20 minutes */
 
-  private final NashornScriptEngine engine = (NashornScriptEngine) new NashornScriptEngineFactory().getScriptEngine();
+  private final NashornScriptEngine engine;
 
   private final BufferedWriter logWriter; // For non-GUI tests.
 
@@ -110,7 +110,8 @@ public class LogScriptEngine {
   private long startRealTime;
   private final JTextArea textArea;
 
-  LogScriptEngine(Simulation simulation, int logNumber, JTextArea logTextArea) {
+  LogScriptEngine(Simulation simulation, String nashornArgs, int logNumber, JTextArea logTextArea) {
+    engine = (NashornScriptEngine) new NashornScriptEngineFactory().getScriptEngine(nashornArgs);
     this.simulation = simulation;
     textArea = logTextArea;
     simulation.getEventCentral().addLogOutputListener(logOutputListener);

--- a/java/org/contikios/cooja/Main.java
+++ b/java/org/contikios/cooja/Main.java
@@ -79,6 +79,12 @@ class Main {
   String logDir = ".";
 
   /**
+   * Option for specifying Nashorn arguments.
+   */
+  @Option(names = "--nashorn-args", paramLabel = "ARGS", description = "the Nashorn arguments")
+  String nashornArgs = "--language=es6";
+
+  /**
    * Option for specifying Contiki-NG path.
    */
   @Option(names = "--contiki", paramLabel = "DIR", description = "the Contiki-NG directory")
@@ -310,6 +316,7 @@ class Main {
       var colors = new LogbackColors(ANSIConstants.BOLD + "91", "96",
               ANSIConstants.GREEN_FG, ANSIConstants.DEFAULT_FG);
       var cfg = new Config(colors, options.gui, options.externalUserConfig,
+                options.nashornArgs,
                 options.logDir, options.contikiPath, options.coojaPath, options.javac);
       Cooja.go(cfg, simConfigs);
     } else { // Start MSPSim.

--- a/java/org/contikios/cooja/Simulation.java
+++ b/java/org/contikios/cooja/Simulation.java
@@ -498,8 +498,8 @@ public final class Simulation {
 
   /** Create a new script engine that logs to the logTextArea and add it to the list
    *  of active script engines. */
-  public LogScriptEngine newScriptEngine(JTextArea logTextArea) {
-    var engine = new LogScriptEngine(this, scriptEngines.size(), logTextArea);
+  public LogScriptEngine newScriptEngine(JTextArea logTextArea, String nashornArgs) {
+    var engine = new LogScriptEngine(this, nashornArgs, scriptEngines.size(), logTextArea);
     scriptEngines.add(engine);
     return engine;
   }

--- a/java/org/contikios/cooja/plugins/ScriptRunner.java
+++ b/java/org/contikios/cooja/plugins/ScriptRunner.java
@@ -104,7 +104,7 @@ public class ScriptRunner implements Plugin, HasQuickHelp {
       frame = null;
       editorTabs = null;
       logTextArea = null;
-      engine = simulation.newScriptEngine(null);
+      engine = simulation.newScriptEngine(null, Cooja.configuration.nashornArgs());
       return;
     }
 
@@ -130,7 +130,7 @@ public class ScriptRunner implements Plugin, HasQuickHelp {
     logTextArea.setMargin(new Insets(5,5,5,5));
     logTextArea.setEditable(false);
     logTextArea.setCursor(null);
-    engine = simulation.newScriptEngine(logTextArea);
+    engine = simulation.newScriptEngine(logTextArea, Cooja.configuration.nashornArgs());
 
     var newScript = new JMenuItem("New");
     newScript.addActionListener(l -> {


### PR DESCRIPTION
The ECMAScript 6 support in Nashorn is
not complete, but enable what is there
by default.

The previous behavior is still available
by passing in an empty string as parameter
to --nashorn-args.