### PR TITLE
CI: key ccache per architecture to avoid arm64/Intel collision

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,17 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
-          key: compilation-${{ matrix.os }}
+          # Key on runner.arch (ARM64/X64), not matrix.os: "macos-26" is a
+          # string prefix of "macos-26-intel", and the ccache action restores
+          # by key prefix, so the arm64 job would otherwise pull in the Intel
+          # job's cache of x86_64 objects and fail to link on arm64.
+          key: compilation-${{ runner.os }}-${{ runner.arch }}
           max-size: 160M
+        env:
+          # Hash the compiler contents rather than its mtime, so a cache that
+          # ever leaks across architectures misses instead of serving a
+          # wrong-arch object.
+          CCACHE_COMPILERCHECK: content
       - name: Run Contiki-NG simulation tests
         run: |
           [ "$(uname)" = "Linux" ] || source ~/.bashrc


### PR DESCRIPTION
The ccache step keyed on `matrix.os`, so the arm64 (`compilation-macos-26`)
and Intel (`compilation-macos-26-intel`) jobs shared a key prefix. Since the
ccache action restores by prefix, the arm64 job can restore the Intel cache
of x86_64 objects - seen as `found architecture 'x86_64', required
architecture 'arm64'` link failures.

Fix: key on `runner.arch` so the caches no longer share a prefix, and set
`CCACHE_COMPILERCHECK=content` so a leaked cache recompiles instead of
serving a wrong-arch object.

**Caveat:** CI recovered on its own before this (unrelated PRs went green
without it), so this isn't confirmed as the incident's cause - possibly a
transient runner-image issue. Hardening either way; low risk (worst case a
cold-cache rebuild).