### PR TITLE
SectionMoteMemory: avoid re-adding symbols

### DIFF
--- a/java/org/contikios/cooja/mote/memory/SectionMoteMemory.java
+++ b/java/org/contikios/cooja/mote/memory/SectionMoteMemory.java
@@ -99,11 +99,6 @@ public class SectionMoteMemory implements MemoryInterface {
     }
 
     sections.put(name, section);
-    if (section.getSymbolMap() != null) {
-      // XXX how to handle double names here?
-      symbols.putAll(section.getSymbolMap());
-    }
-
     if (DEBUG) {
       logger.debug(String.format(
               "Added section '%s' of size %d @0x%x",


### PR DESCRIPTION
There is a single symbol map for the SectionMoteMemory, so use that and stop re-adding the same symbols
when adding sections.