### PR TITLE
mspsim: read back output pin levels from PxIN

### DIFF
--- a/java/se/sics/mspsim/core/IOPort.java
+++ b/java/se/sics/mspsim/core/IOPort.java
@@ -197,7 +197,12 @@ public class IOPort extends IOUnit {
             case IE -> ie;
             case IES -> ies;
             case IFG -> ifg;
-            case IN -> in;
+            /*
+             * PxIN reflects the level on the pad. A pin configured as an
+             * output is driven by PxOUT, so those bits read back what was
+             * written; input bits keep the externally driven level.
+             */
+            case IN -> (in & ~dir) | (out & dir);
             case IV_H -> (iv >> 8) & 0xff;
             case IV_L -> iv & 0xff;
             case OUT -> out;
@@ -217,7 +222,7 @@ public class IOPort extends IOUnit {
         case OUT:
             return out;
         case IN:
-            return in;
+            return (in & ~dir) | (out & dir);
         case DIR:
             return dir;
         case REN:


### PR DESCRIPTION
PxIN reflects the level on the pad, so a pin configured as an output reads back the value driven from PxOUT. MSPSim kept PxIN purely as the externally driven level, updated only when another emulated chip drives a pin, so firmware that configures a pin as an output and reads it back always saw a low level.

Mask by direction instead: output bits come from PxOUT and input bits keep the external level.

This was found with the GPIO HAL example on MSP-EXP430FR5969, which drives three pins and reads them back. On hardware it reports the pins high with a port mask of 0x50, while under emulation every read was low. It now matches the hardware.