### PR TITLE
Fix Error Prone warnings

### DIFF
--- a/java/org/contikios/cooja/GUI.java
+++ b/java/org/contikios/cooja/GUI.java
@@ -1150,15 +1150,10 @@ public class GUI {
 
   public void loadQuickHelp(final Object obj) {
     String help;
-    if (obj instanceof HasQuickHelp) {
-      help = ((HasQuickHelp) obj).getQuickHelp();
+    if (obj instanceof HasQuickHelp hasQuickHelp) {
+      help = hasQuickHelp.getQuickHelp();
     } else {
-      String key;
-      if (obj instanceof String) {
-        key = (String) obj;
-      } else {
-        key = obj.getClass().getName();
-      }
+      String key = obj instanceof String text ? text : obj.getClass().getName();
       help = switch (key) {
         case "KEYBOARD_SHORTCUTS" -> "<b>Keyboard shortcuts</b><br>" +
                 "<br><i>Ctrl+N:</i> New simulation" +

--- a/java/org/contikios/cooja/dialogs/SerialUI.java
+++ b/java/org/contikios/cooja/dialogs/SerialUI.java
@@ -284,7 +284,13 @@ public abstract class SerialUI extends Log implements SerialPort {
   }
 
   private static String trim(String text) {
-    return (text != null) && !(text = text.trim()).isEmpty() ? text : null;
+    if (text != null) {
+      text = text.trim();
+      if (!text.isEmpty()) {
+        return text;
+      }
+    }
+    return null;
   }
 
   @Override

--- a/java/org/contikios/cooja/emulatedmote/Radio802154.java
+++ b/java/org/contikios/cooja/emulatedmote/Radio802154.java
@@ -136,8 +136,8 @@ public abstract class Radio802154 extends Radio implements CustomDataRadio {
 
     @Override
     public void receiveCustomData(Object data) {
-        if (data instanceof RadioByte) {
-            lastIncomingByte = (RadioByte) data;
+        if (data instanceof RadioByte radioByte) {
+            lastIncomingByte = radioByte;
             handleReceive(lastIncomingByte.getPacketData()[0]);
         }
     }

--- a/java/org/contikios/cooja/mspmote/interfaces/CC1101Radio.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/CC1101Radio.java
@@ -78,12 +78,12 @@ public class CC1101Radio extends Radio implements CustomDataRadio {
 	public CC1101Radio(Mote m) {
 		this.mote = (MspMote)m;
     Radio802154 r = this.mote.getCPU().getChip(Radio802154.class);
-    if (!(r instanceof CC1101)) {
+    if (!(r instanceof CC1101 cc1101Radio)) {
       throw new IllegalStateException("Mote is not equipped with an CC1101 radio");
     }
-    this.cc1101 = (CC1101) r;
+    this.cc1101 = cc1101Radio;
 
-		cc1101.addRFListener(new RFListener() {
+		this.cc1101.addRFListener(new RFListener() {
 			int len;
 			int expLen;
 			final byte[] buffer = new byte[256 + 15];
@@ -139,8 +139,8 @@ public class CC1101Radio extends Radio implements CustomDataRadio {
 			}
 		});
 
-    cc1101.setReceiverListener(on -> {
-      if (cc1101.isReadyToReceive()) {
+    this.cc1101.setReceiverListener(on -> {
+      if (this.cc1101.isReadyToReceive()) {
         lastEvent = RadioEvent.HW_ON;
         radioEventTriggers.trigger(RadioEvent.HW_ON, this);
       } else {
@@ -148,7 +148,7 @@ public class CC1101Radio extends Radio implements CustomDataRadio {
       }
     });
 
-    cc1101.addChannelListener(channel -> {
+    this.cc1101.addChannelListener(channel -> {
       /* XXX Currently assumes zero channel switch time */
       lastEvent = RadioEvent.UNKNOWN;
       radioEventTriggers.trigger(RadioEvent.UNKNOWN, this);
@@ -232,11 +232,11 @@ public class CC1101Radio extends Radio implements CustomDataRadio {
 
 	@Override
 	public void receiveCustomData(Object data) {
-		if (!(data instanceof Byte)) {
+		if (!(data instanceof Byte byteData)) {
 			logger.error("Bad custom data: " + data);
 			return;
 		}
-		lastIncomingByte = (Byte) data;
+		lastIncomingByte = byteData;
 
 		final byte inputByte;
 		if (isInterfered()) {

--- a/java/org/contikios/cooja/mspmote/interfaces/CC1120Radio.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/CC1120Radio.java
@@ -79,10 +79,10 @@ public class CC1120Radio extends Radio implements CustomDataRadio {
 	public CC1120Radio(Mote m) {
 		this.mote = (MspMote)m;
 		Radio802154 r = this.mote.getCPU().getChip(Radio802154.class);
-		if (!(r instanceof CC1120)) {
+		if (!(r instanceof CC1120 cc1120Radio)) {
 			throw new IllegalStateException("Mote is not equipped with an CC1120 radio");
 		}
-		this.cc1120 = (CC1120) r;
+		this.cc1120 = cc1120Radio;
 
 		cc1120.addRFListener(new RFListener() {
 			int len;
@@ -234,11 +234,11 @@ public class CC1120Radio extends Radio implements CustomDataRadio {
 
 	@Override
 	public void receiveCustomData(Object data) {
-		if (!(data instanceof Byte)) {
+		if (!(data instanceof Byte byteData)) {
 			logger.error("Bad custom data: " + data);
 			return;
 		}
-		lastIncomingByte = (Byte) data;
+		lastIncomingByte = byteData;
 
 		final byte inputByte;
 		if (isInterfered()) {

--- a/java/org/contikios/cooja/mspmote/interfaces/CC2520Radio.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/CC2520Radio.java
@@ -170,11 +170,11 @@ public class CC2520Radio extends Radio implements CustomDataRadio {
 
   @Override
   public void receiveCustomData(Object data) {
-    if (!(data instanceof Byte)) {
+    if (!(data instanceof Byte byteData)) {
       logger.error("Bad custom data: " + data);
       return;
     }
-    lastIncomingByte = (Byte) data;
+    lastIncomingByte = byteData;
 
     final byte inputByte;
     if (isInterfered()) {

--- a/java/org/contikios/cooja/mspmote/interfaces/Exp5438LED.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/Exp5438LED.java
@@ -59,8 +59,8 @@ public class Exp5438LED extends LED {
   public Exp5438LED(Mote mote) {
     var mspMote = (Exp5438Mote) mote;
     IOUnit unit = mspMote.getCPU().getIOUnit("P1");
-    if (unit instanceof IOPort) {
-      ((IOPort) unit).addPortListener((source, data) -> {
+    if (unit instanceof IOPort ioPort) {
+      ioPort.addPortListener((source, data) -> {
         boolean oldRedOn = redOn;
         boolean oldYellowOn = yellowOn;
         redOn = (data & Exp5438Node.LEDS_CONF_RED) != 0;

--- a/java/org/contikios/cooja/mspmote/interfaces/MspDebugOutput.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/MspDebugOutput.java
@@ -71,17 +71,17 @@ public class MspDebugOutput extends Log {
       /* Disabled */
       return;
     }
-    this.mote.getCPU().addWatchPoint((int) mem.getVariableAddress(CONTIKI_POINTER),
-        memoryMonitor = new MemoryMonitor.Adapter() {
-        @Override
-        public void notifyWriteAfter(int adr, int data, Memory.AccessMode mode) {
-          String msg = extractString(MspDebugOutput.this.mote.getMemory(), data);
-          if (!msg.isEmpty()) {
-            lastLog = "DEBUG: " + msg;
-            getLogDataTriggers().trigger(EventTriggers.Update.UPDATE, new LogDataInfo(mote, lastLog));
-          }
+    memoryMonitor = new MemoryMonitor.Adapter() {
+      @Override
+      public void notifyWriteAfter(int adr, int data, Memory.AccessMode mode) {
+        String msg = extractString(MspDebugOutput.this.mote.getMemory(), data);
+        if (!msg.isEmpty()) {
+          lastLog = "DEBUG: " + msg;
+          getLogDataTriggers().trigger(EventTriggers.Update.UPDATE, new LogDataInfo(mote, lastLog));
+        }
       }
-    });
+    };
+    this.mote.getCPU().addWatchPoint((int) mem.getVariableAddress(CONTIKI_POINTER), memoryMonitor);
   }
 
   private static String extractString(MemoryInterface mem, int address) {

--- a/java/org/contikios/cooja/mspmote/plugins/MspCLI.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCLI.java
@@ -185,7 +185,13 @@ public class MspCLI extends VisPlugin implements MotePlugin, HasQuickHelp {
   }
 
   private static String trim(String text) {
-    return (text != null) && !(text = text.trim()).isEmpty() ? text : null;
+    if (text != null) {
+      text = text.trim();
+      if (!text.isEmpty()) {
+        return text;
+      }
+    }
+    return null;
   }
 
   @Override

--- a/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
+++ b/java/org/contikios/cooja/mspmote/plugins/MspCodeWatcher.java
@@ -218,7 +218,7 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
     add(BorderLayout.SOUTH, sourceCodeControl);
 
     /* Listen for breakpoint changes */
-    watchpointMote.addWatchpointListener(watchpointListener = new WatchpointListener() {
+    watchpointListener = new WatchpointListener() {
       @Override
       public void watchpointTriggered(final Watchpoint watchpoint) {
         SwingUtilities.invokeLater(() -> {
@@ -235,7 +235,8 @@ public class MspCodeWatcher extends VisPlugin implements MotePlugin, HasQuickHel
       public void watchpointsChanged() {
         sourceCodeUI.updateBreakpoints();
       }
-    });
+    };
+    watchpointMote.addWatchpointListener(watchpointListener);
 
     /* Observe when simulation starts/stops */
     simulation.getSimulationStateTriggers().addTrigger(this, (state, simulation) -> EventQueue.invokeLater(() -> {

--- a/java/org/contikios/cooja/plugins/BufferListener.java
+++ b/java/org/contikios/cooja/plugins/BufferListener.java
@@ -362,8 +362,8 @@ public class BufferListener extends VisPlugin {
           Object value, boolean isSelected, boolean hasFocus, int row,
           int column) {
         if (row >= logTable.getRowCount()) {
-          if (value instanceof BufferAccess && parser instanceof GraphicalParser) {
-            graphicalParserPanel.update((BufferAccess) value, (GraphicalParser)parser);
+          if (value instanceof BufferAccess bufferAccess && parser instanceof GraphicalParser graphicalParser) {
+            graphicalParserPanel.update(bufferAccess, graphicalParser);
             return graphicalParserPanel;
           }
           return super.getTableCellRendererComponent(
@@ -382,8 +382,8 @@ public class BufferListener extends VisPlugin {
           bgColor = table.getSelectionBackground();
         }
 
-        if (value instanceof BufferAccess && parser instanceof GraphicalParser) {
-          graphicalParserPanel.update((BufferAccess) value, (GraphicalParser)parser);
+        if (value instanceof BufferAccess bufferAccess && parser instanceof GraphicalParser graphicalParser) {
+          graphicalParserPanel.update(bufferAccess, graphicalParser);
           graphicalParserPanel.setBackground(bgColor);
           return graphicalParserPanel;
         } else {

--- a/java/org/contikios/cooja/plugins/DGRMConfigurator.java
+++ b/java/org/contikios/cooja/plugins/DGRMConfigurator.java
@@ -133,11 +133,11 @@ public class DGRMConfigurator extends VisPlugin {
     graphTable.getColumnModel().getColumn(IDX_RATIO).setCellRenderer(new DefaultTableCellRenderer() {
       @Override
       public void setValue(Object value) {
-        if (!(value instanceof Double)) {
+        if (value instanceof Double valueAsDouble) {
+          setText(String.format("%1.1f%%", 100 * valueAsDouble));
+        } else {
           setText(value.toString());
-          return;
         }
-        setText(String.format("%1.1f%%", 100* (Double) value));
       }
     });
     graphTable.getColumnModel().getColumn(IDX_SIGNAL).setCellRenderer(new DefaultTableCellRenderer() {

--- a/java/org/contikios/cooja/plugins/LogListener.java
+++ b/java/org/contikios/cooja/plugins/LogListener.java
@@ -576,7 +576,7 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
 
     /* Start observing motes for new log output */
     logUpdateAggregator.start();
-    simulation.getEventCentral().addLogOutputListener(logOutputListener = ev -> {
+    logOutputListener = ev -> {
       if (!hasHours && ev.getTime() > TIME_HOUR) {
         hasHours = true;
         repaintTimeColumn();
@@ -586,7 +586,8 @@ public class LogListener extends VisPlugin implements HasQuickHelp {
       if (appendToFile) {
         appendToFile(appendStreamFile, data.getTime() + "\t" + data.getID() + "\t" + data.ev.getMessage() + "\n");
       }
-    });
+    };
+    simulation.getEventCentral().addLogOutputListener(logOutputListener);
 
     /* UI components */
     JPanel filterPanel = new JPanel();

--- a/java/org/contikios/cooja/plugins/MoteInterfaceViewer.java
+++ b/java/org/contikios/cooja/plugins/MoteInterfaceViewer.java
@@ -200,20 +200,21 @@ public class MoteInterfaceViewer extends VisPlugin implements HasQuickHelp, Mote
 
   @Override
   public String getQuickHelp() {
-    String help = "<b>" + Cooja.getDescriptionOf(this) + "</b>";
-    help += "<p>Lists mote interfaces, and allows mote inspection and interaction via mote interface visualizers.";
+    StringBuilder help = new StringBuilder();
+    help.append("<b>").append(Cooja.getDescriptionOf(this)).append("</b>");
+    help.append("<p>Lists mote interfaces, and allows mote inspection and interaction via mote interface visualizers.");
 
     MoteInterface intf = selectedMoteInterface;
     if (intf != null) {
-      if (intf instanceof HasQuickHelp) {
-        help += "<p>" + ((HasQuickHelp)intf).getQuickHelp();
+      if (intf instanceof HasQuickHelp hasQuickHelp) {
+        help.append("<p>").append(hasQuickHelp.getQuickHelp());
       } else {
-        help += "<p><b>" + Cooja.getDescriptionOf(intf) + "</b>";
-        help += "<p>No help available";
+        help.append("<p><b>").append(Cooja.getDescriptionOf(intf)).append("</b>");
+        help.append("<p>No help available");
       }
     }
 
-    return help;
+    return help.toString();
   }
 
   @Override

--- a/java/org/contikios/cooja/plugins/RadioLogger.java
+++ b/java/org/contikios/cooja/plugins/RadioLogger.java
@@ -777,8 +777,8 @@ public class RadioLogger extends VisPlugin {
     byte[] data;
     if (conn.packet == null) {
       data = null;
-    } else if (conn.packet instanceof ConvertedRadioPacket) {
-      data = ((ConvertedRadioPacket) conn.packet).getOriginalPacketData();
+    } else if (conn.packet instanceof ConvertedRadioPacket convertedRadioPacket) {
+      data = convertedRadioPacket.getOriginalPacketData();
     } else {
       data = conn.packet.getPacketData();
     }
@@ -852,8 +852,8 @@ public class RadioLogger extends VisPlugin {
       return;
     }
 
-    if (packet instanceof ConvertedRadioPacket && packet.getPacketData().length > 0) {
-      byte[] original = ((ConvertedRadioPacket) packet).getOriginalPacketData();
+    if (packet instanceof ConvertedRadioPacket convertedRadioPacket && packet.getPacketData().length > 0) {
+      byte[] original = convertedRadioPacket.getOriginalPacketData();
       byte[] converted = packet.getPacketData();
       conn.tooltip = "<html><font face=\"Monospaced\">"
               + "<b>Packet data (" + original.length + " bytes)</b><br>"
@@ -862,8 +862,8 @@ public class RadioLogger extends VisPlugin {
               + "<b>Cross-level packet data (" + converted.length + " bytes)</b><br>"
               + "<pre>" + StringUtils.hexDump(converted) + "</pre>"
               + "</font></html>";
-    } else if (packet instanceof ConvertedRadioPacket) {
-      byte[] original = ((ConvertedRadioPacket) packet).getOriginalPacketData();
+    } else if (packet instanceof ConvertedRadioPacket convertedRadioPacket) {
+      byte[] original = convertedRadioPacket.getOriginalPacketData();
       conn.tooltip = "<html><font face=\"Monospaced\">"
               + "<b>Packet data (" + original.length + " bytes)</b><br>"
               + "<pre>" + StringUtils.hexDump(original) + "</pre>"

--- a/java/org/contikios/cooja/plugins/TimeLine.java
+++ b/java/org/contikios/cooja/plugins/TimeLine.java
@@ -428,7 +428,7 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
     numberMotesWasUpdated();
 
     // Automatically add/delete motes. This listener also observes mote log outputs.
-    simulation.getEventCentral().addLogOutputListener(newMotesListener = ev -> {
+    newMotesListener = ev -> {
       var mote = ev.getMote();
       var logEvent = new LogEvent(ev);
       // TODO: Optimize.
@@ -438,7 +438,8 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
           break;
         }
       }
-    });
+    };
+    simulation.getEventCentral().addLogOutputListener(newMotesListener);
     simulation.getMoteTriggers().addTrigger(this, (event, m) -> {
       if (event == EventTriggers.AddRemove.ADD) {
         addMote(m);
@@ -1972,7 +1973,8 @@ public class TimeLine extends VisPlugin implements HasQuickHelp {
             return logEventColor;
           }
           /* Ask log listener for event color to use */
-          return logEventColor = timeline.logEventFilterPlugin.getColorOfEntry(logEvent);
+          logEventColor = timeline.logEventFilterPlugin.getColorOfEntry(logEvent);
+          return logEventColor;
         }
       }
       return Color.green;

--- a/java/org/contikios/cooja/plugins/Visualizer.java
+++ b/java/org/contikios/cooja/plugins/Visualizer.java
@@ -1527,8 +1527,8 @@ public class Visualizer extends VisPlugin implements HasQuickHelp {
       Simulation simulation = mote.getSimulation();
       SerialPort serialPort = null;
       for (MoteInterface intf : mote.getInterfaces().getInterfaces()) {
-        if (intf instanceof SerialPort) {
-          serialPort = (SerialPort) intf;
+        if (intf instanceof SerialPort port) {
+          serialPort = port;
           break;
         }
       }

--- a/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
+++ b/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
@@ -201,20 +201,21 @@ public abstract class AbstractRadioMedium implements RadioMedium {
             return;
           }
 
-          var data = ((CustomDataRadio) radio).getLastCustomDataTransmitted();
+          var customRadio = (CustomDataRadio) radio;
+          var data = customRadio.getLastCustomDataTransmitted();
           if (data == null) {
             logger.error("No custom data objectTransmission to forward");
             return;
           }
 
           for (var dstRadio : connection.getAllDestinations()) {
-            if (!(dstRadio instanceof CustomDataRadio) ||
-                    !((CustomDataRadio) dstRadio).canReceiveFrom((CustomDataRadio) radio)) {
+            if (!(dstRadio instanceof CustomDataRadio customDstRadio) ||
+                    !customDstRadio.canReceiveFrom(customRadio)) {
               continue; // Radios communicate via radio packets.
             }
 
             if (connection.getDestinationDelay(dstRadio) == 0) {
-              ((CustomDataRadio) dstRadio).receiveCustomData(data);
+              customDstRadio.receiveCustomData(data);
             } else {
               /* EXPERIMENTAL: Simulating propagation delay */
               final var delayedRadio = (CustomDataRadio) dstRadio;
@@ -245,8 +246,8 @@ public abstract class AbstractRadioMedium implements RadioMedium {
           }
 
           for (var dstRadio : connection.getAllDestinations()) {
-            if (radio instanceof CustomDataRadio && dstRadio instanceof CustomDataRadio &&
-                    ((CustomDataRadio) dstRadio).canReceiveFrom((CustomDataRadio) radio)) {
+            if (radio instanceof CustomDataRadio customDataRadio && dstRadio instanceof CustomDataRadio customDstRadio &&
+                    customDstRadio.canReceiveFrom(customDataRadio)) {
               continue; // Radios instead communicate via custom data objects.
             }
             // Forward radio packet.

--- a/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
+++ b/java/org/contikios/cooja/serialsocket/SerialSocketServer.java
@@ -395,7 +395,7 @@ public class SerialSocketServer implements Plugin, MotePlugin {
           }
           final var out = outStream;
           // FIXME: update code to use data directly.
-          serialPort.getSerialDataTriggers().addTrigger(this, serialDataObserver = (event, data) -> {
+          serialDataObserver = (event, data) -> {
             if (out == null) {
               return;
             }
@@ -407,9 +407,10 @@ public class SerialSocketServer implements Plugin, MotePlugin {
               logger.error("Failed writing:", ex);
               cleanupClient();
             }
-          });
-
-          inBytes = outBytes = 0;
+          };
+          serialPort.getSerialDataTriggers().addTrigger(this, serialDataObserver);
+          outBytes = 0;
+          inBytes = 0;
 
           logger.info("Client connected: " + clientSocket.getInetAddress());
           notifyClientConnected(clientSocket);

--- a/java/org/contikios/mrm/AreaViewer.java
+++ b/java/org/contikios/mrm/AreaViewer.java
@@ -1137,7 +1137,8 @@ public class AreaViewer extends VisPlugin {
 
         tempPanel = new JPanel();
         tempPanel.setLayout(new BoxLayout(tempPanel, BoxLayout.X_AXIS));
-        tempPanel.add(tempLabel = new JLabel("Red"));
+        tempLabel = new JLabel("Red");
+        tempPanel.add(tempLabel);
         tempLabel.setPreferredSize(labelDimension);
         tempLabel.setAlignmentY(Component.BOTTOM_ALIGNMENT);
         var tempSlider = new JSlider(JSlider.HORIZONTAL, 0, 255, 0);
@@ -1150,10 +1151,12 @@ public class AreaViewer extends VisPlugin {
 
         tempPanel = new JPanel();
         tempPanel.setLayout(new BoxLayout(tempPanel, BoxLayout.X_AXIS));
-        tempPanel.add(tempLabel = new JLabel("Green"));
+        tempLabel = new JLabel("Green");
+        tempPanel.add(tempLabel);
         tempLabel.setPreferredSize(labelDimension);
         tempLabel.setAlignmentY(Component.BOTTOM_ALIGNMENT);
-        tempPanel.add(tempSlider = new JSlider(JSlider.HORIZONTAL, 0, 255, 0));
+        tempSlider = new JSlider(JSlider.HORIZONTAL, 0, 255, 0);
+        tempPanel.add(tempSlider);
         tempSlider.setMajorTickSpacing(50);
         tempSlider.setPaintTicks(true);
         tempSlider.setPaintLabels(true);
@@ -1162,10 +1165,12 @@ public class AreaViewer extends VisPlugin {
 
         tempPanel = new JPanel();
         tempPanel.setLayout(new BoxLayout(tempPanel, BoxLayout.X_AXIS));
-        tempPanel.add(tempLabel = new JLabel("Blue"));
+        tempLabel = new JLabel("Blue");
+        tempPanel.add(tempLabel);
         tempLabel.setPreferredSize(labelDimension);
         tempLabel.setAlignmentY(Component.BOTTOM_ALIGNMENT);
-        tempPanel.add(tempSlider = new JSlider(JSlider.HORIZONTAL, 0, 255, 0));
+        tempSlider = new JSlider(JSlider.HORIZONTAL, 0, 255, 0);
+        tempPanel.add(tempSlider);
         tempSlider.setMajorTickSpacing(50);
         tempSlider.setPaintTicks(true);
         tempSlider.setPaintLabels(true);
@@ -1175,10 +1180,12 @@ public class AreaViewer extends VisPlugin {
         // Tolerance
         tempPanel = new JPanel();
         tempPanel.setLayout(new BoxLayout(tempPanel, BoxLayout.X_AXIS));
-        tempPanel.add(tempLabel = new JLabel("Tolerance"));
+        tempLabel = new JLabel("Tolerance");
+        tempPanel.add(tempLabel);
         tempLabel.setPreferredSize(labelDimension);
         tempLabel.setAlignmentY(Component.BOTTOM_ALIGNMENT);
-        tempPanel.add(tempSlider = new JSlider(JSlider.HORIZONTAL, 0, 128, 0));
+        tempSlider = new JSlider(JSlider.HORIZONTAL, 0, 128, 0);
+        tempPanel.add(tempSlider);
         tempSlider.setMajorTickSpacing(25);
         tempSlider.setPaintTicks(true);
         tempSlider.setPaintLabels(true);
@@ -1188,10 +1195,12 @@ public class AreaViewer extends VisPlugin {
         // Obstacle size
         tempPanel = new JPanel();
         tempPanel.setLayout(new BoxLayout(tempPanel, BoxLayout.X_AXIS));
-        tempPanel.add(tempLabel = new JLabel("Obstacle size"));
+        tempLabel = new JLabel("Obstacle size");
+        tempPanel.add(tempLabel);
         tempLabel.setPreferredSize(labelDimension);
         tempLabel.setAlignmentY(Component.BOTTOM_ALIGNMENT);
-        tempPanel.add(tempSlider = new JSlider(JSlider.HORIZONTAL, 1, 40, 40));
+        tempSlider = new JSlider(JSlider.HORIZONTAL, 1, 40, 40);
+        tempPanel.add(tempSlider);
         tempSlider.setInverted(true);
         tempSlider.setMajorTickSpacing(5);
         tempSlider.setPaintTicks(true);
@@ -1214,7 +1223,8 @@ public class AreaViewer extends VisPlugin {
           }
         });
         tempPanel.add(Box.createHorizontalStrut(5));
-        tempPanel.add(tempButton = new JButton("Preview obstacles"));
+        tempButton = new JButton("Preview obstacles");
+        tempPanel.add(tempButton);
         tempButton.addActionListener(e -> {
           obstacleImage = createObstacleImage();
           canvasPanel.repaint();
@@ -1244,10 +1254,12 @@ public class AreaViewer extends VisPlugin {
         tempPanel = new JPanel();
         tempPanel.setLayout(new BoxLayout(tempPanel, BoxLayout.X_AXIS));
         tempPanel.add(Box.createHorizontalGlue());
-        tempPanel.add(tempButton = new JButton("Cancel"));
+        tempButton = new JButton("Cancel");
+        tempPanel.add(tempButton);
         tempButton.addActionListener(e -> dispose());
         tempPanel.add(Box.createHorizontalStrut(5));
-        tempPanel.add(tempButton = new JButton("OK"));
+        tempButton = new JButton("OK");
+        tempPanel.add(tempButton);
         tempButton.addActionListener(e -> {
           obstacleImage = createObstacleImage();
           exitedOK = true;

--- a/java/org/contikios/mrm/FormulaViewer.java
+++ b/java/org/contikios/mrm/FormulaViewer.java
@@ -399,16 +399,15 @@ public class FormulaViewer extends org.contikios.cooja.VisPlugin {
    */
   private JFormattedTextField addDoubleParameter(Parameter id, String description, Container contentPane, double initialValue) {
     JPanel panel = new JPanel();
-    JLabel label;
-    JFormattedTextField textField;
-
     panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
     panel.setAlignmentY(Component.TOP_ALIGNMENT);
     panel.add(Box.createHorizontalStrut(10));
-    panel.add(label = new JLabel(description));
+    JLabel label = new JLabel(description);
     label.setPreferredSize(labelDimension);
+    panel.add(label);
     panel.add(Box.createHorizontalGlue());
-    panel.add(textField = new JFormattedTextField(doubleFormat));
+    JFormattedTextField textField = new JFormattedTextField(doubleFormat);
+    panel.add(textField);
     textField.setValue(initialValue);
     textField.setColumns(4);
     textField.putClientProperty("id", id);
@@ -458,10 +457,12 @@ public class FormulaViewer extends org.contikios.cooja.VisPlugin {
     panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
     panel.setAlignmentY(Component.TOP_ALIGNMENT);
     panel.add(Box.createHorizontalStrut(10));
-    panel.add(label = new JLabel(description));
+    label = new JLabel(description);
+    panel.add(label);
     label.setPreferredSize(labelDimension);
     panel.add(Box.createHorizontalGlue());
-    panel.add(textField = new JFormattedTextField(integerFormat));
+    textField = new JFormattedTextField(integerFormat);
+    panel.add(textField);
     textField.setValue((double) initialValue);
     textField.setColumns(4);
     textField.putClientProperty("id", id);
@@ -505,16 +506,15 @@ public class FormulaViewer extends org.contikios.cooja.VisPlugin {
    */
   private JCheckBox addBooleanParameter(Parameter id, String description, Container contentPane, boolean initialValue) {
     JPanel panel = new JPanel();
-    JLabel label;
-    JCheckBox checkBox;
-
     panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
     panel.setAlignmentY(Component.TOP_ALIGNMENT);
     panel.add(Box.createHorizontalStrut(10));
-    panel.add(label = new JLabel(description));
+    JLabel label = new JLabel(description);
+    panel.add(label);
     label.setPreferredSize(labelDimension);
     panel.add(Box.createHorizontalGlue());
-    panel.add(checkBox = new JCheckBox());
+    JCheckBox checkBox = new JCheckBox();
+    panel.add(checkBox);
     checkBox.setSelected(initialValue);
     checkBox.putClientProperty("id", id);
     checkBox.addActionListener(e -> {

--- a/java/se/sics/json/JSONArray.java
+++ b/java/se/sics/json/JSONArray.java
@@ -133,59 +133,31 @@ public class JSONArray extends ArrayList<Object> implements Jsonable {
     }
 
     public int getAsInt(int index, int defaultValue) {
-        Object v = get(index);
-        if (v instanceof Number) {
-            return ((Number)v).intValue();
-        }
-        return defaultValue;
+      return get(index) instanceof Number number ? number.intValue() : defaultValue;
     }
 
     public long getAsLong(int index, long defaultValue) {
-        Object v = get(index);
-        if (v instanceof Number) {
-            return ((Number)v).longValue();
-        }
-        return defaultValue;
+      return get(index) instanceof Number number ? number.longValue() : defaultValue;
     }
 
     public float getAsFloat(int index, float defaultValue) {
-        Object v = get(index);
-        if (v instanceof Number) {
-            return ((Number)v).floatValue();
-        }
-        return defaultValue;
+      return get(index) instanceof Number number ? number.floatValue() : defaultValue;
     }
 
     public double getAsDouble(int index, double defaultValue) {
-        Object v = get(index);
-        if (v instanceof Number) {
-            return ((Number)v).doubleValue();
-        }
-        return defaultValue;
+      return get(index) instanceof Number number ? number.doubleValue() : defaultValue;
     }
 
     public boolean getAsBoolean(int index, boolean defaultValue) {
-        Object v = get(index);
-        if (v instanceof Boolean) {
-            return (Boolean) v;
-        }
-        return defaultValue;
+      return get(index) instanceof Boolean b ? b : defaultValue;
     }
 
     public JSONObject getJSONObject(int index) {
-        Object v = get(index);
-        if (v instanceof JSONObject) {
-            return (JSONObject)v;
-        }
-        return null;
+      return get(index) instanceof JSONObject jsonObject ? jsonObject : null;
     }
 
     public JSONArray getJSONArray(int index) {
-        Object v = get(index);
-        if (v instanceof JSONArray) {
-            return (JSONArray)v;
-        }
-        return null;
+      return get(index) instanceof JSONArray objects ? objects : null;
     }
 
     public void update(JSONArray v) {
@@ -196,13 +168,13 @@ public class JSONArray extends ArrayList<Object> implements Jsonable {
         for(int i = 0; i < count; i++) {
             Object target = get(i);
             Object source = v.get(i);
-            if (source instanceof JSONObject) {
-                if (target instanceof JSONObject) {
-                    ((JSONObject) target).update((JSONObject) source);
+            if (source instanceof JSONObject sourceObject) {
+                if (target instanceof JSONObject jsonObject) {
+                    jsonObject.update(sourceObject);
                 }
-            } else if (source instanceof JSONArray) {
-                if (target instanceof JSONArray) {
-                    ((JSONArray) target).update((JSONArray) source);
+            } else if (source instanceof JSONArray sourceArray) {
+                if (target instanceof JSONArray objects) {
+                    objects.update(sourceArray);
                 }
             } else if (target instanceof JSONObject || target instanceof JSONArray) {
                 // Compound values can not be replaced by primitive values
@@ -220,13 +192,13 @@ public class JSONArray extends ArrayList<Object> implements Jsonable {
         for(int i = 0; i < count; i++) {
             Object target = get(i);
             Object source = v.get(i);
-            if (source instanceof JSONObject) {
-                if (target instanceof JSONObject) {
-                    ((JSONObject) target).merge((JSONObject) source);
+            if (source instanceof JSONObject sourceObject) {
+                if (target instanceof JSONObject jsonObject) {
+                    jsonObject.merge(sourceObject);
                 }
-            } else if (source instanceof JSONArray) {
-                if (target instanceof JSONArray) {
-                    ((JSONArray) target).merge((JSONArray) source);
+            } else if (source instanceof JSONArray sourceArray) {
+                if (target instanceof JSONArray objects) {
+                    objects.merge(sourceArray);
                 }
             } else if (target instanceof JSONObject || target instanceof JSONArray) {
                 // Compound values can not be replaced by primitive values
@@ -237,10 +209,10 @@ public class JSONArray extends ArrayList<Object> implements Jsonable {
         if (v.size() > size()) {
             for(int i = size(), n = v.size(); i < n; i++) {
                 Object source = v.get(i);
-                if (source instanceof JSONObject) {
-                    add(((JSONObject) source).clone());
-                } else if (source instanceof JSONArray) {
-                    add(((JSONArray) source).clone());
+                if (source instanceof JSONObject jsonObject) {
+                    add(jsonObject.clone());
+                } else if (source instanceof JSONArray objects) {
+                    add(objects.clone());
                 } else {
                     add(source);
                 }
@@ -254,10 +226,10 @@ public class JSONArray extends ArrayList<Object> implements Jsonable {
         // Create deep copy
         for(int i = 0, n = clone.size(); i < n; i++) {
             Object value = clone.get(i);
-            if (value instanceof JSONObject) {
-                clone.set(i, ((JSONObject)value).clone());
-            } else if (value instanceof JSONArray) {
-                clone.set(i, ((JSONArray)value).clone());
+            if (value instanceof JSONObject jsonObject) {
+                clone.set(i, jsonObject.clone());
+            } else if (value instanceof JSONArray objects) {
+                clone.set(i, objects.clone());
             }
         }
         return clone;

--- a/java/se/sics/json/JSONObject.java
+++ b/java/se/sics/json/JSONObject.java
@@ -115,59 +115,31 @@ public class JSONObject extends HashMap<String,Object> implements Jsonable {
     }
 
     public int getAsInt(String key, int defaultValue) {
-        Object v = get(key);
-        if (v instanceof Number) {
-            return ((Number) v).intValue();
-        }
-        return defaultValue;
+        return get(key) instanceof Number number ? number.intValue() : defaultValue;
     }
 
     public long getAsLong(String key, long defaultValue) {
-        Object v = get(key);
-        if (v instanceof Number) {
-            return ((Number) v).longValue();
-        }
-        return defaultValue;
+        return get(key) instanceof Number number ? number.longValue() : defaultValue;
     }
 
     public float getAsFloat(String key, float defaultValue) {
-        Object v = get(key);
-        if (v instanceof Number) {
-            return ((Number) v).floatValue();
-        }
-        return defaultValue;
+        return get(key) instanceof Number number ? number.floatValue() : defaultValue;
     }
 
     public double getAsDouble(String key, double defaultValue) {
-        Object v = get(key);
-        if (v instanceof Number) {
-            return ((Number) v).doubleValue();
-        }
-        return defaultValue;
+        return get(key) instanceof Number number ? number.doubleValue() : defaultValue;
     }
 
     public boolean getAsBoolean(String key, boolean defaultValue) {
-        Object v = get(key);
-        if (v instanceof Boolean) {
-            return (Boolean) v;
-        }
-        return defaultValue;
+        return get(key) instanceof Boolean b ? b : defaultValue;
     }
 
     public JSONObject getJSONObject(String key) {
-        Object v = get(key);
-        if (v instanceof JSONObject) {
-            return (JSONObject) v;
-        }
-        return null;
+        return get(key) instanceof JSONObject jsonObject ? jsonObject : null;
     }
 
     public JSONArray getJSONArray(String key) {
-        Object v = get(key);
-        if (v instanceof JSONArray) {
-            return (JSONArray) v;
-        }
-        return null;
+        return get(key) instanceof JSONArray objects ? objects : null;
     }
 
     public void update(JSONObject source) {
@@ -175,13 +147,13 @@ public class JSONObject extends HashMap<String,Object> implements Jsonable {
             if (containsKey(entry.getKey())) {
                 Object target = get(entry.getKey());
                 Object v = entry.getValue();
-                if (v instanceof JSONObject) {
-                    if (target instanceof JSONObject) {
-                        ((JSONObject) target).update((JSONObject) v);
+                if (v instanceof JSONObject valueObject) {
+                    if (target instanceof JSONObject jsonObject) {
+                        jsonObject.update(valueObject);
                     }
-                } else if (v instanceof JSONArray) {
-                    if (target instanceof JSONArray) {
-                        ((JSONArray) target).update((JSONArray) v);
+                } else if (v instanceof JSONArray jsonArray) {
+                    if (target instanceof JSONArray objects) {
+                        objects.update(jsonArray);
                     }
                 } else if (target instanceof JSONObject || target instanceof JSONArray) {
                     // Compound values can not be replaced by primitive values
@@ -197,13 +169,13 @@ public class JSONObject extends HashMap<String,Object> implements Jsonable {
             Object target = get(entry.getKey());
             Object v = entry.getValue();
             if (target != null) {
-                if (v instanceof JSONObject) {
-                    if (target instanceof JSONObject) {
-                        ((JSONObject) target).merge((JSONObject) v);
+                if (v instanceof JSONObject valueObject) {
+                    if (target instanceof JSONObject jsonObject) {
+                        jsonObject.merge(valueObject);
                     }
-                } else if (v instanceof JSONArray) {
-                    if (target instanceof JSONArray) {
-                        ((JSONArray) target).merge((JSONArray) v);
+                } else if (v instanceof JSONArray valueArray) {
+                    if (target instanceof JSONArray objects) {
+                        objects.merge(valueArray);
                     }
                 } else if (target instanceof JSONObject || target instanceof JSONArray) {
                     // Compound values can not be replaced by primitive values
@@ -212,10 +184,10 @@ public class JSONObject extends HashMap<String,Object> implements Jsonable {
                 }
             } else {
                 /* New value */
-                if (v instanceof JSONObject) {
-                    v = ((JSONObject) v).clone();
-                } else if (v instanceof JSONArray) {
-                    v = ((JSONArray) v).clone();
+                if (v instanceof JSONObject jsonObject) {
+                    v = jsonObject.clone();
+                } else if (v instanceof JSONArray objects) {
+                    v = objects.clone();
                 }
                 put(entry.getKey(), v);
             }
@@ -228,10 +200,10 @@ public class JSONObject extends HashMap<String,Object> implements Jsonable {
         // Create deep copy
         for (String key : clone.getKeys()) {
             Object value = clone.get(key);
-            if (value instanceof JSONObject) {
-                clone.put(key, ((JSONObject) value).clone());
-            } else if (value instanceof JSONArray) {
-                clone.put(key, ((JSONArray) value).clone());
+            if (value instanceof JSONObject jsonObject) {
+                clone.put(key, jsonObject.clone());
+            } else if (value instanceof JSONArray objects) {
+                clone.put(key, objects.clone());
             }
         }
         return clone;
@@ -269,17 +241,15 @@ public class JSONObject extends HashMap<String,Object> implements Jsonable {
     }
 
     public static JSONObject parseJSONObject(String input) throws ParseException {
-        Object value = parseJSON(input);
-        if (value instanceof JSONObject) {
-            return (JSONObject) value;
+        if (parseJSON(input) instanceof JSONObject jsonObject) {
+            return jsonObject;
         }
         throw new ParseException("not a JSON object: " + input);
     }
 
     public static JSONObject parseJSONObject(Reader input) throws ParseException {
-        Object value = parseJSON(input);
-        if (value instanceof JSONObject) {
-            return (JSONObject) value;
+        if (parseJSON(input) instanceof JSONObject jsonObject) {
+            return jsonObject;
         }
         throw new ParseException("not a JSON object: " + input);
     }

--- a/java/se/sics/json/ParseException.java
+++ b/java/se/sics/json/ParseException.java
@@ -43,7 +43,7 @@ package se.sics.json;
 /**
  *
  */
-class ParseException extends Exception {
+public class ParseException extends Exception {
     public ParseException(String message) {
         super(message);
     }

--- a/java/se/sics/mspsim/cli/CommandHandler.java
+++ b/java/se/sics/mspsim/cli/CommandHandler.java
@@ -96,8 +96,8 @@ public class CommandHandler implements ActiveComponent, LineListener {
         cErr.println("Error: Command failed: " + e.getMessage());
         e.printStackTrace(cErr);
         error = true;
-        if (e instanceof EmulationException) {
-            throw (EmulationException) e;
+        if (e instanceof EmulationException emulationException) {
+            throw emulationException;
         }
       }
       if (error) {

--- a/java/se/sics/mspsim/cli/MiscCommands.java
+++ b/java/se/sics/mspsim/cli/MiscCommands.java
@@ -394,8 +394,8 @@ public class MiscCommands implements CommandBundle {
           return 1;
         }
         if ("output".equals(inout)) {
-          if (chip instanceof RFSource) {
-            source = (RFSource) chip;
+          if (chip instanceof RFSource rfSource) {
+            source = rfSource;
             listener = data -> context.out.println(Utils.hex8(data));
             source.addRFListener(listener);
           } else {
@@ -490,10 +490,6 @@ public class MiscCommands implements CommandBundle {
   }
 
   private static ServiceComponent getServiceForName(ComponentRegistry registry, String name) {
-    Object o = registry.getComponent(name);
-    if (o instanceof ServiceComponent) {
-      return (ServiceComponent) o;
-    }
-    return null;
+    return registry.getComponent(name) instanceof ServiceComponent serviceComponent ? serviceComponent : null;
   }
 }

--- a/java/se/sics/mspsim/config/CC430f5137Config.java
+++ b/java/se/sics/mspsim/config/CC430f5137Config.java
@@ -126,12 +126,14 @@ public class CC430f5137Config extends MSP430Config {
 //            System.out.println("Adding IOUnit USCI: " + usci.getName());
             ioUnits.add(usci);
         }
-        IOPort last;
-        ioUnits.add(last = IOPort.parseIOPort(cpu, 47, portConfig[0], null));
-        ioUnits.add(last = IOPort.parseIOPort(cpu, 42, portConfig[1], last));
+        IOPort last = IOPort.parseIOPort(cpu, 47, portConfig[0], null);
+        ioUnits.add(last);
+        last = IOPort.parseIOPort(cpu, 42, portConfig[1], last);
+        ioUnits.add(last);
 
         for (int i = 2; i < portConfig.length; i++) {
-            ioUnits.add(last = IOPort.parseIOPort(cpu, 0, portConfig[i], last));
+          last = IOPort.parseIOPort(cpu, 0, portConfig[i], last);
+          ioUnits.add(last);
         }
 
                 /* XXX: Stub IO units: Sysreg and PMM */

--- a/java/se/sics/mspsim/config/MSP430f2617Config.java
+++ b/java/se/sics/mspsim/config/MSP430f2617Config.java
@@ -114,12 +114,14 @@ public class MSP430f2617Config extends MSP430Config {
 
         // Add port 1,2 with interrupt capability!
         // IOPorts will add themselves to the CPU
-        IOPort last = null;
-        ioUnits.add(last = IOPort.parseIOPort(cpu, 18, portConfig[0], last));
-        ioUnits.add(last = IOPort.parseIOPort(cpu, 19, portConfig[1], last));
+        IOPort last = IOPort.parseIOPort(cpu, 18, portConfig[0], null);
+        ioUnits.add(last);
+        last = IOPort.parseIOPort(cpu, 19, portConfig[1], last);
+        ioUnits.add(last);
 
         for (int i = 2; i < portConfig.length; i++) {
-            ioUnits.add(last = IOPort.parseIOPort(cpu, 0, portConfig[i], last));
+          last = IOPort.parseIOPort(cpu, 0, portConfig[i], last);
+          ioUnits.add(last);
         }
 
         ADC12 adc12 = new ADC12(cpu);

--- a/java/se/sics/mspsim/config/MSP430f5437Config.java
+++ b/java/se/sics/mspsim/config/MSP430f5437Config.java
@@ -118,12 +118,14 @@ public class MSP430f5437Config extends MSP430Config {
 //            System.out.println("Adding IOUnit USCI: " + usci.getName());
             ioUnits.add(usci);
         }
-        IOPort last = null;
-        ioUnits.add(last = IOPort.parseIOPort(cpu, 47, portConfig[0], last));
-        ioUnits.add(last = IOPort.parseIOPort(cpu, 42, portConfig[1], last));
+        IOPort last = IOPort.parseIOPort(cpu, 47, portConfig[0], null);
+        ioUnits.add(last);
+        last = IOPort.parseIOPort(cpu, 42, portConfig[1], last);
+        ioUnits.add(last);
 
         for (int i = 2; i < portConfig.length; i++) {
-            ioUnits.add(last = IOPort.parseIOPort(cpu, 0, portConfig[i], last));
+          last = IOPort.parseIOPort(cpu, 0, portConfig[i], last);
+          ioUnits.add(last);
         }
 
                 /* XXX: Stub IO units: Sysreg and PMM */

--- a/java/se/sics/mspsim/core/MSP430Core.java
+++ b/java/se/sics/mspsim/core/MSP430Core.java
@@ -814,30 +814,19 @@ public class MSP430Core extends Chip implements MSP430Constants {
   }
 
   void printWarning(EmulationLogger.WarningType type, int address) throws EmulationException {
-      String message;
-      switch(type) {
-      case MISALIGNED_READ:
-          message = "**** Illegal read - misaligned word from $" +
-                  getAddressAsString(address) + " at $" + getAddressAsString(reg[PC]);
-          break;
-      case MISALIGNED_WRITE:
-          message = "**** Illegal write - misaligned word to $" +
-                  getAddressAsString(address) + " at $" + getAddressAsString(reg[PC]);
-          break;
-      case ADDRESS_OUT_OF_BOUNDS_READ:
-          message = "**** Illegal read - out of bounds from $" +
-                  getAddressAsString(address) + " at $" + getAddressAsString(reg[PC]);
-          break;
-      case ADDRESS_OUT_OF_BOUNDS_WRITE:
-          message = "**** Illegal write -  out of bounds from $" +
-                  getAddressAsString(address) + " at $" + getAddressAsString(reg[PC]);
-          break;
-      default:
-          message = "**** " + type + " address $" + getAddressAsString(address) +
-          " at $" + getAddressAsString(reg[PC]);
-          break;
-      }
-      logger.logw(this, type, message);
+    String message = switch (type) {
+      case MISALIGNED_READ -> "**** Illegal read - misaligned word from $" +
+              getAddressAsString(address) + " at $" + getAddressAsString(reg[PC]);
+      case MISALIGNED_WRITE -> "**** Illegal write - misaligned word to $" +
+              getAddressAsString(address) + " at $" + getAddressAsString(reg[PC]);
+      case ADDRESS_OUT_OF_BOUNDS_READ -> "**** Illegal read - out of bounds from $" +
+              getAddressAsString(address) + " at $" + getAddressAsString(reg[PC]);
+      case ADDRESS_OUT_OF_BOUNDS_WRITE -> "**** Illegal write -  out of bounds from $" +
+              getAddressAsString(address) + " at $" + getAddressAsString(reg[PC]);
+      default -> "**** " + type + " address $" + getAddressAsString(address) +
+              " at $" + getAddressAsString(reg[PC]);
+    };
+    logger.logw(this, type, message);
   }
 
   public void generateTrace(PrintStream out) {

--- a/java/se/sics/mspsim/core/MSP430Core.java
+++ b/java/se/sics/mspsim/core/MSP430Core.java
@@ -367,8 +367,8 @@ public class MSP430Core extends Chip implements MSP430Constants {
 
   public boolean hasWatchPoint(int address) {
       Memory mem = memorySegments[address >> 8];
-      if (mem instanceof WatchedMemory) {
-          return ((WatchedMemory)mem).hasWatchPoint(address);
+      if (mem instanceof WatchedMemory watchedMemory) {
+          return watchedMemory.hasWatchPoint(address);
       }
       return false;
   }
@@ -376,8 +376,8 @@ public class MSP430Core extends Chip implements MSP430Constants {
   public synchronized void addWatchPoint(int address, MemoryMonitor mon) {
       int seg = address >> 8;
       WatchedMemory wm;
-      if (memorySegments[seg] instanceof WatchedMemory) {
-          wm = (WatchedMemory) memorySegments[seg];
+      if (memorySegments[seg] instanceof WatchedMemory watchedMemory) {
+          wm = watchedMemory;
       } else {
           wm = new WatchedMemory(address & 0xfff00, memorySegments[seg]);
           memorySegments[seg] = wm;

--- a/java/se/sics/mspsim/core/MSP430Core.java
+++ b/java/se/sics/mspsim/core/MSP430Core.java
@@ -855,10 +855,12 @@ public class MSP430Core extends Chip implements MSP430Constants {
     if (interruptMax < MAX_INTERRUPT) {
       // Push PC and SR to stack
       // store on stack - always move 2 steps (W) even if B.
-      writeRegister(SP, sp = spBefore - 2);
+      sp = spBefore - 2;
+      writeRegister(SP, sp);
       currentSegment.write(sp, pc, AccessMode.WORD);
 
-      writeRegister(SP, sp = sp - 2);
+      sp -= 2;
+      writeRegister(SP, sp);
       currentSegment.write(sp, (sr & 0x0fff) | ((pc & 0xf0000) >> 4), AccessMode.WORD);
     }
     // Clear SR

--- a/java/se/sics/mspsim/core/PortListenerProxy.java
+++ b/java/se/sics/mspsim/core/PortListenerProxy.java
@@ -51,8 +51,8 @@ public class PortListenerProxy implements PortListener {
         if (portListener == null) {
             return listener;
         }
-        if (portListener instanceof PortListenerProxy) {
-            return ((PortListenerProxy)portListener).add(listener);
+        if (portListener instanceof PortListenerProxy portListenerProxy) {
+            return portListenerProxy.add(listener);
         }
         return new PortListenerProxy(portListener, listener);
     }
@@ -61,8 +61,8 @@ public class PortListenerProxy implements PortListener {
         if (portListener == listener) {
             return null;
         }
-        if (portListener instanceof PortListenerProxy) {
-            return ((PortListenerProxy)portListener).remove(listener);
+        if (portListener instanceof PortListenerProxy portListenerProxy) {
+            return portListenerProxy.remove(listener);
         }
         return portListener;
     }

--- a/java/se/sics/mspsim/core/PortListenerProxy.java
+++ b/java/se/sics/mspsim/core/PortListenerProxy.java
@@ -87,7 +87,7 @@ public class PortListenerProxy implements PortListener {
     @Override
     public void portWrite(IOPort source, int data) {
         PortListener[] listeners = this.portListeners;
-        for(PortListener l : listeners) {
+        for (PortListener l : listeners) {
             l.portWrite(source, data);
         }
     }

--- a/java/se/sics/mspsim/core/Timer.java
+++ b/java/se/sics/mspsim/core/Timer.java
@@ -709,7 +709,8 @@ public class Timer extends IOUnit {
       reg.captureOn = (data & 0x100) > 0;
       reg.sync = (data & 0x800) > 0;
       reg.inputSel = (data >> 12) & 3;
-      int src = reg.inputSrc = srcMap[4 + index * 4 + reg.inputSel];
+      int src = srcMap[4 + index * 4 + reg.inputSel];
+      reg.inputSrc = src;
       reg.capMode = (data >> 14) & 3;
 
       /* capture a port state? */

--- a/java/se/sics/mspsim/core/Watchdog.java
+++ b/java/se/sics/mspsim/core/Watchdog.java
@@ -159,7 +159,8 @@ public class Watchdog extends IOUnit implements SFRModule {
           targetTime = cpu.scheduleTimeEventMillis(wdtTrigger, 1000.0 * delay / cpu.aclkFrq);
       } else {
           if (DEBUG) log("setting delay in cycles");
-          cpu.scheduleCycleEvent(wdtTrigger, targetTime = cpu.cycles + delay);
+          targetTime = cpu.cycles + delay;
+          cpu.scheduleCycleEvent(wdtTrigger, targetTime);
       }
   }
 

--- a/java/se/sics/mspsim/extutil/highlight/CScanner.java
+++ b/java/se/sics/mspsim/extutil/highlight/CScanner.java
@@ -519,31 +519,16 @@ public class CScanner extends Scanner {
     if (c2 == '\\')
       c2 = next();
 
-    switch (c2) {
-    case 'b':
-    case 't':
-    case 'n':
-    case 'f':
-    case 'r':
-    case '\"':
-    case '\'':
-    case '\\':
-      start = start + charlength;
-      charlength = 1;
-      return true;
-    case '0':
-    case '1':
-    case '2':
-    case '3':
-      return readOctal(3);
-    case '4':
-    case '5':
-    case '6':
-    case '7':
-      return readOctal(2);
-    default:
-      return false;
-    }
+    return switch (c2) {
+      case 'b', 't', 'n', 'f', 'r', '\"', '\'', '\\' -> {
+        start = start + charlength;
+        charlength = 1;
+        yield true;
+      }
+      case '0', '1', '2', '3' -> readOctal(3);
+      case '4', '5', '6', '7' -> readOctal(2);
+      default -> false;
+    };
   }
 
   private boolean readOctal(int maxlength) {

--- a/java/se/sics/mspsim/extutil/highlight/JavaScanner.java
+++ b/java/se/sics/mspsim/extutil/highlight/JavaScanner.java
@@ -537,31 +537,16 @@ public class JavaScanner extends Scanner {
     if (c2 == '\\')
       c2 = next();
 
-    switch (c2) {
-    case 'b':
-    case 't':
-    case 'n':
-    case 'f':
-    case 'r':
-    case '\"':
-    case '\'':
-    case '\\':
-      start = start + charlength;
-      charlength = 1;
-      return true;
-    case '0':
-    case '1':
-    case '2':
-    case '3':
-      return readOctal(3);
-    case '4':
-    case '5':
-    case '6':
-    case '7':
-      return readOctal(2);
-    default:
-      return false;
-    }
+    return switch (c2) {
+      case 'b', 't', 'n', 'f', 'r', '\"', '\'', '\\' -> {
+        start = start + charlength;
+        charlength = 1;
+        yield true;
+      }
+      case '0', '1', '2', '3' -> readOctal(3);
+      case '4', '5', '6', '7' -> readOctal(2);
+      default -> false;
+    };
   }
 
   private boolean readOctal(int maxlength) {

--- a/java/se/sics/mspsim/extutil/highlight/LineNumberedBorder.java
+++ b/java/se/sics/mspsim/extutil/highlight/LineNumberedBorder.java
@@ -70,8 +70,8 @@ public class LineNumberedBorder extends AbstractBorder {
   @Override
   public Insets getBorderInsets(Component c, Insets insets) {
     // if c is not a SyntaxHighlighter...nothing is done...
-    if (c instanceof SyntaxHighlighter) {
-      int width = lineNumberWidth((SyntaxHighlighter) c);
+    if (c instanceof SyntaxHighlighter syntaxHighlighter) {
+      int width = lineNumberWidth(syntaxHighlighter);
       if (location == LEFT_SIDE) {
         insets.left = width;
       } else {

--- a/java/se/sics/mspsim/extutil/jfreechart/DataChart.java
+++ b/java/se/sics/mspsim/extutil/jfreechart/DataChart.java
@@ -38,7 +38,8 @@ public class DataChart extends JPanel implements ServiceComponent {
     xyplot.setDomainAxis(domain);
     xyplot.setRangeAxis(range);
  // xyplot.setBackgroundPaint(Color.black);
-    xyplot.setDataset(dataset = new TimeSeriesCollection());
+    dataset = new TimeSeriesCollection();
+    xyplot.setDataset(dataset);
 
     DefaultXYItemRenderer renderer = new DefaultXYItemRenderer();
     renderer.setSeriesPaint(0, Color.red);

--- a/java/se/sics/mspsim/extutil/jfreechart/LineChart.java
+++ b/java/se/sics/mspsim/extutil/jfreechart/LineChart.java
@@ -71,7 +71,8 @@ public class LineChart extends JFreeWindowDataHandler {
     XYPlot xyplot = new XYPlot();
     xyplot.setDomainAxis(domain);
     xyplot.setRangeAxis(range);
-    xyplot.setDataset(dataset = new XYSeriesCollection());
+    dataset = new XYSeriesCollection();
+    xyplot.setDataset(dataset);
     xyplot.setRenderer(renderer);
 
     domain.setAutoRange(true);

--- a/java/se/sics/mspsim/profiler/SimpleProfiler.java
+++ b/java/se/sics/mspsim/profiler/SimpleProfiler.java
@@ -176,8 +176,9 @@ public class SimpleProfiler implements Profiler, EventListener {
     if (cspEntry.calls >= 0) {
       CallEntry ce = profileData.get(fkn);
       if (ce == null) {
-        profileData.put(fkn, ce = new CallEntry());
+        ce = new CallEntry();
         ce.function = fkn;
+        profileData.put(fkn, ce);
       }
       ce.cycles += elapsed;
       ce.exclusiveCycles += exElapsed;

--- a/java/se/sics/mspsim/ui/ControlUI.java
+++ b/java/se/sics/mspsim/ui/ControlUI.java
@@ -100,7 +100,8 @@ public class ControlUI extends JPanel implements ActionListener, SimEventListene
     jp.setLayout(new BorderLayout());
 
     jp.add(this, BorderLayout.WEST);
-    jp.add(dui = new DebugUI(cpu), BorderLayout.CENTER);
+    dui = new DebugUI(cpu);
+    jp.add(dui, BorderLayout.CENTER);
     window.add(jp);
 
     createButton("Debug On");

--- a/java/se/sics/mspsim/ui/DebugUI.java
+++ b/java/se/sics/mspsim/ui/DebugUI.java
@@ -81,7 +81,8 @@ public class DebugUI extends JPanel {
       JPanel regs = new JPanel(new GridLayout(2,8,4,0));
       regsLabel = new JLabel[16];
       for (int i = 0, n = 16; i < n; i++) {
-        regs.add(regsLabel[i] = new JLabel("$0000"));
+        regsLabel[i] = new JLabel("$0000");
+        regs.add(regsLabel[i]);
       }
       add(regs, BorderLayout.SOUTH);
       updateRegs();

--- a/java/se/sics/mspsim/ui/SerialMon.java
+++ b/java/se/sics/mspsim/ui/SerialMon.java
@@ -100,7 +100,8 @@ public class SerialMon implements USARTListener, StateChangeListener, ServiceCom
   private void initGUI() {
     window = new JFrame(title);
 //     window.setBounds(100, 100, 400,340);
-    window.add(new JScrollPane(textArea = new JTextArea(20, 40),
+    textArea = new JTextArea(20, 40);
+    window.add(new JScrollPane(textArea,
                                JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
                                JScrollPane.HORIZONTAL_SCROLLBAR_NEVER),
                BorderLayout.CENTER);

--- a/java/se/sics/mspsim/util/Test.java
+++ b/java/se/sics/mspsim/util/Test.java
@@ -59,9 +59,9 @@ public class Test implements USARTListener {
 
   private Test(MSP430 cpu) {
     this.cpu = cpu;
-    IOUnit usart = cpu.getIOUnit("USART 1");
-    if (usart instanceof USART) {
-      ((USART) usart).addUSARTListener(this);
+    IOUnit ioUnit = cpu.getIOUnit("USART 1");
+    if (ioUnit instanceof USART usart) {
+      usart.addUSARTListener(this);
     }
   }
 


### PR DESCRIPTION
Code cleanup to avoid warnings with Error Prone 2.37:
- use pattern-matching instanceof
- use switch expressions
- avoid assignment expressions
