### PR TITLE
RadioMediums: fix interference updates on channel hops

### DIFF
--- a/java/org/contikios/cooja/RadioConnection.java
+++ b/java/org/contikios/cooja/RadioConnection.java
@@ -186,6 +186,15 @@ public class RadioConnection {
 
   /**
    * @param radio Radio
+   * @return True if radio is a destination in this connection, whether
+   *         interfered or not
+   */
+  public boolean isAnyDestination(Radio radio) {
+    return allDestinations.contains(radio);
+  }
+
+  /**
+   * @param radio Radio
    * @return True if radio is interfered in this connection
    */
   public boolean isInterfered(Radio radio) {

--- a/java/org/contikios/cooja/interfaces/ApplicationRadio.java
+++ b/java/org/contikios/cooja/interfaces/ApplicationRadio.java
@@ -266,6 +266,9 @@ public class ApplicationRadio extends Radio implements NoiseSourceRadio, Directi
    */
   public void setChannel(int channel) {
     radioChannel = channel;
+    /* Deliberately not CHANNEL_HOP: interference is reference-counted in
+     * this radio and must stay in sync with the pending signalReceptionEnd()
+     * calls, so it cannot be cleared on channel changes. */
     lastEvent = RadioEvent.UNKNOWN;
     lastEventTime = simulation.getSimulationTime();
     radioEventTriggers.trigger(RadioEvent.UNKNOWN, this);

--- a/java/org/contikios/cooja/mspmote/interfaces/CC1101Radio.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/CC1101Radio.java
@@ -150,8 +150,9 @@ public class CC1101Radio extends Radio implements CustomDataRadio {
 
     this.cc1101.addChannelListener(channel -> {
       /* XXX Currently assumes zero channel switch time */
-      lastEvent = RadioEvent.UNKNOWN;
-      radioEventTriggers.trigger(RadioEvent.UNKNOWN, this);
+      isInterfered = false;
+      lastEvent = RadioEvent.CHANNEL_HOP;
+      radioEventTriggers.trigger(RadioEvent.CHANNEL_HOP, this);
     });
 	}
 

--- a/java/org/contikios/cooja/mspmote/interfaces/CC1120Radio.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/CC1120Radio.java
@@ -152,8 +152,9 @@ public class CC1120Radio extends Radio implements CustomDataRadio {
 
     cc1120.addChannelListener(channel -> {
       /* XXX Currently assumes zero channel switch time */
-      lastEvent = RadioEvent.UNKNOWN;
-      radioEventTriggers.trigger(RadioEvent.UNKNOWN, this);
+      isInterfered = false;
+      lastEvent = RadioEvent.CHANNEL_HOP;
+      radioEventTriggers.trigger(RadioEvent.CHANNEL_HOP, this);
     });
 	}
 

--- a/java/org/contikios/cooja/mspmote/interfaces/CC2520Radio.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/CC2520Radio.java
@@ -114,8 +114,9 @@ public class CC2520Radio extends Radio implements CustomDataRadio {
 
     radio.addChannelListener(channel -> {
       /* XXX Currently assumes zero channel switch time */
-      lastEvent = RadioEvent.UNKNOWN;
-      radioEventTriggers.trigger(RadioEvent.UNKNOWN, this);
+      isInterfered = false;
+      lastEvent = RadioEvent.CHANNEL_HOP;
+      radioEventTriggers.trigger(RadioEvent.CHANNEL_HOP, this);
     });
   }
 

--- a/java/org/contikios/cooja/mspmote/interfaces/Msp802154Radio.java
+++ b/java/org/contikios/cooja/mspmote/interfaces/Msp802154Radio.java
@@ -152,8 +152,9 @@ public class Msp802154Radio extends Radio implements CustomDataRadio {
 
     radio.addChannelListener(channel -> {
       /* XXX Currently assumes zero channel switch time */
-      lastEvent = RadioEvent.UNKNOWN;
-      radioEventTriggers.trigger(RadioEvent.UNKNOWN, this);
+      isInterfered = false;
+      lastEvent = RadioEvent.CHANNEL_HOP;
+      radioEventTriggers.trigger(RadioEvent.CHANNEL_HOP, this);
     });
   }
 

--- a/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
+++ b/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
@@ -109,16 +109,30 @@ public abstract class AbstractRadioMedium implements RadioMedium {
         case RECEPTION_STARTED:
         case RECEPTION_INTERFERED:
           break;
-        case RECEPTION_FINISHED:
+        case RECEPTION_FINISHED: {
+          /* The radio reverted to "not interfered": continue interfering
+           * if another active transmission still reaches this radio. */
+          reassertInterference(radio);
+        }
+        break;
         case CHANNEL_HOP: {
-          /* in such cases the radio reverts to "not interfered */
+          /* The radio switched channel and reverted to "not interfered". */
           for (RadioConnection conn : getActiveConnections()) {
-            if (conn.isInterfered(radio)
-                && (conn.getSource().getChannel() == radio.getChannel())) {
-              /* continue interfering due to transmission on radio's channel */
-              radio.interfereAnyReception();
+            if (conn.getSource() != radio && conn.isAnyDestination(radio)) {
+              /* The radio switched channel during an ongoing reception:
+               * the partly received packet must not be delivered. */
+              if (!conn.isInterfered(radio)) {
+                conn.addInterfered(radio);
+              }
+              if (!radio.isInterfered()) {
+                radio.interfereAnyReception();
+              }
             }
           }
+          /* Continue interfering if an active transmission on the new
+           * channel marks this radio as interfered. */
+          reassertInterference(radio);
+          updateSignalStrengths();
         }
         break;
         case UNKNOWN:
@@ -377,6 +391,36 @@ public abstract class AbstractRadioMedium implements RadioMedium {
 		}
 	}
 	
+	/**
+	 * @param c1 Channel of the first radio
+	 * @param c2 Channel of the second radio
+	 * @return True if both channels are configured (&gt;= 0) and differ.
+	 *         A negative channel means the radio uses all channels.
+	 */
+	public static boolean channelsDiffer(int c1, int c2) {
+		return c1 >= 0 && c2 >= 0 && c1 != c2;
+	}
+
+	/**
+	 * Interfere the radio again if any active connection on the radio's
+	 * current channel marks it as interfered. Called after a radio has
+	 * reverted to "not interfered" (finished reception or channel hop).
+	 *
+	 * @param radio Radio
+	 */
+	private void reassertInterference(Radio radio) {
+		if (radio.isInterfered()) {
+			return;
+		}
+		for (RadioConnection conn : activeConnections) {
+			if (conn.isInterfered(radio)
+					&& !channelsDiffer(conn.getSource().getChannel(), radio.getChannel())) {
+				radio.interfereAnyReception();
+				return;
+			}
+		}
+	}
+
 	private RadioConnection getActiveConnectionFrom(Radio source) {
 		for (RadioConnection conn : activeConnections) {
 			if (conn.getSource() == source) {

--- a/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
+++ b/java/org/contikios/cooja/radiomediums/AbstractRadioMedium.java
@@ -344,7 +344,7 @@ public abstract class AbstractRadioMedium implements RadioMedium {
       var sourceChannel = conn.getSource().getChannel();
 			for (Radio dstRadio : conn.getDestinations()) {
         var dstChannel = dstRadio.getChannel();
-        if (sourceChannel >= 0 && dstChannel >= 0 && sourceChannel != dstChannel) {
+        if (channelsDiffer(sourceChannel, dstChannel)) {
 					continue;
 				}
 				if (dstRadio.getCurrentSignalStrength() < SS_STRONG) {
@@ -361,7 +361,7 @@ public abstract class AbstractRadioMedium implements RadioMedium {
 					intfRadio.setCurrentSignalStrength(SS_STRONG);
 				}
         var intfChannel = intfRadio.getChannel();
-        if (srcChannel >= 0 && intfChannel >= 0 && srcChannel != intfChannel) {
+        if (channelsDiffer(srcChannel, intfChannel)) {
 					continue;
 				}
 				if (!intfRadio.isInterfered()) {

--- a/java/org/contikios/cooja/radiomediums/DirectedGraphMedium.java
+++ b/java/org/contikios/cooja/radiomediums/DirectedGraphMedium.java
@@ -264,12 +264,12 @@ public class DirectedGraphMedium extends AbstractRadioMedium {
       int dstc = dest.radio.getChannel();
       int edgeChannel = dest.getChannel();
 
-      if (edgeChannel >= 0 && dstc >= 0 && edgeChannel != dstc) {
+      if (channelsDiffer(edgeChannel, dstc)) {
       	/* Fail: the edge is configured for a different radio channel */
         continue;
       }
 
-      if (srcc >= 0 && dstc >= 0 && srcc != dstc) {
+      if (channelsDiffer(srcc, dstc)) {
         /* Fail: radios are on different (but configured) channels */
         newConn.addInterfered(dest.radio);
         continue;

--- a/java/org/contikios/cooja/radiomediums/LogisticLoss.java
+++ b/java/org/contikios/cooja/radiomediums/LogisticLoss.java
@@ -231,7 +231,7 @@ public class LogisticLoss extends AbstractRadioMedium {
             /* Fail if radios are on different (but configured) channels */
             var srcChannel = sender.getChannel();
             var dstChannel = recv.getChannel();
-            if (srcChannel >= 0 && dstChannel >= 0 && srcChannel != dstChannel) {
+            if (channelsDiffer(srcChannel, dstChannel)) {
                 /* Add the connection in a dormant state;
                    it will be activated later when the radio will be
                    turned on and switched to the right channel. This behavior
@@ -402,7 +402,7 @@ public class LogisticLoss extends AbstractRadioMedium {
             var srcChannel = conn.getSource().getChannel();
             for (Radio dstRadio : conn.getDestinations()) {
                 var dstChannel = dstRadio.getChannel();
-                if (srcChannel >= 0 && dstChannel >= 0 && srcChannel != dstChannel) {
+                if (channelsDiffer(srcChannel, dstChannel)) {
                     continue;
                 }
 
@@ -418,7 +418,7 @@ public class LogisticLoss extends AbstractRadioMedium {
             var srcChannel = conn.getSource().getChannel();
             for (Radio intfRadio : conn.getInterfered()) {
                 var intfChannel = intfRadio.getChannel();
-                if (srcChannel >= 0 && intfChannel >= 0 && srcChannel != intfChannel) {
+                if (channelsDiffer(srcChannel, intfChannel)) {
                     continue;
                 }
 

--- a/java/org/contikios/cooja/radiomediums/UDGM.java
+++ b/java/org/contikios/cooja/radiomediums/UDGM.java
@@ -182,7 +182,7 @@ public class UDGM extends AbstractRadioMedium {
       /* Fail if radios are on different (but configured) channels */
       var srcChannel = sender.getChannel();
       var dstChannel = recv.getChannel();
-      if (srcChannel >= 0 && dstChannel >= 0 && srcChannel != dstChannel) {
+      if (channelsDiffer(srcChannel, dstChannel)) {
         /* Add the connection in a dormant state;
            it will be activated later when the radio will be
            turned on and switched to the right channel. This behavior
@@ -287,7 +287,7 @@ public class UDGM extends AbstractRadioMedium {
       var srcChannel = conn.getSource().getChannel();
       for (Radio dstRadio : conn.getDestinations()) {
         var dstChannel = dstRadio.getChannel();
-        if (srcChannel >= 0 && dstChannel >= 0 && srcChannel != dstChannel) {
+        if (channelsDiffer(srcChannel, dstChannel)) {
           continue;
         }
 
@@ -309,7 +309,7 @@ public class UDGM extends AbstractRadioMedium {
       var srcChannel = conn.getSource().getChannel();
       for (Radio intfRadio : conn.getInterfered()) {
         var intfChannel = intfRadio.getChannel();
-        if (srcChannel >= 0 && intfChannel >= 0 && srcChannel != intfChannel) {
+        if (channelsDiffer(srcChannel, intfChannel)) {
           continue;
         }
 

--- a/java/org/contikios/mrm/MRM.java
+++ b/java/org/contikios/mrm/MRM.java
@@ -154,7 +154,7 @@ public class MRM extends AbstractRadioMedium {
       /* Fail if radios are on different (but configured) channels */
       var srcChannel = sender.getChannel();
       var dstChannel = recv.getChannel();
-      if (srcChannel >= 0 && dstChannel >= 0 && srcChannel != dstChannel) {
+      if (channelsDiffer(srcChannel, dstChannel)) {
         newConnection.addInterfered(recv);
         continue;
       }
@@ -283,7 +283,7 @@ public class MRM extends AbstractRadioMedium {
       for (Radio dstRadio : conn.getDestinations()) {
         double signalStrength = ((MRMRadioConnection) conn).getDestinationSignalStrength(dstRadio);
         var dstChannel = dstRadio.getChannel();
-        if (srcChannel >= 0 && dstChannel >= 0 && srcChannel != dstChannel) {
+        if (channelsDiffer(srcChannel, dstChannel)) {
           continue;
         }
         if (dstRadio.getCurrentSignalStrength() < signalStrength) {
@@ -297,7 +297,7 @@ public class MRM extends AbstractRadioMedium {
       var srcChannel = conn.getSource().getChannel();
       for (Radio intfRadio : conn.getInterfered()) {
         var intfChannel = intfRadio.getChannel();
-        if (srcChannel >= 0 && intfChannel >= 0 && srcChannel != intfChannel) {
+        if (channelsDiffer(srcChannel, intfChannel)) {
           continue;
         }
         double signalStrength = ((MRMRadioConnection) conn).getInterferenceSignalStrength(intfRadio);


### PR DESCRIPTION
- Compare channels wildcard-aware via a new channelsDiffer() helper.
- A channel hop now aborts any reception in progress, so a partly
  received packet is dropped instead of delivered, and refreshes
  signal strengths as the previous UNKNOWN event did.
- MSPSim-backed radios now fire CHANNEL_HOP like ContikiRadio, so
  they no longer keep a stale interfered flag across channel changes.
  ApplicationRadio stays on UNKNOWN (reference-counted interference).
