### PR TITLE
CI: run spotless as part of build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,12 +50,21 @@ jobs:
           # Put Homebrew installed make first in PATH so "make" is version 4.x.
           echo "export PATH=$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$PATH" >> ~/.profile
           echo "export PATH=$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$PATH" >> ~/.bashrc
+      # The build step includes :spotlessJavaBuild.
       - name: Build Cooja and Documentation
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 8.4
           cache-read-only: false
-          arguments: jar -Perrorprone
+          arguments: build -Perrorprone
+          build-root-directory: contiki-ng/tools/cooja
+      # The Jar is important for MSPSim in Contiki-NG.
+      - name: Build Jar
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 8.4
+          cache-read-only: false
+          arguments: jar
           build-root-directory: contiki-ng/tools/cooja
       - name: Test MSPSim
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
Run ./gradlew build to run a step that
includes :spotlessJavaBuild for format
checks.