### PR TITLE
Fix warnings found by ErrorProne 2.50.0

### DIFF
--- a/java/org/contikios/cooja/Cooja.java
+++ b/java/org/contikios/cooja/Cooja.java
@@ -271,7 +271,7 @@ public class Cooja {
     return gui.myDesktopPane;
   }
 
-  //// PROJECT CONFIG AND EXTENDABLE PARTS METHODS ////
+  // // PROJECT CONFIG AND EXTENDABLE PARTS METHODS ////
 
   /**
    * Register new mote type class.

--- a/java/org/contikios/cooja/SimEventCentral.java
+++ b/java/org/contikios/cooja/SimEventCentral.java
@@ -90,7 +90,7 @@ public class SimEventCentral {
   }
 
   /* GENERIC */
-  private static class MoteEvent {
+  static class MoteEvent {
     static int _ID_COUNTER; /* Debugging */
     final int ID; /* Debugging */
 

--- a/java/se/sics/mspsim/extutil/jfreechart/DataSourceSampler.java
+++ b/java/se/sics/mspsim/extutil/jfreechart/DataSourceSampler.java
@@ -62,7 +62,7 @@ public class DataSourceSampler implements ActionListener {
     sampleAll();
   }
 
-  private static class TimeSource {
+  static class TimeSource {
 
     private final MSP430Core cpu;
     private final DataSource dataSource;

--- a/java/se/sics/mspsim/util/NetworkConnection.java
+++ b/java/se/sics/mspsim/util/NetworkConnection.java
@@ -167,7 +167,7 @@ public class NetworkConnection implements Runnable {
       notifyAll();
     }
 
-    synchronized SendEvent getNext() throws InterruptedException {
+    private synchronized SendEvent getNext() throws InterruptedException {
       while (queue.isEmpty()) {
         wait();
       }

--- a/java/se/sics/mspsim/util/NetworkPacket.java
+++ b/java/se/sics/mspsim/util/NetworkPacket.java
@@ -84,7 +84,7 @@ public class NetworkPacket {
   }
 
 
-  NetworkPacket(String pattern, Map<String, Field> fields) {
+  private NetworkPacket(String pattern, Map<String, Field> fields) {
     this.description = pattern;
     this.fields = fields;
   }


### PR DESCRIPTION
ExposedPrivateType: align visibility where non-private signatures referenced private nested types, and NotJavadoc: reword a //// comment that parsed as markdown Javadoc.