### PR TITLE
CI: override Contiki-NG version check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,8 +69,7 @@ jobs:
       - name: Run Contiki-NG simulation tests
         run: |
           [ "$(uname)" = "Linux" ] || source ~/.bashrc
-          # Update Contiki-NG for current build version.
-          perl -pi -e 's#^EXPECTED_COOJA_VERSION =(.*)$#EXPECTED_COOJA_VERSION = 2023090701#g' contiki-ng/arch/platform/cooja/Makefile.cooja
+          export COOJA_CI=true
           cd contiki-ng/tests/07-simulation-base
           # Skip MSP430 tests, no compiler installed.
           rm ??-*sky*.csc ??-*z1*.csc


### PR DESCRIPTION
Contiki-NG now supports overriding
the version check, so use that instead
of doing in-place editing of Makefile.