### PR TITLE
ContikiMoteType: pass through COOJA_CI

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMoteType.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMoteType.java
@@ -213,6 +213,10 @@ public class ContikiMoteType extends BaseContikiMoteType {
     if (ci != null) {
       env.put("CI", ci);
     }
+    String coojaCi = System.getenv("COOJA_CI");
+    if (coojaCi != null) {
+      env.put("COOJA_CI", coojaCi);
+    }
     String relstr = System.getenv("RELSTR");
     if (relstr != null) {
       env.put("RELSTR", relstr);


### PR DESCRIPTION
This will enable the CI to avoid version checks
when the support in Contiki-NG has landed.