### PR TITLE
Separate initialization of simMoteId and simRandomSeed

### DIFF
--- a/java/org/contikios/cooja/contikimote/ContikiMote.java
+++ b/java/org/contikios/cooja/contikimote/ContikiMote.java
@@ -38,6 +38,7 @@ import org.contikios.cooja.interfaces.PolledAfterAllTicks;
 import org.contikios.cooja.interfaces.PolledBeforeActiveTicks;
 import org.contikios.cooja.interfaces.PolledBeforeAllTicks;
 import org.contikios.cooja.mote.memory.SectionMoteMemory;
+import org.contikios.cooja.mote.memory.VarMemory;
 import org.contikios.cooja.motes.AbstractWakeupMote;
 
 /**
@@ -87,6 +88,14 @@ public class ContikiMote extends AbstractWakeupMote<ContikiMoteType, SectionMote
       }
     }
     requestImmediateWakeup();
+  }
+
+  @Override
+  public void added() {
+    super.added();
+    VarMemory moteMem = new VarMemory(getMemory());
+    int simRandomSeed = getSimulation().getRandomGenerator().nextInt();
+    moteMem.setIntValueOf("simRandomSeed", simRandomSeed);
   }
 
   /**

--- a/java/org/contikios/cooja/contikimote/interfaces/ContikiMoteID.java
+++ b/java/org/contikios/cooja/contikimote/interfaces/ContikiMoteID.java
@@ -41,10 +41,7 @@ import org.contikios.cooja.mote.memory.VarMemory;
  * Contiki variables:
  * <ul>
  * <li>int simMoteID
- * <li>char simMoteIDChanged
  * </ul>
- *
- * This interface also seeds the Contiki random generator: 'random_init()'.
  * <p>
  *
  * This observable notifies observers when the mote ID is set or altered.
@@ -71,7 +68,5 @@ public class ContikiMoteID extends MoteID<ContikiMote> {
   public void setMoteID(int newID) {
     super.setMoteID(newID);
     moteMem.setIntValueOf("simMoteID", newID);
-    moteMem.setByteValueOf("simMoteIDChanged", (byte) 1);
-    moteMem.setIntValueOf("simRandomSeed", (int) (mote.getSimulation().getRandomSeed() + newID));
   }
 }


### PR DESCRIPTION
This PR separates the initialization of `simMoteId` and `simRandomSeed` since they are unrelated.