### PR TITLE
mspsim: fix new ErrorProne 2.49.0 warnings

### DIFF
--- a/java/se/sics/mspsim/core/RTC.java
+++ b/java/se/sics/mspsim/core/RTC.java
@@ -259,7 +259,7 @@ public class RTC extends IOUnit {
                         }
                 }
 
-                /**
+                /*
                  * Re-Schedule the timer event
                  */
                 private void reSchedule() {
@@ -267,7 +267,7 @@ public class RTC extends IOUnit {
                         rtcInit();
                 }
 
-                /**
+                /*
                  * Update the counters or the calendar, depending on the mode
                  */
                 private void updateCounters() {
@@ -313,7 +313,7 @@ public class RTC extends IOUnit {
                         }
                 }
 
-                /**
+                /*
                  * Trigger a microprocessor interrupt
                  */
                 private void generateInterrupt() {

--- a/java/se/sics/mspsim/extutil/highlight/JavaScanner.java
+++ b/java/se/sics/mspsim/extutil/highlight/JavaScanner.java
@@ -25,14 +25,14 @@ public class JavaScanner extends Scanner {
     super();
     initKind();
     initUniKind();
-    switch (version) {
-      case "1.1" -> this.version = 11;
-      case "1.2" -> this.version = 12;
-      case "1.3" -> this.version = 13;
-      case "1.4" -> this.version = 14;
-      case "1.5" -> this.version = 15;
+    this.version = switch (version) {
+      case "1.1" -> 11;
+      case "1.2" -> 12;
+      case "1.3" -> 13;
+      case "1.4" -> 14;
+      case "1.5" -> 15;
       default -> throw new Error("Unknown version of Java: " + version);
-    }
+    };
   }
 
   /** Override the read method from the Scanner class. */


### PR DESCRIPTION
Address `NotJavadoc` warnings on three private methods inside an anonymous TimeEvent in RTC.java by switching their Javadoc comments to plain block comments, and refactor the version switch in JavaScanner to a switch expression to satisfy RefactorSwitch.